### PR TITLE
fix: rename filesystem key manager to db system key manager

### DIFF
--- a/apps/backend/src/crypto/key/adapters/db-key.service.ts
+++ b/apps/backend/src/crypto/key/adapters/db-key.service.ts
@@ -24,7 +24,7 @@ import { KeyService } from "../key.service";
 /**
  * The key service is responsible for managing the keys of the issuer.
  */
-export class FileSystemKeyService extends KeyService {
+export class DBKeyService extends KeyService {
     private crypto: CryptoImplementation;
 
     constructor(

--- a/apps/backend/src/crypto/key/key.module.ts
+++ b/apps/backend/src/crypto/key/key.module.ts
@@ -3,9 +3,8 @@ import { DynamicModule, Global, Module } from "@nestjs/common";
 import { ConfigModule, ConfigService } from "@nestjs/config";
 import { getRepositoryToken, TypeOrmModule } from "@nestjs/typeorm";
 import * as Joi from "joi";
-import { PinoLogger } from "nestjs-pino";
 import { Repository } from "typeorm/repository/Repository";
-import { FileSystemKeyService } from "./adapters/filesystem-key.service";
+import { DBKeyService } from "./adapters/db-key.service";
 import { VaultKeyService } from "./adapters/vault-key.service";
 import { CryptoImplementatationModule } from "./crypto-implementation/crypto-implementation.module";
 import { CryptoImplementationService } from "./crypto-implementation/crypto-implementation.service";
@@ -13,7 +12,7 @@ import { CertEntity } from "./entities/cert.entity";
 import { KeyEntity } from "./entities/keys.entity";
 
 export const KEY_VALIDATION_SCHEMA = {
-    KM_TYPE: Joi.string().valid("file", "vault").default("file"),
+    KM_TYPE: Joi.string().valid("db", "vault").default("db"),
 
     // Vault-related config
     VAULT_URL: Joi.string().uri().when("KM_TYPE", {
@@ -62,7 +61,7 @@ export class KeyModule {
                             );
                         }
 
-                        return new FileSystemKeyService(
+                        return new DBKeyService(
                             configService,
                             cryptoService,
                             certRepository,


### PR DESCRIPTION
Signed-off-by: Mirko Mollik <mirko.mollik@eudi.sprind.org>

## 📝 Description

Update the class name and documentation to the change that keys are not managed by the filesystem, but by the database. The vault approach is untouched by this change.