### PR TITLE
fix: extract webhook from presentation object

### DIFF
--- a/apps/backend/src/auth/auth.controller.ts
+++ b/apps/backend/src/auth/auth.controller.ts
@@ -124,17 +124,25 @@ export class AuthController {
             throw new UnauthorizedException("Invalid client credentials");
         }
 
+        //TODO: check if the access token should only include the session id or also e.g. the credentials that should be issued. I would think this is not required since we still need the claims for it.
         const payload: TokenPayload = {
             sub: client.id,
         };
 
-        const token = await this.jwtService.generateToken(payload, {
+        //TODO: make expiresIn configurable?
+        const access_token = await this.jwtService.generateToken(payload, {
             expiresIn: "24h",
             audience: "eudiplo-service",
         });
 
+        const refresh_token = await this.jwtService.generateToken(payload, {
+            expiresIn: "30d",
+            audience: "eudiplo-service",
+        });
+
         return {
-            access_token: token,
+            access_token,
+            refresh_token,
             token_type: "Bearer",
             expires_in: 86400, // 24 hours in seconds
         };

--- a/apps/backend/src/auth/dto/token-response.dto.ts
+++ b/apps/backend/src/auth/dto/token-response.dto.ts
@@ -1,5 +1,6 @@
 export class TokenResponse {
     access_token: string;
+    refresh_token?: string;
     token_type: "Bearer";
     expires_in: number;
 }

--- a/apps/backend/src/issuer/authorize/authorize.service.ts
+++ b/apps/backend/src/issuer/authorize/authorize.service.ts
@@ -256,13 +256,14 @@ export class AuthorizeService {
             throw new Error('Credential offer not found');
         } */
         const issuanceId = session.issuanceId!;
-        const config = await this.issuanceService.getIssuanceConfigurationById(
-            issuanceId,
-            session.tenantId,
-        );
+        const issuanceConfig =
+            await this.issuanceService.getIssuanceConfigurationById(
+                issuanceId,
+                session.tenantId,
+            );
 
         // Use the new authentication configuration structure
-        const authConfig = config.authenticationConfig;
+        const authConfig = issuanceConfig.authenticationConfig;
 
         if (!authConfig) {
             throw new Error(
@@ -276,9 +277,7 @@ export class AuthorizeService {
             )
         ) {
             // OID4VP flow - credential presentation required
-            const presentationConfig =
-                AuthenticationConfigHelper.getPresentationConfig(authConfig);
-            const webhook = presentationConfig?.presentation.webhook;
+            const webhook = issuanceConfig.claimWebhook;
             const response = await this.parseChallengeRequest(
                 body,
                 session.tenantId,

--- a/apps/backend/src/issuer/credentials-metadata/dto/credential-config.dto.ts
+++ b/apps/backend/src/issuer/credentials-metadata/dto/credential-config.dto.ts
@@ -1,5 +1,4 @@
-import { IsObject, IsString } from "class-validator";
-import { WebhookConfig } from "../../../utils/webhook/webhook.dto";
+import { IsString } from "class-validator";
 
 export class VCT {
     @IsString()
@@ -16,11 +15,4 @@ export class VCT {
     schema_uri?: string;
     @IsString()
     "schema_uri#integrity"?: string;
-}
-
-export class PresentationDuringIssuance {
-    @IsString()
-    type: string;
-    @IsObject()
-    webhook?: WebhookConfig;
 }

--- a/apps/backend/src/issuer/issuance/dto/authentication-config.dto.ts
+++ b/apps/backend/src/issuer/issuance/dto/authentication-config.dto.ts
@@ -12,7 +12,6 @@ import {
     ValidatorConstraintInterface,
 } from "class-validator";
 import { WebhookConfig } from "../../../utils/webhook/webhook.dto";
-import { PresentationDuringIssuance } from "../../credentials-metadata/dto/credential-config.dto";
 
 /**
  * Custom validator to ensure config type matches the authentication method
@@ -41,7 +40,7 @@ export class AuthConfigValidator implements ValidatorConstraintInterface {
             return (
                 config &&
                 typeof config === "object" &&
-                typeof config.presentation === "object"
+                typeof config.type === "string"
             );
         }
 
@@ -95,12 +94,10 @@ export class AuthenticationUrlConfig {
  */
 export class PresentationDuringIssuanceConfig {
     /**
-     * Presentation configuration that specifies what credentials need to be presented via OID4VP
+     * Link to the presentation configuration that is relevant for the issuance process
      */
-    @IsObject()
-    @ValidateNested()
-    @Type(() => PresentationDuringIssuance)
-    presentation: PresentationDuringIssuance;
+    @IsString()
+    type: string;
 }
 
 /**

--- a/apps/backend/src/issuer/issuance/dto/issuance.dto.ts
+++ b/apps/backend/src/issuer/issuance/dto/issuance.dto.ts
@@ -56,6 +56,15 @@ export class IssuanceDto {
     authenticationConfig: AuthenticationConfigDto;
 
     /**
+     * Optional webhook configuration to receive claims during the issuance process.
+     */
+    @IsObject()
+    @IsOptional()
+    @ValidateNested()
+    @Type(() => WebhookConfig)
+    claimWebhook?: WebhookConfig;
+
+    /**
      * Optional webhook configuration to send the results of the notification response.
      */
     @IsObject()

--- a/apps/backend/src/issuer/issuance/entities/issuance-config.entity.ts
+++ b/apps/backend/src/issuer/issuance/entities/issuance-config.entity.ts
@@ -72,6 +72,12 @@ export class IssuanceConfig {
     updatedAt: Date;
 
     /**
+     * Webhook to receive claims for the issuance process.
+     */
+    @Column("json", { nullable: true })
+    claimWebhook?: WebhookConfig;
+
+    /**
      * Webhook to send the result of the notification response
      */
     @Column("json", { nullable: true })

--- a/assets/config/root/issuance/issuance/citizen.json
+++ b/assets/config/root/issuance/issuance/citizen.json
@@ -2,12 +2,7 @@
     "authenticationConfig": {
         "method": "presentationDuringIssuance",
         "config": {
-            "presentation": {
-                "type": "pid",
-                "webhook": {
-                    "url": "http://localhost:8787/process"
-                }
-            }
+            "type": "pid"
         }
     },
     "credentialConfigs": [
@@ -15,6 +10,9 @@
             "id": "citizen"
         }
     ],
+    "claimWebhook": {
+        "url": "http://localhost:8787/process"
+    },
     "notifyWebhook": {
         "url": "http://localhost:8787/notify",
         "auth": {

--- a/docs/architecture/webhooks.md
+++ b/docs/architecture/webhooks.md
@@ -34,23 +34,23 @@ EUDIPLO service. The object must contain the following fields:
 - `url`: The URL of the webhook endpoint to which the data will be sent. The
   request will be sent as an HTTP `POST` request.
 - `auth`: Optional authentication information for the webhook endpoint.
-    - `type`: The type of authentication to use. Supported types are:
-        - `apiKey`: API key authentication, where the key is sent in a header.
+  - `type`: The type of authentication to use. Supported types are:
+    - `apiKey`: API key authentication, where the key is sent in a header.
 
 Here is an example of a webhook configuration:
 
 ```json
 {
-    "webhook": {
-        "url": "http://localhost:8787/consume",
-        "auth": {
-            "type": "apiKey",
-            "config": {
-                "headerName": "x-api-key",
-                "value": "your-api-key"
-            }
-        }
+  "webhook": {
+    "url": "http://localhost:8787/consume",
+    "auth": {
+      "type": "apiKey",
+      "config": {
+        "headerName": "x-api-key",
+        "value": "your-api-key"
+      }
     }
+  }
 }
 ```
 
@@ -63,24 +63,24 @@ configuration or passing the webhook dynamically via offer creation:
 
 ```json
 {
-    "authenticationConfig": {
-        "method": "presentationDuringIssuance",
-        "config": {
-            "presentation": {
-                "type": "pid",
-                "webhook": {
-                    "url": "http://localhost:8787/process",
-                    "auth": {
-                        "type": "apiKey",
-                        "config": {
-                            "headerName": "x-api-key",
-                            "value": "your-api-key"
-                        }
-                    }
-                }
+  "authenticationConfig": {
+    "method": "presentationDuringIssuance",
+    "config": {
+      "presentation": {
+        "type": "pid",
+        "webhook": {
+          "url": "http://localhost:8787/process",
+          "auth": {
+            "type": "apiKey",
+            "config": {
+              "headerName": "x-api-key",
+              "value": "your-api-key"
             }
+          }
         }
+      }
     }
+  }
 }
 ```
 
@@ -92,16 +92,16 @@ received and accepted the credential.
 
 ```json
 {
-    "notifyWebhook": {
-        "url": "http://localhost:8787/notify",
-        "auth": {
-            "type": "apiKey",
-            "config": {
-                "headerName": "x-api-key",
-                "value": "your-api-key"
-            }
-        }
+  "notifyWebhook": {
+    "url": "http://localhost:8787/notify",
+    "auth": {
+      "type": "apiKey",
+      "config": {
+        "headerName": "x-api-key",
+        "value": "your-api-key"
+      }
     }
+  }
 }
 ```
 
@@ -115,10 +115,10 @@ only the **presented claims**.
 It is structured as follows:
 
 - `credentials`: An array of credential objects, each containing:
-    - `id`: The ID of the DCQL query to identify which was passed for the
-      request.
-    - `values`: The claims presented by the wallet. SD-JWT VC specific fields
-      like cnf and status got removed for simplicity.
+  - `id`: The ID of the DCQL query to identify which was passed for the
+    request.
+  - `values`: The claims presented by the wallet. SD-JWT VC specific fields
+    like cnf and status got removed for simplicity.
 - `session`: The session ID used to identify the request.
 
 In case the verification of a credential fails, an `error` field with a message
@@ -128,26 +128,26 @@ is included instead of the values.
 
 ```json
 {
-    "credentials": [
-        {
-            "id": "pid",
-            "values": {
-                "iss": "https://service.eudi-wallet.dev",
-                "iat": 1751884150,
-                "vct": "https://service.eudi-wallet.dev/credentials/vct/pid",
-                "address": {
-                    "locality": "KÖLN",
-                    "postal_code": "51147",
-                    "street_address": "HEIDESTRAẞE 17"
-                }
-            }
-        },
-        {
-            "id": "citizen",
-            "error": "Credential verification failed: invalid signature"
+  "credentials": [
+    {
+      "id": "pid",
+      "values": {
+        "iss": "https://service.eudi-wallet.dev",
+        "iat": 1751884150,
+        "vct": "https://service.eudi-wallet.dev/credentials/vct/pid",
+        "address": {
+          "locality": "KÖLN",
+          "postal_code": "51147",
+          "street_address": "HEIDESTRAẞE 17"
         }
-    ],
-    "session": "a6318799-dff4-4b60-9d1d-58703611bd23"
+      }
+    },
+    {
+      "id": "citizen",
+      "error": "Credential verification failed: invalid signature"
+    }
+  ],
+  "session": "a6318799-dff4-4b60-9d1d-58703611bd23"
 }
 ```
 
@@ -166,9 +166,9 @@ Issuing a credential with the ID `citizen`:
 
 ```json
 {
-    "citizen": {
-        "town": "Berlin"
-    }
+  "citizen": {
+    "town": "Berlin"
+  }
 }
 ```
 


### PR DESCRIPTION
Signed-off-by: Mirko Mollik <mirko.mollik@eudi.sprind.org>

## 📝 Description

Adds a refresh token (needs to be aligned when full presentation during issuance approach is updated)

Adds the `claimsWebhook` that will fetch the credentials during the credential request. In this case, the claims are not passed during the credential offer, so they do not need to get persisted into the database. On the other hand it requires the service to support webhooks.

Fixes #32

## 🔄 Type of Change

Please delete options that are not relevant:

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality
      to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test improvements
- [ ] 🏗️ Build/CI changes

## 🧪 Testing

Describe the tests that you ran to verify your changes:

- [ ] Unit tests pass
- [ ] Integration tests pass
- [x] E2E tests pass
- [ ] Manual testing performed
