### PR TITLE
fix(ci): run docker build also on PRs

### DIFF
--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -170,7 +170,6 @@ jobs:
 
   docker-backend:
     name: Build & Push Backend Docker Image
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     needs: [test-e2e]
     runs-on: ubuntu-latest
     permissions:
@@ -179,21 +178,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Log in to GitHub Container Registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u
-          ${{ github.actor }} --password-stdin
-
       - name: Build Backend Docker image
-        run: docker build -t
-          ghcr.io/openwallet-foundation-labs/eudiplo:main --build-arg
-          VERSION=main . --target eudiplo
+        run: docker build -t ghcr.io/openwallet-foundation-labs/eudiplo:main --build-arg VERSION=main . --target eudiplo
+
+      - name: Log in to GitHub Container Registry
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Push Backend Docker image
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         run: docker push ghcr.io/openwallet-foundation-labs/eudiplo:main
 
   docker-client:
     name: Build & Push Client Docker Image
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     needs: [build-client]
     runs-on: ubuntu-latest
     permissions:
@@ -202,13 +199,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Log in to GitHub Container Registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u
-          ${{ github.actor }} --password-stdin
-
       - name: Build Client Docker image
-        run: docker build -t
-          ghcr.io/openwallet-foundation-labs/eudiplo-client:main . --target client
+        run: docker build -t ghcr.io/openwallet-foundation-labs/eudiplo-client:main . --target client
+
+      - name: Log in to GitHub Container Registry
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Push Client Docker image
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         run: docker push ghcr.io/openwallet-foundation-labs/eudiplo-client:main

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -32,6 +32,7 @@
     "@ngx-formly/material": "^7.0.0",
     "@peculiar/x509": "^1.13.0",
     "@types/qrcode": "^1.5.5",
+    "ajv": "^8.17.1",
     "json-schema": "link:@ngx-formly/core/json-schema",
     "monaco-editor": "^0.52.2",
     "ngx-flexible-layout": "^20.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -298,6 +298,9 @@ importers:
       '@types/qrcode':
         specifier: ^1.5.5
         version: 1.5.5
+      ajv:
+        specifier: ^8.17.1
+        version: 8.17.1
       json-schema:
         specifier: link:@ngx-formly/core/json-schema
         version: link:@ngx-formly/core/json-schema


### PR DESCRIPTION
Signed-off-by: Mirko Mollik <mirko.mollik@eudi.sprind.org>

## 📝 Description

Run docker build also on open PRs to make sure that the images are build. Only when on the main branch, the images will be pushed to the registry.