### PR TITLE
fix: import keys

### DIFF
--- a/apps/backend/src/crypto/crypto.service.ts
+++ b/apps/backend/src/crypto/crypto.service.ts
@@ -111,7 +111,7 @@ export class CryptoService {
                             readFileSync(join(path, file), "utf8"),
                         );
 
-                        const id = payload.kid;
+                        const id = payload.privateKey.kid;
                         const exists = await this.keyService
                             .getPublicKey("jwk", tenant.name, id)
                             .catch(() => false);


### PR DESCRIPTION
## 📝 Description

Fixes the import of keys from the config directory

## 🔄 Type of Change

Please delete options that are not relevant:

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality
      to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test improvements
- [ ] 🏗️ Build/CI changes

## 🧪 Testing

Describe the tests that you ran to verify your changes:

- [x] Unit tests pass
- [ ] Integration tests pass
- [ ] E2E tests pass
- [x] Manual testing performed

**Test Configuration**:

- Node.js version: 22.19.0
- OS: mac
- Test environment: 

## 📸 Screenshots (if applicable)

Add screenshots to help explain your changes.

## ✔️ Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## 📋 Additional Notes

Before key are not imported and importing the current examples lead to error
```
rm tmp/service.db
pnpm --filter @eudiplo/backend run dev
```
<img width="1632" height="814" alt="image" src="https://github.com/user-attachments/assets/1c50410e-2d7a-4001-8075-5aa8e88c32ba" />

now the import works
```
rm tmp/service.db
pnpm --filter @eudiplo/backend run dev
```
<img width="835" height="352" alt="image" src="https://github.com/user-attachments/assets/0b2876de-0b32-4640-b1c6-6eef18cc0bb5" />

