### PR TITLE
Change offer URI to anchor

### DIFF
--- a/apps/client/src/app/session-management/session-management-show/session-management-show.component.html
+++ b/apps/client/src/app/session-management/session-management-show/session-management-show.component.html
@@ -143,7 +143,9 @@
             <div class="info-item">
               <strong>Offer URI:</strong>
               <div class="value-with-copy">
-                <span class="uri-value">{{ getOfferUri() }}</span>
+                <span class="uri-value">
+                  <a href="{{ getOfferUri() }}">{{ getOfferUri() }}</a>
+                </span>
                 <button
                   mat-icon-button
                   (click)="copyToClipboard(getOfferUri()!)"


### PR DESCRIPTION
## 📝 Description

Changing the Offer URI in the client to an anchor take, makes it possible to open it in an app.
Copy/pasting the URL in a browser does not open a registered app for the `openid-credential-offer` scheme.

Fixes #209 

## 🔄 Type of Change

Please delete options that are not relevant:

- [x] 🚀 New feature (non-breaking change which adds functionality)

## 🧪 Testing

Describe the tests that you ran to verify your changes:

- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] E2E tests pass
- [x] Manual testing performed

## ✔️ Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
