### PR TITLE
Restrict openid4vc updates to major only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,7 +55,6 @@ updates:
 
       openid4vc-all:
         patterns: ["@openid4vc/*"]
-        update-types: ["major", "minor", "patch"]
 
       sd-jwt:
         patterns: ["@sd-jwt/*"]


### PR DESCRIPTION
Removed minor and patch updates for openid4vc.

## 📝 Description

fix update type