### PR TITLE
fix: allow to edit certs

### DIFF
--- a/apps/client/src/app/key-management/certificate-edit/certificate-edit.component.ts
+++ b/apps/client/src/app/key-management/certificate-edit/certificate-edit.component.ts
@@ -85,8 +85,8 @@ export class CertificateEditComponent implements OnInit {
 
     // Initialize form with optional keyId field for standalone mode
     this.form = new FormGroup({
-      keyId: new FormControl(this.keyId || '', this.isStandaloneMode ? Validators.required : []),
-      certUsageTypes: new FormControl('', Validators.required),
+      keyId: new FormControl(this.keyId || ''),
+      certUsageTypes: new FormControl([], Validators.required),
       description: new FormControl(),
       crt: new FormControl(),
     });

--- a/assets/config/root/issuance/credentials/pid.json
+++ b/assets/config/root/issuance/credentials/pid.json
@@ -3,7 +3,6 @@
     "description": "Personal ID",
     "config": {
         "format": "dc+sd-jwt",
-        "scope": "pid",
         "display": [
             {
                 "name": "PID",


### PR DESCRIPTION
Signed-off-by: Mirko Mollik <mirko.mollik@eudi.sprind.org>

## 📝 Description

certId field for disabled but set to required so the form validation would never pass.