### PR TITLE
fix: remove trusted authorities from dcql

### DIFF
--- a/apps/backend/src/verifier/oid4vp/oid4vp.service.ts
+++ b/apps/backend/src/verifier/oid4vp/oid4vp.service.ts
@@ -79,6 +79,12 @@ export class Oid4vpService {
                 ),
             );
 
+            //remove trusted_authorities from dcql
+            dcql_query.credentials = dcql_query.credentials.map((cred: any) => {
+                const { trusted_authorities, ...rest } = cred;
+                return rest;
+            });
+
             if (this.registrarService.isEnabled()) {
                 const registrationCert = JSON.parse(
                     JSON.stringify(

--- a/apps/backend/src/verifier/resolver/trust/trust-store.service.ts
+++ b/apps/backend/src/verifier/resolver/trust/trust-store.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from "@nestjs/common";
 import { decodeJwt } from "jose";
+import { LoTE } from "../../../issuer/trust-list/dto/types";
 import { LoteParserService } from "./lote-parser.service";
 import { TrustListJwtService } from "./trustlist-jwt.service";
 import { TrustedEntity, TrustListSource } from "./types";
@@ -37,7 +38,7 @@ export class TrustStoreService {
         for (const ref of source.lotes) {
             const jwt = await this.trustListJwt.fetchJwt(ref.url);
             await this.trustListJwt.verifyTrustListJwt(ref, jwt); // hook
-            const decoded = decodeJwt(jwt);
+            const decoded = decodeJwt<LoTE>(jwt);
 
             let parsed = this.loteParser.parse(decoded);
             if (source.acceptedServiceTypes) {
@@ -63,7 +64,7 @@ export class TrustStoreService {
         this.cache = store;
 
         this.logger.debug(
-            `Built trust store with ${entities.length} trusted entit(y/ies)`,
+            `Built trust store with ${entities.length} trusted entit${entities.length === 1 ? "y" : "ies"}`,
         );
         return store;
     }

--- a/apps/client/src/app/trust-list/trust-list-show/trust-list-show.component.html
+++ b/apps/client/src/app/trust-list/trust-list-show/trust-list-show.component.html
@@ -71,7 +71,7 @@
             <p class="url-hint">
               <mat-icon class="hint-icon">lightbulb</mat-icon>
               <span
-                >Tip: Use <code>&lt;TENANT_URL&gt;/trust-list/{{ trustList?.id }}</code> in your
+                >Tip: Use <code>&lt;TENANT_URL&gt;/trust-list/{{ trustList.id }}</code> in your
                 configurations for instance-independent references.</span
               >
             </p>


### PR DESCRIPTION
Signed-off-by: Mirko Mollik <mirko.mollik@eudi.sprind.org>

## 📝 Description

Removes trusted authorities from DCQL that is sent to the Wallet since most of them have not implemented it.

It will be only used by the verifier