### PR TITLE
fix: add A256GCM for vp encryption

### DIFF
--- a/apps/backend/src/verifier/oid4vp/oid4vp.service.ts
+++ b/apps/backend/src/verifier/oid4vp/oid4vp.service.ts
@@ -166,7 +166,10 @@ export class Oid4vpService {
                                     this.cryptoImplementationService.getSupportedAlgorithms(),
                             },
                         },
-                        encrypted_response_enc_values_supported: ["A128GCM"],
+                        encrypted_response_enc_values_supported: [
+                            "A128GCM",
+                            "A256GCM",
+                        ],
                     },
                     state: session.useDcApi ? undefined : session.id,
                     transaction_data,

--- a/apps/backend/test/utils.ts
+++ b/apps/backend/test/utils.ts
@@ -774,6 +774,7 @@ export async function encryptVpToken(
     vp_token: string,
     credentialId: string,
     resolved: ResolvedOpenid4vpAuthorizationRequest,
+    enc: "A128GCM" | "A256GCM" = "A128GCM",
 ): Promise<string> {
     const key = (await importJWK(
         resolved.authorizationRequestPayload.client_metadata?.jwks
@@ -787,7 +788,7 @@ export async function encryptVpToken(
     })
         .setProtectedHeader({
             alg: "ECDH-ES",
-            enc: "A128GCM",
+            enc,
         })
         .setIssuedAt()
         .setExpirationTime("2h")


### PR DESCRIPTION
Signed-off-by: Mirko Mollik <mirko.mollik@eudi.sprind.org>

## 📝 Description

Allow A256GCM to A128GCM since both algorithms will be relevant for EUDI Wallets