### PR TITLE
fix: allow to mount a tls cert into eudiplo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,19 @@ LOG_ENABLE_SESSION_LOGGER=false
 # Enable HTTP request/response logging
 LOG_ENABLE_HTTP_LOGGER=false
 
+# TLS/HTTPS Configuration
+# Enable built-in TLS support (set to 'true' to enable)
+# When enabled, the service will serve HTTPS directly without needing a reverse proxy
+#TLS_ENABLED=false
+# Path to the TLS certificate file (PEM format)
+#TLS_CERT_PATH=/path/to/cert.pem
+# Path to the TLS private key file (PEM format)
+#TLS_KEY_PATH=/path/to/key.pem
+# Optional: Path to CA certificate chain for client verification (PEM format)
+#TLS_CA_PATH=/path/to/ca.pem
+# Optional: Passphrase for encrypted private key files
+#TLS_KEY_PASSPHRASE=your-key-passphrase
+
 # Integrated OAuth2 server configuration
 # ⚠️  DEMO CREDENTIALS - Change these in production!
 # If not set, the following demo defaults will be used:

--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -57,6 +57,12 @@ docker run -d \
 !!! warning "External Dependencies Required"
 Single container mode requires external PostgreSQL and S3-compatible storage (MinIO/AWS S3) configured via environment variables.
 
+## TLS/HTTPS Configuration
+
+EUDIPLO supports built-in TLS termination for serving HTTPS directly without a reverse proxy. This is useful for simple deployments or development environments.
+
+See: [TLS Configuration Guide](tls.md)
+
 ## Production Checklist
 
 Before deploying to production, ensure you:

--- a/docs/deployment/tls.md
+++ b/docs/deployment/tls.md
@@ -1,0 +1,234 @@
+# TLS/HTTPS Configuration
+
+EUDIPLO supports built-in TLS termination, allowing you to serve HTTPS directly from the application without requiring a reverse proxy like Nginx or Traefik.
+
+## Overview
+
+| Method            | Best For                        | Complexity  | Recommendation               |
+| ----------------- | ------------------------------- | ----------- | ---------------------------- |
+| **Built-in TLS**  | Simple deployments, development | ⭐ Easy     | Small-scale, single instance |
+| **Reverse Proxy** | Production, load balancing      | ⭐⭐ Medium | Large-scale, multi-instance  |
+
+## Built-in TLS Configuration
+
+### Environment Variables
+
+| Variable             | Required | Description                                            |
+| -------------------- | -------- | ------------------------------------------------------ |
+| `TLS_ENABLED`        | Yes      | Set to `true` to enable TLS                            |
+| `TLS_CERT_PATH`      | Yes      | Path to the TLS certificate file (PEM format)          |
+| `TLS_KEY_PATH`       | Yes      | Path to the TLS private key file (PEM format)          |
+| `TLS_CA_PATH`        | No       | Path to CA certificate chain (for client verification) |
+| `TLS_KEY_PASSPHRASE` | No       | Passphrase for encrypted private key files             |
+
+### Basic Setup
+
+1. **Generate or obtain TLS certificates**
+
+    For development, you can generate a self-signed certificate:
+
+    ```bash
+    # Generate a self-signed certificate valid for 365 days
+    openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365 -nodes \
+        -subj "/CN=localhost"
+    ```
+
+    For production, use certificates from a trusted Certificate Authority (CA) like Let's Encrypt.
+
+2. **Configure environment variables**
+
+    Add the following to your `.env` file:
+
+    ```bash
+    TLS_ENABLED=true
+    TLS_CERT_PATH=/path/to/cert.pem
+    TLS_KEY_PATH=/path/to/key.pem
+
+    # Update PUBLIC_URL to use HTTPS
+    PUBLIC_URL=https://your-domain.com:3000
+    ```
+
+3. **Start the application**
+
+    The application will automatically use HTTPS when TLS is enabled.
+
+### Docker Compose Example
+
+To use built-in TLS with Docker Compose, mount your certificates as volumes:
+
+```yaml
+services:
+    eudiplo:
+        image: ghcr.io/openwallet-foundation-labs/eudiplo:latest
+        ports:
+            - '3000:3000'
+        environment:
+            TLS_ENABLED: 'true'
+            TLS_CERT_PATH: /certs/cert.pem
+            TLS_KEY_PATH: /certs/key.pem
+            PUBLIC_URL: https://your-domain.com:3000
+        volumes:
+            - ./certs:/certs:ro
+```
+
+### Using Let's Encrypt Certificates
+
+When using Let's Encrypt certificates (e.g., via Certbot), point to the certificate files:
+
+```bash
+TLS_ENABLED=true
+TLS_CERT_PATH=/etc/letsencrypt/live/your-domain.com/fullchain.pem
+TLS_KEY_PATH=/etc/letsencrypt/live/your-domain.com/privkey.pem
+```
+
+!!! tip "Certificate Renewal"
+Let's Encrypt certificates expire every 90 days. Set up automatic renewal with Certbot and restart the application after renewal to pick up new certificates.
+
+### With CA Certificate Chain
+
+For mutual TLS (mTLS) or when you need to verify client certificates:
+
+```bash
+TLS_ENABLED=true
+TLS_CERT_PATH=/path/to/cert.pem
+TLS_KEY_PATH=/path/to/key.pem
+TLS_CA_PATH=/path/to/ca-chain.pem
+```
+
+### With Encrypted Private Key
+
+If your private key is encrypted with a passphrase:
+
+```bash
+TLS_ENABLED=true
+TLS_CERT_PATH=/path/to/cert.pem
+TLS_KEY_PATH=/path/to/encrypted-key.pem
+TLS_KEY_PASSPHRASE=your-key-passphrase
+```
+
+## Reverse Proxy Alternative
+
+For production deployments with multiple instances or advanced load balancing, consider using a reverse proxy:
+
+### Nginx Example
+
+```nginx
+server {
+    listen 443 ssl http2;
+    server_name your-domain.com;
+
+    ssl_certificate /etc/letsencrypt/live/your-domain.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/your-domain.com/privkey.pem;
+
+    # Modern TLS configuration
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256;
+    ssl_prefer_server_ciphers off;
+
+    location / {
+        proxy_pass http://localhost:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_cache_bypass $http_upgrade;
+    }
+}
+```
+
+### Traefik Example (Docker Compose)
+
+```yaml
+services:
+    traefik:
+        image: traefik:v3.0
+        command:
+            - '--providers.docker=true'
+            - '--entrypoints.websecure.address=:443'
+            - '--certificatesresolvers.letsencrypt.acme.tlschallenge=true'
+            - '--certificatesresolvers.letsencrypt.acme.email=your-email@example.com'
+            - '--certificatesresolvers.letsencrypt.acme.storage=/letsencrypt/acme.json'
+        ports:
+            - '443:443'
+        volumes:
+            - '/var/run/docker.sock:/var/run/docker.sock:ro'
+            - 'letsencrypt:/letsencrypt'
+
+    eudiplo:
+        image: ghcr.io/openwallet-foundation-labs/eudiplo:latest
+        labels:
+            - 'traefik.enable=true'
+            - 'traefik.http.routers.eudiplo.rule=Host(`your-domain.com`)'
+            - 'traefik.http.routers.eudiplo.entrypoints=websecure'
+            - 'traefik.http.routers.eudiplo.tls.certresolver=letsencrypt'
+        environment:
+            PUBLIC_URL: https://your-domain.com
+
+volumes:
+    letsencrypt:
+```
+
+## Security Considerations
+
+!!! warning "Production Security" - **Never use self-signed certificates in production**. Use certificates from trusted CAs. - **Keep private keys secure**. Restrict file permissions (`chmod 600 key.pem`). - **Use strong TLS configuration**. Prefer TLS 1.2+ and modern cipher suites. - **Rotate certificates regularly**. Set up automated renewal for Let's Encrypt.
+
+### Recommended TLS Configuration
+
+The built-in TLS uses Node.js defaults, which are generally secure. For advanced configuration, consider using a reverse proxy that offers more fine-grained control over TLS settings.
+
+## Troubleshooting
+
+### TLS Not Enabled Despite Configuration
+
+Check that:
+
+1. `TLS_ENABLED` is set to `true` (case-insensitive)
+2. Both `TLS_CERT_PATH` and `TLS_KEY_PATH` are set
+3. Certificate and key files exist at the specified paths
+4. The application has read permissions for the certificate files
+
+The application logs will show warnings if TLS configuration is incomplete:
+
+```
+⚠️ TLS_ENABLED is true but TLS_CERT_PATH or TLS_KEY_PATH is not set. Falling back to HTTP.
+```
+
+### Certificate Verification Errors
+
+If clients report certificate errors:
+
+1. Ensure the certificate matches the hostname
+2. Include the full certificate chain in `TLS_CERT_PATH`
+3. Verify the certificate is not expired
+
+### Permission Errors
+
+```bash
+# Set proper permissions for certificate files
+chmod 644 cert.pem
+chmod 600 key.pem
+```
+
+## Verifying TLS Configuration
+
+After starting the application with TLS enabled, verify the configuration:
+
+```bash
+# Check if HTTPS is working
+curl -v https://localhost:3000/health
+
+# For self-signed certificates, use -k to skip verification
+curl -k https://localhost:3000/health
+
+# Check certificate details
+openssl s_client -connect localhost:3000 -showcerts
+```
+
+The startup logs will show the TLS status:
+
+```
+🔒 TLS:            Enabled
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -125,6 +125,7 @@ nav:
       - Overview: deployment/index.md
       - Docker Compose: deployment/docker-compose.md
       - Kubernetes: deployment/kubernetes.md
+      - TLS/HTTPS: deployment/tls.md
   - Architecture:
       - Overview: architecture/index.md      
       - Supported Protocols: architecture/supported-protocols.md


### PR DESCRIPTION
Signed-off-by: Mirko Mollik <mirko.mollik@eudi.sprind.org>

## 📝 Description

Allow to use an exsiting TLS cert for running the service. It will not be used for any access certs or so.