### PR TITLE
fix: add correct migration files

### DIFF
--- a/apps/backend/src/database/migrations/1743000000000-AddKeyUsageEntity.ts
+++ b/apps/backend/src/database/migrations/1743000000000-AddKeyUsageEntity.ts
@@ -21,6 +21,15 @@ export class AddKeyUsageEntity1743000000000 implements MigrationInterface {
     name = "AddKeyUsageEntity1743000000000";
 
     public async up(queryRunner: QueryRunner): Promise<void> {
+        // On a fresh database, key_entity won't exist yet — TypeORM synchronize will create the full schema.
+        const keyTable = await queryRunner.getTable("key_entity");
+        if (!keyTable) {
+            console.log(
+                "[Migration] key_entity table not found — skipping (schema may not exist yet).",
+            );
+            return;
+        }
+
         // Check if key_usage_entity already exists
         const table = await queryRunner.getTable("key_usage_entity");
         if (table) {

--- a/apps/backend/src/database/migrations/1745000000000-RenameSigningToAttestation.ts
+++ b/apps/backend/src/database/migrations/1745000000000-RenameSigningToAttestation.ts
@@ -9,6 +9,15 @@ export class RenameSigningToAttestation1745000000000
     name = "RenameSigningToAttestation1745000000000";
 
     public async up(queryRunner: QueryRunner): Promise<void> {
+        // On a fresh database, key_usage_entity won't exist yet — TypeORM synchronize will create the full schema.
+        const table = await queryRunner.getTable("key_usage_entity");
+        if (!table) {
+            console.log(
+                "[Migration] key_usage_entity table not found — skipping (schema may not exist yet).",
+            );
+            return;
+        }
+
         // Update key_usage_entity usage column from 'signing' to 'attestation'
         await queryRunner.query(
             `UPDATE "key_usage_entity" SET "usage" = 'attestation' WHERE "usage" = 'signing'`,
@@ -16,6 +25,11 @@ export class RenameSigningToAttestation1745000000000
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
+        const table = await queryRunner.getTable("key_usage_entity");
+        if (!table) {
+            return;
+        }
+
         // Revert: update key_usage_entity usage column from 'attestation' to 'signing'
         await queryRunner.query(
             `UPDATE "key_usage_entity" SET "usage" = 'signing' WHERE "usage" = 'attestation'`,

--- a/apps/backend/src/database/migrations/1746000000000-FlattenKeyUsageType.ts
+++ b/apps/backend/src/database/migrations/1746000000000-FlattenKeyUsageType.ts
@@ -26,11 +26,9 @@ export class FlattenKeyUsageType1746000000000 implements MigrationInterface {
         }
 
         // Check if usageType column already exists
-        const columns = await queryRunner.query(
-            `PRAGMA table_info("key_entity")`,
-        );
-        const hasUsageType = columns.some(
-            (col: any) => col.name === "usageType",
+        const keyTable = await queryRunner.getTable("key_entity");
+        const hasUsageType = keyTable?.columns.some(
+            (col) => col.name === "usageType",
         );
         if (hasUsageType) {
             console.log(
@@ -105,10 +103,7 @@ export class FlattenKeyUsageType1746000000000 implements MigrationInterface {
         queryRunner: QueryRunner,
         tableName: string,
     ): Promise<boolean> {
-        const result = await queryRunner.query(
-            `SELECT name FROM sqlite_master WHERE type='table' AND name=?`,
-            [tableName],
-        );
-        return result.length > 0;
+        const table = await queryRunner.getTable(tableName);
+        return !!table;
     }
 }

--- a/apps/backend/src/database/migrations/1747000000000-MigrateKeysToKeyChain.ts
+++ b/apps/backend/src/database/migrations/1747000000000-MigrateKeysToKeyChain.ts
@@ -20,11 +20,8 @@ export class MigrateKeysToKeyChain1747000000000 implements MigrationInterface {
         queryRunner: QueryRunner,
         tableName: string,
     ): Promise<boolean> {
-        const result = await queryRunner.query(
-            `SELECT name FROM sqlite_master WHERE type='table' AND name=?`,
-            [tableName],
-        );
-        return result.length > 0;
+        const table = await queryRunner.getTable(tableName);
+        return !!table;
     }
 
     async up(queryRunner: QueryRunner): Promise<void> {


### PR DESCRIPTION
## Summary

Fixes migrations that fail on a fresh database (especially with PostgreSQL).

### Problem

On a fresh database, TypeORM runs migrations **before** `synchronize` creates the schema. Several migrations reference tables (`key_entity`, `key_usage_entity`) that don't exist yet, causing a fatal error:

```
Migration "AddKeyUsageEntity1743000000000" failed, error: relation "key_entity" does not exist
```

Additionally, two migrations used SQLite-specific queries (`sqlite_master`, `PRAGMA table_info`) that fail on PostgreSQL.

### Changes

- **1743000000000-AddKeyUsageEntity**: Added early return if `key_entity` doesn't exist (matching the pattern used by other migrations)
- **1745000000000-RenameSigningToAttestation**: Added early return if `key_usage_entity` doesn't exist
- **1746000000000-FlattenKeyUsageType**: Replaced `sqlite_master` query and `PRAGMA table_info` with database-agnostic `queryRunner.getTable()`
- **1747000000000-MigrateKeysToKeyChain**: Replaced `sqlite_master` query with database-agnostic `queryRunner.getTable()`