### PR TITLE
feat(webhook): implement raw token pass-through in webhooks

### DIFF
--- a/apps/backend/src/shared/utils/webhook/webhook.dto.ts
+++ b/apps/backend/src/shared/utils/webhook/webhook.dto.ts
@@ -6,6 +6,8 @@ import {
     IsObject,
     IsString,
     ValidateNested,
+    IsArray,
+    IsOptional,
 } from "class-validator";
 
 /**
@@ -104,4 +106,19 @@ export class WebhookConfig {
     })
     @IsObject()
     auth!: WebHookAuthConfigNone | WebHookAuthConfigHeader;
+
+    /**
+     * Optional array of credential configuration IDs.
+     * If provided, the webhook payload will include the raw cryptographic 
+     * presentation (e.g., vp_token) for these specific credentials.
+     */
+    @IsOptional()
+    @IsArray()
+    @IsString({ each: true })
+    @ApiProperty({
+        required: false,
+        type: [String],
+        description: "List of credential IDs to include raw tokens for (e.g., ['sca_credential'])"
+    })
+    includeRawTokensFor?: string[];
 }

--- a/apps/backend/src/shared/utils/webhook/webhook.dto.ts
+++ b/apps/backend/src/shared/utils/webhook/webhook.dto.ts
@@ -109,7 +109,7 @@ export class WebhookConfig {
 
     /**
      * Optional array of credential configuration IDs.
-     * If provided, the webhook payload will include the raw cryptographic 
+     * If provided, the webhook payload will include the raw cryptographic
      * presentation (e.g., vp_token) for these specific credentials.
      */
     @IsOptional()
@@ -118,7 +118,8 @@ export class WebhookConfig {
     @ApiProperty({
         required: false,
         type: [String],
-        description: "List of credential IDs to include raw tokens for (e.g., ['sca_credential'])"
+        description:
+            "List of credential IDs to include raw tokens for (e.g., ['sca_credential'])",
     })
     includeRawTokensFor?: string[];
 }

--- a/apps/backend/src/shared/utils/webhook/webhook.service.ts
+++ b/apps/backend/src/shared/utils/webhook/webhook.service.ts
@@ -9,7 +9,7 @@ import { SessionService } from "../../../session/session.service";
 import { SessionLoggerService } from "../logger/session-logger.service";
 import { SessionLogContext } from "../logger/session-logger-context";
 import { WebhookConfig } from "./webhook.dto";
-import { extractRawTokenFromSubmission } from './webhook.utils';
+import { extractRawTokenFromSubmission } from "./webhook.utils";
 
 /**
  * Response from a webhook to receive credentials.
@@ -81,28 +81,35 @@ export class WebhookService {
         let payloadCredentials = values.credentials;
 
         if (
-            payloadCredentials && 
-            values.webhook.includeRawTokensFor?.length && 
-            values.rawPresentationPayload 
+            payloadCredentials &&
+            values.webhook.includeRawTokensFor?.length &&
+            values.rawPresentationPayload
         ) {
             const requestedIds = values.webhook.includeRawTokensFor;
             const rawPayload = values.rawPresentationPayload;
 
-            payloadCredentials = payloadCredentials.map(cred => {
+            payloadCredentials = payloadCredentials.map((cred) => {
                 if (requestedIds.includes(cred.id)) {
                     // Extract the raw cryptographic token using the utility function
-                    const rawToken = extractRawTokenFromSubmission(cred.id, rawPayload);
+                    const rawToken = extractRawTokenFromSubmission(
+                        cred.id,
+                        rawPayload,
+                    );
                     return {
                         ...cred,
-                        rawToken
+                        rawToken,
                     };
                 }
                 return cred;
             });
-            
-            this.sessionLogger.logSession(values.logContext, "Appended raw tokens to credentials", {
-                requestedIds
-            });
+
+            this.sessionLogger.logSession(
+                values.logContext,
+                "Appended raw tokens to credentials",
+                {
+                    requestedIds,
+                },
+            );
         }
 
         this.sessionLogger.logSession(values.logContext, "Sending webhook", {

--- a/apps/backend/src/shared/utils/webhook/webhook.service.ts
+++ b/apps/backend/src/shared/utils/webhook/webhook.service.ts
@@ -9,6 +9,7 @@ import { SessionService } from "../../../session/session.service";
 import { SessionLoggerService } from "../logger/session-logger.service";
 import { SessionLogContext } from "../logger/session-logger-context";
 import { WebhookConfig } from "./webhook.dto";
+import { extractRawTokenFromSubmission } from './webhook.utils';
 
 /**
  * Response from a webhook to receive credentials.
@@ -68,6 +69,7 @@ export class WebhookService {
         session: Session;
         credentials?: any[];
         expectResponse: boolean;
+        rawPresentationPayload?: any;
     }): Promise<WebhookResponse> {
         const headers: Record<string, string> = {};
 
@@ -75,6 +77,34 @@ export class WebhookService {
             headers[values.webhook.auth.config.headerName] =
                 values.webhook.auth.config.value;
         }
+
+        let payloadCredentials = values.credentials;
+
+        if (
+            payloadCredentials && 
+            values.webhook.includeRawTokensFor?.length && 
+            values.rawPresentationPayload 
+        ) {
+            const requestedIds = values.webhook.includeRawTokensFor;
+            const rawPayload = values.rawPresentationPayload;
+
+            payloadCredentials = payloadCredentials.map(cred => {
+                if (requestedIds.includes(cred.id)) {
+                    // Extract the raw cryptographic token using the utility function
+                    const rawToken = extractRawTokenFromSubmission(cred.id, rawPayload);
+                    return {
+                        ...cred,
+                        rawToken
+                    };
+                }
+                return cred;
+            });
+            
+            this.sessionLogger.logSession(values.logContext, "Appended raw tokens to credentials", {
+                requestedIds
+            });
+        }
+
         this.sessionLogger.logSession(values.logContext, "Sending webhook", {
             webhookUrl: values.webhook.url,
             authType: values.webhook.auth?.type || "none",

--- a/apps/backend/src/shared/utils/webhook/webhook.service.ts
+++ b/apps/backend/src/shared/utils/webhook/webhook.service.ts
@@ -121,7 +121,7 @@ export class WebhookService {
             this.httpService.post(
                 values.webhook.url,
                 {
-                    credentials: values.credentials,
+                    credentials: payloadCredentials,
                     session: values.session.id,
                 },
                 {

--- a/apps/backend/src/shared/utils/webhook/webhook.utils.spec.ts
+++ b/apps/backend/src/shared/utils/webhook/webhook.utils.spec.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { extractRawTokenFromSubmission } from './webhook.utils';
+
+describe('Webhook Utils: extractRawTokenFromSubmission', () => {
+    it('should return null if rawPayload is missing or invalid', () => {
+        expect(extractRawTokenFromSubmission('test_id', null)).toBeNull();
+        expect(extractRawTokenFromSubmission('test_id', {})).toBeNull();
+        expect(extractRawTokenFromSubmission('test_id', { vp_token: 'token' })).toBeNull();
+    });
+
+    it('should return null if credentialId is not in descriptor_map', () => {
+        const payload = {
+            vp_token: 'some_token',
+            presentation_submission: {
+                descriptor_map: [{ id: 'other_id', path: '$' }],
+            },
+        };
+        expect(extractRawTokenFromSubmission('test_id', payload)).toBeNull();
+    });
+
+    it('should extract a single string vp_token (Path: $)', () => {
+        const payload = {
+            vp_token: 'header.payload.signature',
+            presentation_submission: {
+                descriptor_map: [{ id: 'sca_credential', path: '$' }],
+            },
+        };
+        expect(extractRawTokenFromSubmission('sca_credential', payload)).toBe('header.payload.signature');
+    });
+
+    it('should extract a single string vp_token (Path: $[0])', () => {
+        const payload = {
+            vp_token: 'header.payload.signature',
+            presentation_submission: {
+                descriptor_map: [{ id: 'age_credential', path: '$[0]' }],
+            },
+        };
+        expect(extractRawTokenFromSubmission('age_credential', payload)).toBe('header.payload.signature');
+    });
+
+    it('should extract the correct token from an array of vp_tokens', () => {
+        const payload = {
+            vp_token: ['token_index_0', 'token_index_1', 'token_index_2'],
+            presentation_submission: {
+                descriptor_map: [
+                    { id: 'age_credential', path: '$[0]' },
+                    { id: 'sca_credential', path: '$[1]' },
+                ],
+            },
+        };
+        expect(extractRawTokenFromSubmission('sca_credential', payload)).toBe('token_index_1');
+        expect(extractRawTokenFromSubmission('age_credential', payload)).toBe('token_index_0');
+    });
+
+    it('should safely return null on malformed JSON paths', () => {
+        const payload = {
+            vp_token: ['token1', 'token2'],
+            presentation_submission: {
+                descriptor_map: [{ id: 'broken_credential', path: 'invalid_path' }],
+            },
+        };
+        expect(extractRawTokenFromSubmission('broken_credential', payload)).toBeNull();
+    });
+});

--- a/apps/backend/src/shared/utils/webhook/webhook.utils.spec.ts
+++ b/apps/backend/src/shared/utils/webhook/webhook.utils.spec.ts
@@ -2,152 +2,193 @@ import { describe, it, expect } from "vitest";
 import { extractRawTokenFromSubmission } from "./webhook.utils";
 
 describe("Webhook Utils: extractRawTokenFromSubmission", () => {
-  const testId = "pid_credential";
-  const mockToken = "eyJ0eXAiOiJkYytzZC1qd3QiLCJhbGciOiJFUzI1NiJ9.mock_payload";
+    const testId = "pid_credential";
+    const mockToken =
+        "eyJ0eXAiOiJkYytzZC1qd3QiLCJhbGciOiJFUzI1NiJ9.mock_payload";
 
-  describe("Basic Validation", () => {
-    it("should return undefined if payload is null or undefined", () => {
-      expect(extractRawTokenFromSubmission(testId, null)).toBeUndefined();
-      expect(extractRawTokenFromSubmission(testId, undefined)).toBeUndefined();
+    describe("Basic Validation", () => {
+        it("should return undefined if payload is null or undefined", () => {
+            expect(extractRawTokenFromSubmission(testId, null)).toBeUndefined();
+            expect(
+                extractRawTokenFromSubmission(testId, undefined),
+            ).toBeUndefined();
+        });
+
+        it("should return undefined if vp_token is missing", () => {
+            expect(extractRawTokenFromSubmission(testId, {})).toBeUndefined();
+            expect(
+                extractRawTokenFromSubmission(testId, {
+                    presentation_submission: {},
+                }),
+            ).toBeUndefined();
+        });
+
+        it("should return undefined for unsupported vp_token types (e.g. number, boolean)", () => {
+            expect(
+                extractRawTokenFromSubmission(testId, {
+                    vp_token: 12345,
+                } as any),
+            ).toBeUndefined();
+            expect(
+                extractRawTokenFromSubmission(testId, {
+                    vp_token: true,
+                } as any),
+            ).toBeUndefined();
+        });
     });
 
-    it("should return undefined if vp_token is missing", () => {
-      expect(extractRawTokenFromSubmission(testId, {})).toBeUndefined();
-      expect(extractRawTokenFromSubmission(testId, { presentation_submission: {} })).toBeUndefined();
+    describe("Strategy 1: descriptor_map (Official OID4VP Standard)", () => {
+        it("should extract token using '$' path", () => {
+            const payload = {
+                vp_token: [mockToken],
+                presentation_submission: {
+                    descriptor_map: [{ id: testId, path: "$" }],
+                },
+            };
+            expect(extractRawTokenFromSubmission(testId, payload)).toBe(
+                mockToken,
+            );
+        });
+
+        it("should extract token using '$[0]' path", () => {
+            const payload = {
+                vp_token: [mockToken],
+                presentation_submission: {
+                    descriptor_map: [{ id: testId, path: "$[0]" }],
+                },
+            };
+            expect(extractRawTokenFromSubmission(testId, payload)).toBe(
+                mockToken,
+            );
+        });
+
+        it("should extract the correct index in Multi-Credential flows (e.g. $[1])", () => {
+            const payload = {
+                vp_token: ["other_token", mockToken],
+                presentation_submission: {
+                    descriptor_map: [
+                        { id: "other_id", path: "$[0]" },
+                        { id: testId, path: "$[1]" },
+                    ],
+                },
+            };
+            expect(extractRawTokenFromSubmission(testId, payload)).toBe(
+                mockToken,
+            );
+        });
+
+        it("should return undefined if the path index is out of bounds", () => {
+            const payload = {
+                vp_token: [mockToken],
+                presentation_submission: {
+                    descriptor_map: [{ id: testId, path: "$[10]" }],
+                },
+            };
+            expect(
+                extractRawTokenFromSubmission(testId, payload),
+            ).toBeUndefined();
+        });
+
+        it("should return undefined if the found element in the array is not a string", () => {
+            const payload = {
+                vp_token: [12345], // Not a string
+                presentation_submission: {
+                    descriptor_map: [{ id: testId, path: "$[0]" }],
+                },
+            };
+            expect(
+                extractRawTokenFromSubmission(testId, payload as any),
+            ).toBeUndefined();
+        });
+
+        it("should return undefined if vp_token is not an array but descriptor_map is provided", () => {
+            const payload = {
+                vp_token: mockToken, // String instead of array
+                presentation_submission: {
+                    descriptor_map: [{ id: testId, path: "$[0]" }],
+                },
+            };
+            // Logic skips Strategy 1 because Array.isArray(vpToken) is false
+            // and falls through to other strategies.
+            expect(extractRawTokenFromSubmission(testId, payload)).toBe(
+                mockToken,
+            );
+        });
     });
 
-    it("should return undefined for unsupported vp_token types (e.g. number, boolean)", () => {
-      expect(extractRawTokenFromSubmission(testId, { vp_token: 12345 } as any)).toBeUndefined();
-      expect(extractRawTokenFromSubmission(testId, { vp_token: true } as any)).toBeUndefined();
-    });
-  });
+    describe("Strategy 2: ID-Mapping (E2E & Legacy Fallback)", () => {
+        it("should extract token if vp_token is an object keyed by ID (string value)", () => {
+            const payload = {
+                vp_token: {
+                    [testId]: mockToken,
+                    unrelated: "other_data",
+                },
+            };
+            expect(extractRawTokenFromSubmission(testId, payload)).toBe(
+                mockToken,
+            );
+        });
 
-  describe("Strategy 1: descriptor_map (Official OID4VP Standard)", () => {
-    it("should extract token using '$' path", () => {
-      const payload = {
-        vp_token: [mockToken],
-        presentation_submission: {
-          descriptor_map: [{ id: testId, path: "$" }]
-        }
-      };
-      expect(extractRawTokenFromSubmission(testId, payload)).toBe(mockToken);
-    });
+        it("should extract the first element if the mapped object value is an array", () => {
+            const payload = {
+                vp_token: {
+                    [testId]: [mockToken, "second_token"],
+                },
+            };
+            expect(extractRawTokenFromSubmission(testId, payload)).toBe(
+                mockToken,
+            );
+        });
 
-    it("should extract token using '$[0]' path", () => {
-      const payload = {
-        vp_token: [mockToken],
-        presentation_submission: {
-          descriptor_map: [{ id: testId, path: "$[0]" }]
-        }
-      };
-      expect(extractRawTokenFromSubmission(testId, payload)).toBe(mockToken);
-    });
-
-    it("should extract the correct index in Multi-Credential flows (e.g. $[1])", () => {
-      const payload = {
-        vp_token: ["other_token", mockToken],
-        presentation_submission: {
-          descriptor_map: [
-            { id: "other_id", path: "$[0]" },
-            { id: testId, path: "$[1]" }
-          ]
-        }
-      };
-      expect(extractRawTokenFromSubmission(testId, payload)).toBe(mockToken);
+        it("should protect against prototype pollution", () => {
+            const pollutedVpToken = Object.create({
+                [testId]: "malicious_token",
+            });
+            const payload = {
+                vp_token: pollutedVpToken,
+            };
+            // Should not find the ID because it's inherited, not an "own" property
+            expect(
+                extractRawTokenFromSubmission(testId, payload),
+            ).toBeUndefined();
+        });
     });
 
-    it("should return undefined if the path index is out of bounds", () => {
-      const payload = {
-        vp_token: [mockToken],
-        presentation_submission: {
-          descriptor_map: [{ id: testId, path: "$[10]" }]
-        }
-      };
-      expect(extractRawTokenFromSubmission(testId, payload)).toBeUndefined();
+    describe("Strategy 3: Simple String", () => {
+        it("should return the vp_token directly if it is a single string", () => {
+            const payload = {
+                vp_token: mockToken,
+            };
+            expect(extractRawTokenFromSubmission(testId, payload)).toBe(
+                mockToken,
+            );
+        });
     });
 
-    it("should return undefined if the found element in the array is not a string", () => {
-      const payload = {
-        vp_token: [12345], // Not a string
-        presentation_submission: {
-          descriptor_map: [{ id: testId, path: "$[0]" }]
-        }
-      };
-      expect(extractRawTokenFromSubmission(testId, payload as any)).toBeUndefined();
-    });
+    describe("Strictness Checks", () => {
+        it("should return undefined if vp_token is an array but no descriptor_map matches the ID", () => {
+            const payload = {
+                vp_token: [mockToken],
+                presentation_submission: {
+                    descriptor_map: [{ id: "wrong_id", path: "$[0]" }],
+                },
+            };
+            // Stricter version: No fallback to index 0 if a descriptor map exists but doesn't match
+            expect(
+                extractRawTokenFromSubmission(testId, payload),
+            ).toBeUndefined();
+        });
 
-    it("should return undefined if vp_token is not an array but descriptor_map is provided", () => {
-      const payload = {
-        vp_token: mockToken, // String instead of array
-        presentation_submission: {
-          descriptor_map: [{ id: testId, path: "$[0]" }]
-        }
-      };
-      // Logic skips Strategy 1 because Array.isArray(vpToken) is false
-      // and falls through to other strategies.
-      expect(extractRawTokenFromSubmission(testId, payload)).toBe(mockToken);
+        it("should return undefined if vp_token is an empty array", () => {
+            const payload = {
+                vp_token: [],
+                presentation_submission: {
+                    descriptor_map: [{ id: testId, path: "$[0]" }],
+                },
+            };
+            expect(
+                extractRawTokenFromSubmission(testId, payload),
+            ).toBeUndefined();
+        });
     });
-  });
-
-  describe("Strategy 2: ID-Mapping (E2E & Legacy Fallback)", () => {
-    it("should extract token if vp_token is an object keyed by ID (string value)", () => {
-      const payload = {
-        vp_token: {
-          [testId]: mockToken,
-          unrelated: "other_data"
-        }
-      };
-      expect(extractRawTokenFromSubmission(testId, payload)).toBe(mockToken);
-    });
-
-    it("should extract the first element if the mapped object value is an array", () => {
-      const payload = {
-        vp_token: {
-          [testId]: [mockToken, "second_token"]
-        }
-      };
-      expect(extractRawTokenFromSubmission(testId, payload)).toBe(mockToken);
-    });
-
-    it("should protect against prototype pollution", () => {
-      const pollutedVpToken = Object.create({ [testId]: "malicious_token" });
-      const payload = {
-        vp_token: pollutedVpToken
-      };
-      // Should not find the ID because it's inherited, not an "own" property
-      expect(extractRawTokenFromSubmission(testId, payload)).toBeUndefined();
-    });
-  });
-
-  describe("Strategy 3: Simple String", () => {
-    it("should return the vp_token directly if it is a single string", () => {
-      const payload = {
-        vp_token: mockToken
-      };
-      expect(extractRawTokenFromSubmission(testId, payload)).toBe(mockToken);
-    });
-  });
-
-  describe("Strictness Checks", () => {
-    it("should return undefined if vp_token is an array but no descriptor_map matches the ID", () => {
-      const payload = {
-        vp_token: [mockToken],
-        presentation_submission: {
-          descriptor_map: [{ id: "wrong_id", path: "$[0]" }]
-        }
-      };
-      // Stricter version: No fallback to index 0 if a descriptor map exists but doesn't match
-      expect(extractRawTokenFromSubmission(testId, payload)).toBeUndefined();
-    });
-
-    it("should return undefined if vp_token is an empty array", () => {
-      const payload = {
-        vp_token: [],
-        presentation_submission: {
-          descriptor_map: [{ id: testId, path: "$[0]" }]
-        }
-      };
-      expect(extractRawTokenFromSubmission(testId, payload)).toBeUndefined();
-    });
-  });
 });

--- a/apps/backend/src/shared/utils/webhook/webhook.utils.spec.ts
+++ b/apps/backend/src/shared/utils/webhook/webhook.utils.spec.ts
@@ -2,77 +2,152 @@ import { describe, it, expect } from "vitest";
 import { extractRawTokenFromSubmission } from "./webhook.utils";
 
 describe("Webhook Utils: extractRawTokenFromSubmission", () => {
-    it("should return null if rawPayload is missing or invalid", () => {
-        expect(extractRawTokenFromSubmission("test_id", null)).toBeNull();
-        expect(extractRawTokenFromSubmission("test_id", {})).toBeNull();
-        expect(
-            extractRawTokenFromSubmission("test_id", { vp_token: "token" }),
-        ).toBeNull();
+  const testId = "pid_credential";
+  const mockToken = "eyJ0eXAiOiJkYytzZC1qd3QiLCJhbGciOiJFUzI1NiJ9.mock_payload";
+
+  describe("Basic Validation", () => {
+    it("should return undefined if payload is null or undefined", () => {
+      expect(extractRawTokenFromSubmission(testId, null)).toBeUndefined();
+      expect(extractRawTokenFromSubmission(testId, undefined)).toBeUndefined();
     });
 
-    it("should return null if credentialId is not in descriptor_map", () => {
-        const payload = {
-            vp_token: "some_token",
-            presentation_submission: {
-                descriptor_map: [{ id: "other_id", path: "$" }],
-            },
-        };
-        expect(extractRawTokenFromSubmission("test_id", payload)).toBeNull();
+    it("should return undefined if vp_token is missing", () => {
+      expect(extractRawTokenFromSubmission(testId, {})).toBeUndefined();
+      expect(extractRawTokenFromSubmission(testId, { presentation_submission: {} })).toBeUndefined();
     });
 
-    it("should extract a single string vp_token (Path: $)", () => {
-        const payload = {
-            vp_token: "header.payload.signature",
-            presentation_submission: {
-                descriptor_map: [{ id: "sca_credential", path: "$" }],
-            },
-        };
-        expect(extractRawTokenFromSubmission("sca_credential", payload)).toBe(
-            "header.payload.signature",
-        );
+    it("should return undefined for unsupported vp_token types (e.g. number, boolean)", () => {
+      expect(extractRawTokenFromSubmission(testId, { vp_token: 12345 } as any)).toBeUndefined();
+      expect(extractRawTokenFromSubmission(testId, { vp_token: true } as any)).toBeUndefined();
+    });
+  });
+
+  describe("Strategy 1: descriptor_map (Official OID4VP Standard)", () => {
+    it("should extract token using '$' path", () => {
+      const payload = {
+        vp_token: [mockToken],
+        presentation_submission: {
+          descriptor_map: [{ id: testId, path: "$" }]
+        }
+      };
+      expect(extractRawTokenFromSubmission(testId, payload)).toBe(mockToken);
     });
 
-    it("should extract a single string vp_token (Path: $[0])", () => {
-        const payload = {
-            vp_token: "header.payload.signature",
-            presentation_submission: {
-                descriptor_map: [{ id: "age_credential", path: "$[0]" }],
-            },
-        };
-        expect(extractRawTokenFromSubmission("age_credential", payload)).toBe(
-            "header.payload.signature",
-        );
+    it("should extract token using '$[0]' path", () => {
+      const payload = {
+        vp_token: [mockToken],
+        presentation_submission: {
+          descriptor_map: [{ id: testId, path: "$[0]" }]
+        }
+      };
+      expect(extractRawTokenFromSubmission(testId, payload)).toBe(mockToken);
     });
 
-    it("should extract the correct token from an array of vp_tokens", () => {
-        const payload = {
-            vp_token: ["token_index_0", "token_index_1", "token_index_2"],
-            presentation_submission: {
-                descriptor_map: [
-                    { id: "age_credential", path: "$[0]" },
-                    { id: "sca_credential", path: "$[1]" },
-                ],
-            },
-        };
-        expect(extractRawTokenFromSubmission("sca_credential", payload)).toBe(
-            "token_index_1",
-        );
-        expect(extractRawTokenFromSubmission("age_credential", payload)).toBe(
-            "token_index_0",
-        );
+    it("should extract the correct index in Multi-Credential flows (e.g. $[1])", () => {
+      const payload = {
+        vp_token: ["other_token", mockToken],
+        presentation_submission: {
+          descriptor_map: [
+            { id: "other_id", path: "$[0]" },
+            { id: testId, path: "$[1]" }
+          ]
+        }
+      };
+      expect(extractRawTokenFromSubmission(testId, payload)).toBe(mockToken);
     });
 
-    it("should safely return null on malformed JSON paths", () => {
-        const payload = {
-            vp_token: ["token1", "token2"],
-            presentation_submission: {
-                descriptor_map: [
-                    { id: "broken_credential", path: "invalid_path" },
-                ],
-            },
-        };
-        expect(
-            extractRawTokenFromSubmission("broken_credential", payload),
-        ).toBeNull();
+    it("should return undefined if the path index is out of bounds", () => {
+      const payload = {
+        vp_token: [mockToken],
+        presentation_submission: {
+          descriptor_map: [{ id: testId, path: "$[10]" }]
+        }
+      };
+      expect(extractRawTokenFromSubmission(testId, payload)).toBeUndefined();
     });
+
+    it("should return undefined if the found element in the array is not a string", () => {
+      const payload = {
+        vp_token: [12345], // Not a string
+        presentation_submission: {
+          descriptor_map: [{ id: testId, path: "$[0]" }]
+        }
+      };
+      expect(extractRawTokenFromSubmission(testId, payload as any)).toBeUndefined();
+    });
+
+    it("should return undefined if vp_token is not an array but descriptor_map is provided", () => {
+      const payload = {
+        vp_token: mockToken, // String instead of array
+        presentation_submission: {
+          descriptor_map: [{ id: testId, path: "$[0]" }]
+        }
+      };
+      // Logic skips Strategy 1 because Array.isArray(vpToken) is false
+      // and falls through to other strategies.
+      expect(extractRawTokenFromSubmission(testId, payload)).toBe(mockToken);
+    });
+  });
+
+  describe("Strategy 2: ID-Mapping (E2E & Legacy Fallback)", () => {
+    it("should extract token if vp_token is an object keyed by ID (string value)", () => {
+      const payload = {
+        vp_token: {
+          [testId]: mockToken,
+          unrelated: "other_data"
+        }
+      };
+      expect(extractRawTokenFromSubmission(testId, payload)).toBe(mockToken);
+    });
+
+    it("should extract the first element if the mapped object value is an array", () => {
+      const payload = {
+        vp_token: {
+          [testId]: [mockToken, "second_token"]
+        }
+      };
+      expect(extractRawTokenFromSubmission(testId, payload)).toBe(mockToken);
+    });
+
+    it("should protect against prototype pollution", () => {
+      const pollutedVpToken = Object.create({ [testId]: "malicious_token" });
+      const payload = {
+        vp_token: pollutedVpToken
+      };
+      // Should not find the ID because it's inherited, not an "own" property
+      expect(extractRawTokenFromSubmission(testId, payload)).toBeUndefined();
+    });
+  });
+
+  describe("Strategy 3: Simple String", () => {
+    it("should return the vp_token directly if it is a single string", () => {
+      const payload = {
+        vp_token: mockToken
+      };
+      expect(extractRawTokenFromSubmission(testId, payload)).toBe(mockToken);
+    });
+  });
+
+  describe("Strictness Checks", () => {
+    it("should return undefined if vp_token is an array but no descriptor_map matches the ID", () => {
+      const payload = {
+        vp_token: [mockToken],
+        presentation_submission: {
+          descriptor_map: [{ id: "wrong_id", path: "$[0]" }]
+        }
+      };
+      // Stricter version: No fallback to index 0 if a descriptor map exists but doesn't match
+      expect(extractRawTokenFromSubmission(testId, payload)).toBeUndefined();
+    });
+
+    it("should return undefined if vp_token is an empty array", () => {
+      const payload = {
+        vp_token: [],
+        presentation_submission: {
+          descriptor_map: [{ id: testId, path: "$[0]" }]
+        }
+      };
+      expect(extractRawTokenFromSubmission(testId, payload)).toBeUndefined();
+    });
+  });
 });

--- a/apps/backend/src/shared/utils/webhook/webhook.utils.spec.ts
+++ b/apps/backend/src/shared/utils/webhook/webhook.utils.spec.ts
@@ -1,64 +1,78 @@
-import { describe, it, expect } from 'vitest';
-import { extractRawTokenFromSubmission } from './webhook.utils';
+import { describe, it, expect } from "vitest";
+import { extractRawTokenFromSubmission } from "./webhook.utils";
 
-describe('Webhook Utils: extractRawTokenFromSubmission', () => {
-    it('should return null if rawPayload is missing or invalid', () => {
-        expect(extractRawTokenFromSubmission('test_id', null)).toBeNull();
-        expect(extractRawTokenFromSubmission('test_id', {})).toBeNull();
-        expect(extractRawTokenFromSubmission('test_id', { vp_token: 'token' })).toBeNull();
+describe("Webhook Utils: extractRawTokenFromSubmission", () => {
+    it("should return null if rawPayload is missing or invalid", () => {
+        expect(extractRawTokenFromSubmission("test_id", null)).toBeNull();
+        expect(extractRawTokenFromSubmission("test_id", {})).toBeNull();
+        expect(
+            extractRawTokenFromSubmission("test_id", { vp_token: "token" }),
+        ).toBeNull();
     });
 
-    it('should return null if credentialId is not in descriptor_map', () => {
+    it("should return null if credentialId is not in descriptor_map", () => {
         const payload = {
-            vp_token: 'some_token',
+            vp_token: "some_token",
             presentation_submission: {
-                descriptor_map: [{ id: 'other_id', path: '$' }],
+                descriptor_map: [{ id: "other_id", path: "$" }],
             },
         };
-        expect(extractRawTokenFromSubmission('test_id', payload)).toBeNull();
+        expect(extractRawTokenFromSubmission("test_id", payload)).toBeNull();
     });
 
-    it('should extract a single string vp_token (Path: $)', () => {
+    it("should extract a single string vp_token (Path: $)", () => {
         const payload = {
-            vp_token: 'header.payload.signature',
+            vp_token: "header.payload.signature",
             presentation_submission: {
-                descriptor_map: [{ id: 'sca_credential', path: '$' }],
+                descriptor_map: [{ id: "sca_credential", path: "$" }],
             },
         };
-        expect(extractRawTokenFromSubmission('sca_credential', payload)).toBe('header.payload.signature');
+        expect(extractRawTokenFromSubmission("sca_credential", payload)).toBe(
+            "header.payload.signature",
+        );
     });
 
-    it('should extract a single string vp_token (Path: $[0])', () => {
+    it("should extract a single string vp_token (Path: $[0])", () => {
         const payload = {
-            vp_token: 'header.payload.signature',
+            vp_token: "header.payload.signature",
             presentation_submission: {
-                descriptor_map: [{ id: 'age_credential', path: '$[0]' }],
+                descriptor_map: [{ id: "age_credential", path: "$[0]" }],
             },
         };
-        expect(extractRawTokenFromSubmission('age_credential', payload)).toBe('header.payload.signature');
+        expect(extractRawTokenFromSubmission("age_credential", payload)).toBe(
+            "header.payload.signature",
+        );
     });
 
-    it('should extract the correct token from an array of vp_tokens', () => {
+    it("should extract the correct token from an array of vp_tokens", () => {
         const payload = {
-            vp_token: ['token_index_0', 'token_index_1', 'token_index_2'],
+            vp_token: ["token_index_0", "token_index_1", "token_index_2"],
             presentation_submission: {
                 descriptor_map: [
-                    { id: 'age_credential', path: '$[0]' },
-                    { id: 'sca_credential', path: '$[1]' },
+                    { id: "age_credential", path: "$[0]" },
+                    { id: "sca_credential", path: "$[1]" },
                 ],
             },
         };
-        expect(extractRawTokenFromSubmission('sca_credential', payload)).toBe('token_index_1');
-        expect(extractRawTokenFromSubmission('age_credential', payload)).toBe('token_index_0');
+        expect(extractRawTokenFromSubmission("sca_credential", payload)).toBe(
+            "token_index_1",
+        );
+        expect(extractRawTokenFromSubmission("age_credential", payload)).toBe(
+            "token_index_0",
+        );
     });
 
-    it('should safely return null on malformed JSON paths', () => {
+    it("should safely return null on malformed JSON paths", () => {
         const payload = {
-            vp_token: ['token1', 'token2'],
+            vp_token: ["token1", "token2"],
             presentation_submission: {
-                descriptor_map: [{ id: 'broken_credential', path: 'invalid_path' }],
+                descriptor_map: [
+                    { id: "broken_credential", path: "invalid_path" },
+                ],
             },
         };
-        expect(extractRawTokenFromSubmission('broken_credential', payload)).toBeNull();
+        expect(
+            extractRawTokenFromSubmission("broken_credential", payload),
+        ).toBeNull();
     });
 });

--- a/apps/backend/src/shared/utils/webhook/webhook.utils.ts
+++ b/apps/backend/src/shared/utils/webhook/webhook.utils.ts
@@ -3,15 +3,18 @@
  * Supporting Multi-Credential-Flows by evaluating the descriptor_map or falling back to ID-mapping.
  */
 export function extractRawTokenFromSubmission(
-    id: string, 
-    payload: { vp_token?: unknown; presentation_submission?: any } | null | undefined
+    id: string,
+    payload:
+        | { vp_token?: unknown; presentation_submission?: any }
+        | null
+        | undefined,
 ): string | undefined {
     const vpToken = payload?.vp_token;
     if (!vpToken) return undefined;
 
     // 1. PRIMARY STRATEGY: Use the descriptor_map
     const descriptor = payload?.presentation_submission?.descriptor_map?.find(
-        (d: any) => d.id === id
+        (d: any) => d.id === id,
     );
 
     if (descriptor && Array.isArray(vpToken)) {
@@ -19,29 +22,38 @@ export function extractRawTokenFromSubmission(
 
         // Path is "$" or "$[0]" -> First element
         if (path === "$" || path === "$[0]") {
-            return typeof vpToken[0] === 'string' ? vpToken[0] : undefined;
+            return typeof vpToken[0] === "string" ? vpToken[0] : undefined;
         }
 
         // Path is an index like "$[1]" (Crucial for Multi-Credential-Flows!)
         const indexMatch = path.match(/^\$\[(\d+)\]$/);
         if (indexMatch) {
             const index = parseInt(indexMatch[1], 10);
-            return typeof vpToken[index] === 'string' ? vpToken[index] : undefined;
+            return typeof vpToken[index] === "string"
+                ? vpToken[index]
+                : undefined;
         }
     }
 
     // 2. FALLBACK STRATEGY: ID-Mapping
-    if (typeof vpToken === 'object' && vpToken !== null && !Array.isArray(vpToken)) {
+    if (
+        typeof vpToken === "object" &&
+        vpToken !== null &&
+        !Array.isArray(vpToken)
+    ) {
         const mapping = vpToken as Record<string, unknown>;
         if (Object.prototype.hasOwnProperty.call(mapping, id)) {
             const tokenForId = mapping[id];
-            if (Array.isArray(tokenForId)) return typeof tokenForId[0] === 'string' ? tokenForId[0] : undefined;
-            if (typeof tokenForId === 'string') return tokenForId;
+            if (Array.isArray(tokenForId))
+                return typeof tokenForId[0] === "string"
+                    ? tokenForId[0]
+                    : undefined;
+            if (typeof tokenForId === "string") return tokenForId;
         }
     }
 
     // 3. LAST RESORT: Simple String (Single credential flow)
-    if (typeof vpToken === 'string') {
+    if (typeof vpToken === "string") {
         return vpToken;
     }
 

--- a/apps/backend/src/shared/utils/webhook/webhook.utils.ts
+++ b/apps/backend/src/shared/utils/webhook/webhook.utils.ts
@@ -1,53 +1,49 @@
 /**
- * Extracts the raw token (e.g., SD-JWT, mDoc) for a specific credential ID
- * based on the OpenID4VP presentation_submission descriptor_map.
- *
- * @param credentialId The ID of the credential requested (e.g., 'sca_credential')
- * @param rawPayload The raw OID4VP presentation response from the wallet
- * @returns The raw cryptographic token as a string, or null if not found/parseable
+ * Extracts the raw cryptographic token from the presentation payload.
+ * Supporting Multi-Credential-Flows by evaluating the descriptor_map or falling back to ID-mapping.
  */
 export function extractRawTokenFromSubmission(
-    credentialId: string,
-    rawPayload: any,
-): string | null {
-    try {
-        const submission = rawPayload?.presentation_submission;
-        const vpToken = rawPayload?.vp_token;
+    id: string, 
+    payload: { vp_token?: unknown; presentation_submission?: any } | null | undefined
+): string | undefined {
+    const vpToken = payload?.vp_token;
+    if (!vpToken) return undefined;
 
-        if (!submission?.descriptor_map || !vpToken) {
-            return null;
+    // 1. PRIMARY STRATEGY: Use the descriptor_map
+    const descriptor = payload?.presentation_submission?.descriptor_map?.find(
+        (d: any) => d.id === id
+    );
+
+    if (descriptor && Array.isArray(vpToken)) {
+        const path = descriptor.path as string;
+
+        // Path is "$" or "$[0]" -> First element
+        if (path === "$" || path === "$[0]") {
+            return typeof vpToken[0] === 'string' ? vpToken[0] : undefined;
         }
 
-        // Find the entry in the descriptor_map that corresponds to this ID
-        const descriptor = submission.descriptor_map.find(
-            (d: any) => d.id === credentialId,
-        );
-
-        if (!descriptor) {
-            return null;
+        // Path is an index like "$[1]" (Crucial for Multi-Credential-Flows!)
+        const indexMatch = path.match(/^\$\[(\d+)\]$/);
+        if (indexMatch) {
+            const index = parseInt(indexMatch[1], 10);
+            return typeof vpToken[index] === 'string' ? vpToken[index] : undefined;
         }
-
-        const path = descriptor.path; // e.g., "$", "$[0]", "$[1]"
-
-        // Logic according to the OID4VP specification:
-        // If vp_token is a single string, the path is usually "$" or "$[0]"
-        if (typeof vpToken === "string" && (path === "$" || path === "$[0]")) {
-            return vpToken;
-        }
-
-        // If vp_token is an array (multiple presentations in a single request)
-        if (Array.isArray(vpToken)) {
-            // Parse the JSONPath (basic implementation for $[0], $[1], etc.)
-            const match = path.match(/\$\[(\d+)\]/);
-            if (match && match[1]) {
-                const index = parseInt(match[1], 10);
-                return vpToken[index] || null;
-            }
-        }
-
-        return null;
-    } catch (error) {
-        // Fallback to prevent the webhook from crashing due to a parsing error
-        return null;
     }
+
+    // 2. FALLBACK STRATEGY: ID-Mapping
+    if (typeof vpToken === 'object' && vpToken !== null && !Array.isArray(vpToken)) {
+        const mapping = vpToken as Record<string, unknown>;
+        if (Object.prototype.hasOwnProperty.call(mapping, id)) {
+            const tokenForId = mapping[id];
+            if (Array.isArray(tokenForId)) return typeof tokenForId[0] === 'string' ? tokenForId[0] : undefined;
+            if (typeof tokenForId === 'string') return tokenForId;
+        }
+    }
+
+    // 3. LAST RESORT: Simple String (Single credential flow)
+    if (typeof vpToken === 'string') {
+        return vpToken;
+    }
+
+    return undefined;
 }

--- a/apps/backend/src/shared/utils/webhook/webhook.utils.ts
+++ b/apps/backend/src/shared/utils/webhook/webhook.utils.ts
@@ -7,8 +7,8 @@
  * @returns The raw cryptographic token as a string, or null if not found/parseable
  */
 export function extractRawTokenFromSubmission(
-    credentialId: string, 
-    rawPayload: any
+    credentialId: string,
+    rawPayload: any,
 ): string | null {
     try {
         const submission = rawPayload?.presentation_submission;
@@ -19,8 +19,10 @@ export function extractRawTokenFromSubmission(
         }
 
         // Find the entry in the descriptor_map that corresponds to this ID
-        const descriptor = submission.descriptor_map.find((d: any) => d.id === credentialId);
-        
+        const descriptor = submission.descriptor_map.find(
+            (d: any) => d.id === credentialId,
+        );
+
         if (!descriptor) {
             return null;
         }
@@ -29,7 +31,7 @@ export function extractRawTokenFromSubmission(
 
         // Logic according to the OID4VP specification:
         // If vp_token is a single string, the path is usually "$" or "$[0]"
-        if (typeof vpToken === 'string' && (path === '$' || path === '$[0]')) {
+        if (typeof vpToken === "string" && (path === "$" || path === "$[0]")) {
             return vpToken;
         }
 
@@ -46,6 +48,6 @@ export function extractRawTokenFromSubmission(
         return null;
     } catch (error) {
         // Fallback to prevent the webhook from crashing due to a parsing error
-        return null; 
+        return null;
     }
 }

--- a/apps/backend/src/shared/utils/webhook/webhook.utils.ts
+++ b/apps/backend/src/shared/utils/webhook/webhook.utils.ts
@@ -1,0 +1,51 @@
+/**
+ * Extracts the raw token (e.g., SD-JWT, mDoc) for a specific credential ID
+ * based on the OpenID4VP presentation_submission descriptor_map.
+ *
+ * @param credentialId The ID of the credential requested (e.g., 'sca_credential')
+ * @param rawPayload The raw OID4VP presentation response from the wallet
+ * @returns The raw cryptographic token as a string, or null if not found/parseable
+ */
+export function extractRawTokenFromSubmission(
+    credentialId: string, 
+    rawPayload: any
+): string | null {
+    try {
+        const submission = rawPayload?.presentation_submission;
+        const vpToken = rawPayload?.vp_token;
+
+        if (!submission?.descriptor_map || !vpToken) {
+            return null;
+        }
+
+        // Find the entry in the descriptor_map that corresponds to this ID
+        const descriptor = submission.descriptor_map.find((d: any) => d.id === credentialId);
+        
+        if (!descriptor) {
+            return null;
+        }
+
+        const path = descriptor.path; // e.g., "$", "$[0]", "$[1]"
+
+        // Logic according to the OID4VP specification:
+        // If vp_token is a single string, the path is usually "$" or "$[0]"
+        if (typeof vpToken === 'string' && (path === '$' || path === '$[0]')) {
+            return vpToken;
+        }
+
+        // If vp_token is an array (multiple presentations in a single request)
+        if (Array.isArray(vpToken)) {
+            // Parse the JSONPath (basic implementation for $[0], $[1], etc.)
+            const match = path.match(/\$\[(\d+)\]/);
+            if (match && match[1]) {
+                const index = parseInt(match[1], 10);
+                return vpToken[index] || null;
+            }
+        }
+
+        return null;
+    } catch (error) {
+        // Fallback to prevent the webhook from crashing due to a parsing error
+        return null; 
+    }
+}

--- a/apps/backend/src/verifier/oid4vp/dto/presentation-request.dto.ts
+++ b/apps/backend/src/verifier/oid4vp/dto/presentation-request.dto.ts
@@ -5,7 +5,6 @@ import {
     IsObject,
     IsOptional,
     IsString,
-    ValidateNested,
 } from "class-validator";
 import { WebhookConfig } from "../../../shared/utils/webhook/webhook.dto";
 import { TransactionData } from "../../presentations/entities/presentation-config.entity";

--- a/apps/backend/src/verifier/oid4vp/oid4vp.service.ts
+++ b/apps/backend/src/verifier/oid4vp/oid4vp.service.ts
@@ -432,7 +432,7 @@ export class Oid4vpService {
                         // Direct Pass-through of the raw presentation payload.
                         // We intentionally do not persist this in the database (Session entity)
                         // to adhere to privacy-by-design principles (data minimization).
-                        // Since webhooks currently do not support retries, keeping 
+                        // Since webhooks currently do not support retries, keeping
                         // the raw PII/tokens only in memory for this call is sufficient.
                         // ==========================================================
                         rawPresentationPayload: decrypted,

--- a/apps/backend/src/verifier/oid4vp/oid4vp.service.ts
+++ b/apps/backend/src/verifier/oid4vp/oid4vp.service.ts
@@ -428,6 +428,14 @@ export class Oid4vpService {
                         session,
                         credentials,
                         expectResponse: false,
+                        // ==========================================================
+                        // Direct Pass-through of the raw presentation payload.
+                        // We intentionally do not persist this in the database (Session entity)
+                        // to adhere to privacy-by-design principles (data minimization).
+                        // Since webhooks currently do not support retries, keeping 
+                        // the raw PII/tokens only in memory for this call is sufficient.
+                        // ==========================================================
+                        rawPresentationPayload: decrypted,
                     })
                     .catch((error) => {
                         this.sessionLogger.logFlowError(

--- a/apps/backend/test/presentation/presentation-webhook.e2e-spec.ts
+++ b/apps/backend/test/presentation/presentation-webhook.e2e-spec.ts
@@ -43,6 +43,7 @@ describe("Presentation - Webhook Integration", () => {
         requestId: string;
         credentialId: string;
         webhookUrl?: string;
+        includeRawTokensFor?: string[];
         privateKey: CryptoKey;
         issuerCert: string;
     }) {
@@ -53,6 +54,7 @@ describe("Presentation - Webhook Integration", () => {
                 webhook: {
                     url: values.webhookUrl,
                     auth: { type: AuthConfig.NONE },
+                    includeRawTokensFor: values.includeRawTokensFor,
                 },
             }),
         };
@@ -180,6 +182,41 @@ describe("Presentation - Webhook Integration", () => {
             issuerCert,
             credentialId: "pid",
             webhookUrl: "http://localhost:8787/custom",
+        });
+
+        expect(submitRes).toBeDefined();
+        expect(submitRes.response.status).toBe(200);
+        expect(nock.isDone()).toBe(true);
+    });
+
+    test("webhook with raw token pass-through", async () => {
+        // Wir erwarten, dass der Webhook-Body jetzt das Feld 'rawToken' enthält
+        nock("http://localhost:8787")
+            .post("/raw-token-test", (body) => {
+                expect(body).toBeDefined();
+                expect(body.credentials).toBeDefined();
+                expect(body.credentials[0].id).toBe("pid");
+
+                // DAS IST DER ENTSCHEIDENDE CHECK:
+                expect(body.credentials[0].rawToken).toBeDefined();
+                expect(typeof body.credentials[0].rawToken).toBe("string");
+
+                // Optional: Prüfen, ob es wie ein JWT/JWS aussieht (3 Teile mit Punkt)
+                expect(
+                    body.credentials[0].rawToken.split(".").length,
+                ).toBeGreaterThanOrEqual(2);
+
+                return true;
+            })
+            .reply(200);
+
+        const { submitRes } = await submitPresentation({
+            requestId: "pid",
+            privateKey: privateIssuerKey,
+            issuerCert,
+            credentialId: "pid",
+            webhookUrl: "http://localhost:8787/raw-token-test",
+            includeRawTokensFor: ["pid"], // Wir fordern das Token für 'pid' an
         });
 
         expect(submitRes).toBeDefined();

--- a/docs/architecture/webhooks.md
+++ b/docs/architecture/webhooks.md
@@ -117,10 +117,15 @@ The **presentation webhook** receives verified claims from the wallet after a pr
                 "headerName": "x-api-key",
                 "value": "your-api-key"
             }
-        }
+        },
+        "includeRawTokensFor": ["pid"]
     }
 }
 ```
+
+!!! info "Raw Token Pass-Through"
+
+    By default, EUDIPLO only forwards the extracted claims. If your use case requires the original cryptographic proof, you can use the optional `includeRawTokensFor` array to specify credential IDs. The raw `vp_token` will then be appended to those specific credentials.
 
 ### Webhook Request Format
 
@@ -131,6 +136,7 @@ EUDIPLO sends an HTTP `POST` request with the following structure:
     - `values`: The claims presented by the wallet.
         - SD-JWT VC–specific fields (e.g., `cnf`, `status`) are removed for simplicity.
     - `error`: Present instead of `values` if verification failed.
+    - `rawToken`: (Optional) The raw cryptographic proof (the `vp_token`), present only if explicitly requested via `includeRawTokensFor`.
 - `session`: The session ID identifying the request.
 
 ```json
@@ -147,7 +153,8 @@ EUDIPLO sends an HTTP `POST` request with the following structure:
                     "postal_code": "51147",
                     "street_address": "HEIDESTRAẞE 17"
                 }
-            }
+            },
+            "rawToken": "eyJ0eXAiOiJkYytzZC1qd3QiLCJhbGciOiJFUzI1NiJ9..."
         },
         {
             "id": "citizen",


### PR DESCRIPTION
## 📝 Description

This PR introduces the ability to selectively pass through raw cryptographic tokens (specifically the `vp_token`) to webhook subscribers. 

This addresses the requirement for specific use cases like **Payments (SCA)**, where the Verifier must forward the original cryptographic proof to a third-party backend (e.g., a payment rail) for final verification and non-repudiation.

**Key Changes:**
- Added `includeRawTokensFor` array to `WebhookConfig` (DTO).
- Implemented `extractRawTokenFromSubmission` utility to reliably extract tokens using standard OID4VP `descriptor_map` parsing (supporting Multi-Credential flows) with robust fallbacks.
- Updated `Oid4vpService` to pass the decrypted payload down to the webhook service statelessly.
- Enriched `WebhookService` to append the `rawToken` to specific credentials before HTTP transmission.
- Added comprehensive unit tests and E2E validation.

Fixes #592

## 🔄 Type of Change

- [x] 🚀 New feature (non-breaking change which adds functionality)
- [x] 📚 Documentation update
- [x] 🧪 Test improvements

## 💥 Breaking Changes (if applicable)

- None. This feature is strictly opt-in. Existing webhooks without the `includeRawTokensFor` configuration will experience no changes in their payload.

## 🧪 Testing

Describe the tests that you ran to verify your changes:

- [x] Unit tests pass
- [x] Integration tests pass
- [x] E2E tests pass
- [ ] Manual testing performed

**Test Configuration**:

- Node.js version: v25.8.1
- OS: macOS 26.3.1
- Test environment: Vitest (Unit & E2E)

## ✔️ Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## 📋 Additional Notes

As discussed in the original issue, exposing the full signed VP poses a potential threat. Therefore, this implementation:
1. Demands explicit opt-in per credential ID via the webhook config (`includeRawTokensFor`).
2. Does **not** save the raw token to the `Session` entity in the DB. It is only held in memory during the webhook lifecycle.
