### PR TITLE
fix: restrict client endpoints to clients:manage role only

### DIFF
--- a/apps/backend/src/auth/client/client.controller.ts
+++ b/apps/backend/src/auth/client/client.controller.ts
@@ -24,7 +24,6 @@ import { UpdateClientDto } from "./dto/update-client.dto";
  * Controller to manage clients.
  */
 @ApiTags("Client")
-@Secured([Role.Clients, Role.Tenants])
 @Controller("client")
 export class ClientController {
     constructor(
@@ -36,6 +35,7 @@ export class ClientController {
      * @param user
      * @returns
      */
+    @Secured([Role.Clients])
     @Get()
     getClients(@Token() user: TokenPayload) {
         return this.clients.getClients(user.entity!.id);
@@ -47,6 +47,7 @@ export class ClientController {
      * @param user
      * @returns
      */
+    @Secured([Role.Clients])
     @Get(":id")
     getClient(@Param("id") id: string, @Token() user: TokenPayload) {
         return this.clients.getClient(user.entity!.id, id);
@@ -59,6 +60,7 @@ export class ClientController {
      * @param user
      * @returns
      */
+    @Secured([Role.Clients])
     @Get(":id/secret")
     getClientSecret(
         @Param("id") id: string,
@@ -81,6 +83,7 @@ export class ClientController {
      * @param user
      * @returns The new client secret (displayed only once)
      */
+    @Secured([Role.Clients, Role.Tenants])
     @Post(":id/rotate-secret")
     async rotateClientSecret(
         @Param("id") id: string,
@@ -102,6 +105,7 @@ export class ClientController {
      * @param user
      * @returns
      */
+    @Secured([Role.Clients])
     @Patch(":id")
     updateClient(
         @Param("id") id: string,
@@ -126,6 +130,7 @@ export class ClientController {
      * @param user
      * @returns
      */
+    @Secured([Role.Clients])
     @Post()
     createClient(
         @Body() createClientDto: CreateClientDto,
@@ -149,6 +154,7 @@ export class ClientController {
      * @param user
      * @returns
      */
+    @Secured([Role.Clients])
     @Delete(":id")
     deleteClient(@Param("id") id: string, @Token() user: TokenPayload) {
         return this.clients.removeClient(user.entity!.id, id);


### PR DESCRIPTION
## Summary

Fixes #591

The root tenant-manager client (bootstrapped via `AUTH_CLIENT_ID` / `AUTH_CLIENT_SECRET`) has no tenant association, so `user.entity` is `undefined`. The class-level `@Secured([Role.Clients, Role.Tenants])` allowed this client to reach endpoints that dereference `user.entity!.id`, causing a 500 error.

## Changes

Replaced the class-level `@Secured` with per-endpoint guards:

- **All CRUD endpoints** (`GET /client`, `GET /client/:id`, `POST /client`, `PATCH /client/:id`, `DELETE /client/:id`, `GET /client/:id/secret`) → `@Secured([Role.Clients])` only
- **`POST /client/:id/rotate-secret`** → `@Secured([Role.Clients, Role.Tenants])` so tenant managers can still rotate secrets for recovery

This is safe because the `RolesGuard` already supports per-handler overrides via `getAllAndOverride`, and this pattern is used in other controllers (e.g., `PresentationsController`).

## Breaking Changes

None — the root client was never able to use these endpoints successfully (it always crashed with a 500). Clients with `clients:manage` role are unaffected.