### PR TITLE
fix: allow attestation key chains as fallback for status list signing

### DIFF
--- a/apps/backend/src/crypto/key/cert/cert.service.ts
+++ b/apps/backend/src/crypto/key/cert/cert.service.ts
@@ -22,6 +22,11 @@ export interface FindCertOptions {
      */
     keyId?: string;
     /**
+     * Optional fallback usage type. If no key chain is found for the
+     * primary `type`, a second lookup using this type is attempted.
+     */
+    fallbackType?: KeyUsageType;
+    /**
      * Skip certificate validation (expiry and CRL check).
      * Default: false
      */
@@ -83,7 +88,7 @@ export class CertService {
      * Returns the certificate from the matching key chain.
      */
     async find(options: FindCertOptions): Promise<CertificateInfo> {
-        const { tenantId, type, skipValidation } = options;
+        const { tenantId, type, skipValidation, fallbackType } = options;
         // Support both certId (deprecated) and keyId
         const keyId = options.keyId || options.certId;
 
@@ -91,6 +96,7 @@ export class CertService {
             tenantId,
             type,
             keyId,
+            fallbackType,
         );
 
         // Parse the certificate PEM to extract chain

--- a/apps/backend/src/crypto/key/key-chain.service.ts
+++ b/apps/backend/src/crypto/key/key-chain.service.ts
@@ -578,11 +578,16 @@ export class KeyChainService {
 
     /**
      * Find a key chain by usage type.
+     * If a fallbackUsageType is provided and no key chain is found for
+     * the primary type, a second lookup is performed with the fallback.
+     * This enables attestation keys to also sign status lists when no
+     * dedicated status-list key chain has been configured.
      */
     async findByUsageType(
         tenantId: string,
         usageType: KeyUsageType,
         keyId?: string,
+        fallbackUsageType?: KeyUsageType,
     ): Promise<KeyChainEntity> {
         const whereClause: Record<string, unknown> = {
             tenantId,
@@ -593,13 +598,29 @@ export class KeyChainService {
             whereClause.id = keyId;
         }
 
-        const keyChain = await this.keyChainRepository.findOne({
+        let keyChain = await this.keyChainRepository.findOne({
             where: whereClause,
         });
 
+        if (!keyChain && fallbackUsageType) {
+            const fallbackWhere: Record<string, unknown> = {
+                tenantId,
+                usageType: fallbackUsageType,
+            };
+            if (keyId) {
+                fallbackWhere.id = keyId;
+            }
+            keyChain = await this.keyChainRepository.findOne({
+                where: fallbackWhere,
+            });
+        }
+
         if (!keyChain) {
+            const types = fallbackUsageType
+                ? `'${usageType}' or '${fallbackUsageType}'`
+                : `'${usageType}'`;
             throw new NotFoundException(
-                `No key chain found with usage type '${usageType}' for tenant ${tenantId}`,
+                `No key chain found with usage type ${types} for tenant ${tenantId}`,
             );
         }
 

--- a/apps/backend/src/issuer/lifecycle/status/status-list.service.ts
+++ b/apps/backend/src/issuer/lifecycle/status/status-list.service.ts
@@ -144,6 +144,7 @@ export class StatusListService {
             const cert = await this.certService.find({
                 tenantId,
                 type: KeyUsageType.StatusList,
+                fallbackType: KeyUsageType.Attestation,
                 keyId: options.keyChainId,
             });
             if (!cert) {
@@ -199,16 +200,19 @@ export class StatusListService {
             ttl, // Maximum cache time in seconds for verifiers
         };
 
-        // Use the pinned key chain if specified, otherwise use the tenant's default status list key chain
+        // Use the pinned key chain if specified, otherwise use the tenant's default status list key chain.
+        // Falls back to attestation key chains when no dedicated status list key exists.
         const cert = entry.keyChainId
             ? await this.certService.find({
                   tenantId: entry.tenantId,
                   type: KeyUsageType.StatusList,
+                  fallbackType: KeyUsageType.Attestation,
                   keyId: entry.keyChainId,
               })
             : await this.certService.find({
                   tenantId: entry.tenantId,
                   type: KeyUsageType.StatusList,
+                  fallbackType: KeyUsageType.Attestation,
               });
 
         if (!cert) {
@@ -541,6 +545,7 @@ export class StatusListService {
             const cert = await this.certService.find({
                 tenantId,
                 type: KeyUsageType.StatusList,
+                fallbackType: KeyUsageType.Attestation,
                 keyId: updates.keyChainId,
             });
             if (!cert) {
@@ -640,6 +645,7 @@ export class StatusListService {
             const cert = await this.certService.find({
                 tenantId,
                 type: KeyUsageType.StatusList,
+                fallbackType: KeyUsageType.Attestation,
                 keyId: config.keyChainId,
             });
             if (!cert) {

--- a/apps/client/src/app/status-list-management/status-list-edit/status-list-edit.component.html
+++ b/apps/client/src/app/status-list-management/status-list-edit/status-list-edit.component.html
@@ -172,7 +172,9 @@
               <mat-select formControlName="keyChainId">
                 <mat-option [value]="null">Default (auto-managed)</mat-option>
                 @for (keyChain of keyChains; track keyChain.id) {
-                  <mat-option [value]="keyChain.id">{{ keyChain.id }} ({{ keyChain.usageType }})</mat-option>
+                  <mat-option [value]="keyChain.id"
+                    >{{ keyChain.id }} ({{ keyChain.usageType }})</mat-option
+                  >
                 }
               </mat-select>
               <mat-icon matSuffix>key</mat-icon>
@@ -183,8 +185,9 @@
               <div class="info-box">
                 <mat-icon>info</mat-icon>
                 <span>
-                  No key chains with <strong>statusList</strong> or <strong>attestation</strong> usage found.
-                  The tenant's default key chain will be used for signing.
+                  No key chains with <strong>statusList</strong> or
+                  <strong>attestation</strong> usage found. The tenant's default key chain will be
+                  used for signing.
                 </span>
               </div>
             }

--- a/apps/client/src/app/status-list-management/status-list-edit/status-list-edit.component.html
+++ b/apps/client/src/app/status-list-management/status-list-edit/status-list-edit.component.html
@@ -172,7 +172,7 @@
               <mat-select formControlName="keyChainId">
                 <mat-option [value]="null">Default (auto-managed)</mat-option>
                 @for (keyChain of keyChains; track keyChain.id) {
-                  <mat-option [value]="keyChain.id">{{ keyChain.id }}</mat-option>
+                  <mat-option [value]="keyChain.id">{{ keyChain.id }} ({{ keyChain.usageType }})</mat-option>
                 }
               </mat-select>
               <mat-icon matSuffix>key</mat-icon>
@@ -183,8 +183,8 @@
               <div class="info-box">
                 <mat-icon>info</mat-icon>
                 <span>
-                  No key chains with <strong>statusList</strong> usage found. The tenant's default
-                  key chain will be used for signing.
+                  No key chains with <strong>statusList</strong> or <strong>attestation</strong> usage found.
+                  The tenant's default key chain will be used for signing.
                 </span>
               </div>
             }

--- a/apps/client/src/app/status-list-management/status-list-edit/status-list-edit.component.ts
+++ b/apps/client/src/app/status-list-management/status-list-edit/status-list-edit.component.ts
@@ -57,7 +57,7 @@ export class StatusListEditComponent implements OnInit {
   /** Available credential configs for binding */
   credentialConfigs: CredentialConfig[] = [];
 
-  /** Available key chains with statusList usage */
+  /** Available key chains with statusList or attestation usage */
   keyChains: KeyChainResponseDto[] = [];
 
   /** Available bits per status options */
@@ -102,7 +102,8 @@ export class StatusListEditComponent implements OnInit {
 
       this.credentialConfigs = configsResponse.data || [];
       this.keyChains = (keyChainResponse.data || []).filter(
-        (kc: KeyChainResponseDto) => kc.usageType === 'statusList'
+        (kc: KeyChainResponseDto) =>
+          kc.usageType === 'statusList' || kc.usageType === 'attestation'
       );
 
       if (this.listId) {

--- a/apps/client/src/app/status-list-management/status-list-edit/status-list-edit.component.ts
+++ b/apps/client/src/app/status-list-management/status-list-edit/status-list-edit.component.ts
@@ -102,8 +102,7 @@ export class StatusListEditComponent implements OnInit {
 
       this.credentialConfigs = configsResponse.data || [];
       this.keyChains = (keyChainResponse.data || []).filter(
-        (kc: KeyChainResponseDto) =>
-          kc.usageType === 'statusList' || kc.usageType === 'attestation'
+        (kc: KeyChainResponseDto) => kc.usageType === 'statusList' || kc.usageType === 'attestation'
       );
 
       if (this.listId) {

--- a/docs/architecture/key-management.md
+++ b/docs/architecture/key-management.md
@@ -330,6 +330,13 @@ Each key chain is assigned a usage type that determines how it can be used:
 | `statusList`  | Status list (credential revocation) signing        |
 | `encrypt`     | Encryption (JWE)                                   |
 
+!!! note "Attestation fallback for status lists"
+
+    If no `statusList` key chain is configured, the `attestation` key chain is
+    used as a fallback for signing status list JWTs. This keeps status lists
+    under the same trust anchor as the issued credentials. Create a dedicated
+    `statusList` key chain only when a different signing key is required.
+
 ### Key Chain Types
 
 **Standalone Key Chain**:

--- a/docs/architecture/status-management.md
+++ b/docs/architecture/status-management.md
@@ -212,6 +212,23 @@ certificate. You can pin a specific certificate to a status list for:
 - Compliance with specific signing requirements
 - Isolation of signing keys per use case
 
+### Signing Key Resolution
+
+When signing a status list JWT, EUDIPLO looks for a key chain with usage type
+`statusList`. If no dedicated status list key chain exists for the tenant, it
+automatically falls back to the `attestation` key chain. This ensures that
+status lists share the same trust anchor as the issued credentials, which is
+required by wallets that validate the authority of the revocation provider
+against the credential issuer (e.g., Paradym/Credo).
+
+!!! tip "Shared Trust Chain"
+
+    If your deployment policy does **not** require the status list to be signed
+    under the same trust anchor as the credentials, you can create a separate
+    `statusList` key chain (e.g., Standalone / self-signed). This is useful when
+    the security level required for status list protection differs from that of
+    credential signatures.
+
 ## API Operations
 
 The Status Management API provides endpoints for managing status lists and


### PR DESCRIPTION
# Fix: Status List JWT Verification Fails for Tenant-Based SD-JWT Credentials

Fixes #593

## Problem

In a multi-tenant environment, the status list JWT is signed with a dedicated `statusList` key chain. However, after the v4.x key chain split, a tenant that only has an `attestation` key chain (used for credential signing) cannot create or sign status lists — the service throws:

```
No key chain found with usage type 'statusList' for tenant tenant-01
```

This forces tenants to either create a separate `statusList` key chain (which is standalone/self-signed) or import the same private key under a second key chain. The resulting signature mismatch causes wallets like Paradym/Credo to reject the Status List JWT with `Invalid JWT Signature`, since the status list signing key doesn't share the same trust anchor as the credential's issuer.

## Solution

Added a **fallback mechanism** to `KeyChainService.findByUsageType()`: when looking up a key chain by usage type and no match is found, an optional `fallbackUsageType` is attempted before throwing.

All status list signing paths now pass `KeyUsageType.Attestation` as the fallback for `KeyUsageType.StatusList`. This means:

- **Dedicated `statusList` key chains still take priority** when they exist
- **If no `statusList` key chain is configured**, the `attestation` key chain is used instead, ensuring the status list JWT shares the same trust anchor as the issued credentials
- **No breaking changes** — existing setups with dedicated `statusList` keys are unaffected

### Files Changed

| File | Change |
|------|--------|
| `key-chain.service.ts` | Added optional `fallbackUsageType` param to `findByUsageType()` |
| `cert.service.ts` | Added `fallbackType` to `FindCertOptions`, threaded through to `findByUsageType()` |
| `status-list.service.ts` | All 5 cert lookup calls now include `fallbackType: KeyUsageType.Attestation` |
| `status-management.md` | Documented signing key resolution and shared trust chain behavior |
| `key-management.md` | Added note about attestation fallback for status list usage type |

## Testing

- Tenant with only `attestation` key chain: status list signing now succeeds using the attestation key
- Tenant with dedicated `statusList` key chain: uses the dedicated key (no behavior change)
- Tenant with both: `statusList` key is preferred, attestation is only used as fallback"