### PR TITLE
chore(deps): simplify dependabot groups to reduce PR volume

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,52 +21,13 @@ updates:
       - dependency-name: "@eudiplo/*"
 
     groups:
-      angular-minor-patch:
-        patterns: ["@angular/*", "rxjs", "zone.js"]
+      # All minor/patch updates bundled together
+      all-minor-patch:
         update-types: ["minor", "patch"]
 
-      nestjs-minor-patch:
-        patterns: ["@nestjs/*", "reflect-metadata", "class-transformer", "class-validator"]
-        update-types: ["minor", "patch"]
-
-      lint-and-format:
-        patterns: ["eslint*", "@eslint/*", "typescript-eslint*", "prettier", "@trivago/prettier-plugin-sort-imports"]
-        dependency-type: "development"
-        update-types: ["minor", "patch"]
-
-      test-stack:
-        patterns: ["jest*", "ts-jest", "@types/jest", "vitest", "@vitest/*", "testing-library*", "cypress*"]
-        dependency-type: "development"
-        update-types: ["minor", "patch"]
-
-      types-packages:
-        patterns: ["@types/*"]
-        dependency-type: "development"
-        update-types: ["minor", "patch"]
-
-      # Keep majors separate for easier review
-      angular-majors:
-        patterns: ["@angular/*", "rxjs", "zone.js"]
+      # All major updates bundled together
+      all-majors:
         update-types: ["major"]
-
-      nestjs-majors:
-        patterns: ["@nestjs/*", "reflect-metadata", "class-transformer", "class-validator"]
-        update-types: ["major"]
-
-      tooling-majors:
-        patterns: ["eslint*", "@eslint/*", "typescript-eslint*", "prettier", "jest*", "vitest", "cypress*"]
-        update-types: ["major"]
-
-      openid4vc-all:
-        patterns: ["@openid4vc/*"]
-
-      sd-jwt:
-        patterns: ["@sd-jwt/*"]
-        update-types: ["major", "minor", "patch"]
-
-      aws-sdk:
-        patterns: ["@aws-sdk/*"]
-        update-types: ["major", "minor", "patch"]
 
   # --- GitHub Actions versions in .github/workflows ---
   - package-ecosystem: github-actions


### PR DESCRIPTION
## Summary
Replaces 12 framework-specific dependency groups with 2 catch-all groups:
- **all-minor-patch**: bundles all minor/patch updates
- **all-majors**: bundles all major updates

## Motivation
Reduces weekly npm dependency PRs from ~10 to at most 2, lowering maintainer overhead while still keeping majors separate for review.