### PR TITLE
feat: add Grafana deep links and improve session observability

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,5 +63,12 @@ AUTH_CLIENT_SECRET=your-secure-secret
 # Set to true to completely disable the OpenTelemetry SDK (e.g., local dev without collector)
 #OTEL_SDK_DISABLED=true
 
+# Grafana Deep Links (optional)
+# Set GRAFANA_URL to enable deep links from the dashboard to Grafana for logs and traces.
+# The datasource UIDs default to "tempo" and "loki" (matching the provisioned datasources).
+#GRAFANA_URL=http://localhost:3001
+#GRAFANA_DATASOURCE_TEMPO_UID=tempo
+#GRAFANA_DATASOURCE_LOKI_UID=loki
+
 # If set, HTML base href will be configured to this value (e.g., for reverse proxy setups).
 # CLIENT_BASE_HREF=/your-base-path/

--- a/apps/backend/src/core/app/app.controller.ts
+++ b/apps/backend/src/core/app/app.controller.ts
@@ -5,7 +5,9 @@ import {
     ApiSecurity,
     ApiTags,
 } from "@nestjs/swagger";
+import { ConfigService } from "@nestjs/config";
 import { JwtAuthGuard } from "../../auth/auth.guard";
+import { FrontendConfigResponseDto } from "./dto/frontend-config-response.dto";
 
 /**
  * Main application controller
@@ -13,6 +15,8 @@ import { JwtAuthGuard } from "../../auth/auth.guard";
 @ApiTags("App")
 @Controller()
 export class AppController {
+    constructor(private readonly configService: ConfigService) {}
+
     /**
      * Main endpoint providing service info
      */
@@ -36,6 +40,35 @@ export class AppController {
     getVersion() {
         return {
             version: process.env.VERSION ?? "main",
+        };
+    }
+
+    /**
+     * Returns runtime configuration for the frontend client.
+     */
+    @Get("frontend-config")
+    @UseGuards(JwtAuthGuard)
+    @ApiSecurity("oauth2")
+    @ApiOperation({ summary: "Get frontend runtime configuration" })
+    @ApiResponse({
+        status: 200,
+        description: "Frontend configuration",
+        type: FrontendConfigResponseDto,
+    })
+    getFrontendConfig(): FrontendConfigResponseDto {
+        const grafanaUrl = this.configService.get<string>("GRAFANA_URL");
+        return {
+            grafana: {
+                url: grafanaUrl || undefined,
+                tempoUid: this.configService.get<string>(
+                    "GRAFANA_DATASOURCE_TEMPO_UID",
+                    "tempo",
+                ),
+                lokiUid: this.configService.get<string>(
+                    "GRAFANA_DATASOURCE_LOKI_UID",
+                    "loki",
+                ),
+            },
         };
     }
 }

--- a/apps/backend/src/core/app/dto/frontend-config-response.dto.ts
+++ b/apps/backend/src/core/app/dto/frontend-config-response.dto.ts
@@ -1,0 +1,26 @@
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
+
+class GrafanaConfigDto {
+    @ApiPropertyOptional({
+        description: "Base URL of the Grafana instance",
+        example: "http://localhost:3001",
+    })
+    url?: string;
+
+    @ApiProperty({
+        description: "UID of the Tempo data source in Grafana",
+        example: "tempo",
+    })
+    tempoUid!: string;
+
+    @ApiProperty({
+        description: "UID of the Loki data source in Grafana",
+        example: "loki",
+    })
+    lokiUid!: string;
+}
+
+export class FrontendConfigResponseDto {
+    @ApiProperty({ description: "Grafana observability configuration" })
+    grafana!: GrafanaConfigDto;
+}

--- a/apps/backend/src/issuer/issuance/oid4vci/oid4vci.service.ts
+++ b/apps/backend/src/issuer/issuance/oid4vci/oid4vci.service.ts
@@ -40,10 +40,8 @@ import {
     SessionStatus,
 } from "../../../session/entities/session.entity";
 import { SessionService } from "../../../session/session.service";
-import {
-    AuditLogContext,
-    AuditLogService,
-} from "../../../shared/utils/logger/audit-log.service";
+import { AuditLogContext } from "../../../shared/utils/logger/audit-log.service";
+import { SessionLoggerService } from "../../../shared/utils/logger/session-logger.service";
 import { WebhookService } from "../../../shared/utils/webhook/webhook.service";
 import { CredentialsService } from "../../configuration/credentials/credentials.service";
 import { AuthorizationIdentity } from "../../configuration/credentials/dto/authorization-identity";
@@ -96,7 +94,7 @@ export class Oid4vciService {
         public readonly credentialsService: CredentialsService,
         private readonly configService: ConfigService,
         private readonly sessionService: SessionService,
-        private readonly auditLogger: AuditLogService,
+        private readonly auditLogger: SessionLoggerService,
         private readonly issuanceService: IssuanceService,
         private readonly webhookService: WebhookService,
         private readonly httpService: HttpService,

--- a/apps/backend/src/shared/utils/config-printer/validation.schema.ts
+++ b/apps/backend/src/shared/utils/config-printer/validation.schema.ts
@@ -9,4 +9,20 @@ export const BASE_VALIDATION_SCHEMA = Joi.object({
         .default("../../tmp")
         .description("Root working folder for temp files")
         .meta({ group: "general", order: 10 }),
+    GRAFANA_URL: Joi.string()
+        .uri({ scheme: ["http", "https"] })
+        .optional()
+        .allow("")
+        .description(
+            "Base URL of the Grafana instance for deep linking from the dashboard UI",
+        )
+        .meta({ group: "observability", order: 10 }),
+    GRAFANA_DATASOURCE_TEMPO_UID: Joi.string()
+        .default("tempo")
+        .description("UID of the Tempo data source in Grafana")
+        .meta({ group: "observability", order: 20 }),
+    GRAFANA_DATASOURCE_LOKI_UID: Joi.string()
+        .default("loki")
+        .description("UID of the Loki data source in Grafana")
+        .meta({ group: "observability", order: 30 }),
 }).unknown(true);

--- a/apps/backend/src/shared/utils/logger/audit-log.module.ts
+++ b/apps/backend/src/shared/utils/logger/audit-log.module.ts
@@ -3,20 +3,19 @@ import { TypeOrmModule } from "@nestjs/typeorm";
 import { SessionLogEntry } from "../../../session/entities/session-log-entry.entity";
 import { AuditLogService } from "./audit-log.service";
 import { SessionLogStoreService } from "./session-log-store.service";
+import { SessionLoggerService } from "./session-logger.service";
 
 /**
- * Module for audit logging to the database.
+ * Module for audit logging.
  *
- * This module provides services for persisting audit events (flow_start, flow_complete,
- * flow_error, credential_issuance, credential_verification) to PostgreSQL for compliance
- * and audit trail purposes.
- *
- * For observability/debug logging, use `PinoLogger` directly — logs are exported to Loki
- * via the OpenTelemetry transport.
+ * Provides two services:
+ * - `AuditLogService`: persists audit events to the database only.
+ * - `SessionLoggerService`: persists to the database AND logs via PinoLogger
+ *   (exported to Loki via OpenTelemetry) for full observability.
  */
 @Module({
     imports: [TypeOrmModule.forFeature([SessionLogEntry])],
-    providers: [SessionLogStoreService, AuditLogService],
-    exports: [AuditLogService, SessionLogStoreService],
+    providers: [SessionLogStoreService, AuditLogService, SessionLoggerService],
+    exports: [AuditLogService, SessionLoggerService, SessionLogStoreService],
 })
 export class AuditLogModule {}

--- a/apps/backend/src/verifier/oid4vp/oid4vp.service.ts
+++ b/apps/backend/src/verifier/oid4vp/oid4vp.service.ts
@@ -14,10 +14,8 @@ import { KeyChainService } from "../../crypto/key/key-chain.service";
 import { OfferResponse } from "../../issuer/issuance/oid4vci/dto/offer-request.dto";
 import { SessionStatus } from "../../session/entities/session.entity";
 import { SessionService } from "../../session/session.service";
-import {
-    AuditLogContext,
-    AuditLogService,
-} from "../../shared/utils/logger/audit-log.service";
+import { AuditLogContext } from "../../shared/utils/logger/audit-log.service";
+import { SessionLoggerService } from "../../shared/utils/logger/session-logger.service";
 import { WebhookService } from "../../shared/utils/webhook/webhook.service";
 import { AuthResponse } from "../presentations/dto/auth-response.dto";
 import { IncompletePresentationException } from "../presentations/exceptions/incomplete-presentation.exception";
@@ -34,7 +32,7 @@ export class Oid4vpService {
         private readonly configService: ConfigService,
         private readonly presentationsService: PresentationsService,
         private readonly sessionService: SessionService,
-        private readonly auditLogger: AuditLogService,
+        private readonly auditLogger: SessionLoggerService,
         private readonly webhookService: WebhookService,
         private readonly cryptoImplementationService: CryptoImplementationService,
         private readonly traceService: TraceService,

--- a/apps/backend/src/verifier/presentations/credential/credential-chain-validation.service.ts
+++ b/apps/backend/src/verifier/presentations/credential/credential-chain-validation.service.ts
@@ -1,5 +1,6 @@
-import { Injectable, Logger } from "@nestjs/common";
+import { Injectable } from "@nestjs/common";
 import * as x509 from "@peculiar/x509";
+import { PinoLogger } from "nestjs-pino";
 import { StatusListVerifierService } from "../../../shared/trust/status-list-verifier.service";
 import {
     BuiltTrustStore,
@@ -61,13 +62,14 @@ export interface CertificateChainInfo {
  */
 @Injectable()
 export class CredentialChainValidationService {
-    private readonly logger = new Logger(CredentialChainValidationService.name);
-
     constructor(
         private readonly trustStore: TrustStoreService,
         private readonly x509v: X509ValidationService,
         private readonly statusListVerifier: StatusListVerifierService,
-    ) {}
+        private readonly logger: PinoLogger,
+    ) {
+        this.logger.setContext(CredentialChainValidationService.name);
+    }
 
     /**
      * Validate a certificate chain against the trust store.

--- a/apps/backend/src/verifier/presentations/credential/mdocverifier/mdocverifier.service.ts
+++ b/apps/backend/src/verifier/presentations/credential/mdocverifier/mdocverifier.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from "@nestjs/common";
+import { Injectable } from "@nestjs/common";
 import {
     base64,
     DeviceRequest,
@@ -11,6 +11,7 @@ import {
 } from "@owf/mdoc";
 import * as x509 from "@peculiar/x509";
 import { Span } from "nestjs-otel";
+import { PinoLogger } from "nestjs-pino";
 import { VerifierOptions } from "../../../../shared/trust/types";
 import { mdocContext } from "../../mdoc-context";
 import {
@@ -46,11 +47,12 @@ interface MdocErrorDetails {
 
 @Injectable()
 export class MdocverifierService {
-    private readonly logger = new Logger(MdocverifierService.name);
-
     constructor(
         private readonly chainValidation: CredentialChainValidationService,
-    ) {}
+        private readonly logger: PinoLogger,
+    ) {
+        this.logger.setContext(MdocverifierService.name);
+    }
 
     /**
      * Verifies an mDOC credential.

--- a/apps/backend/src/verifier/presentations/credential/sdjwtvcverifier/sdjwtvcverifier.service.ts
+++ b/apps/backend/src/verifier/presentations/credential/sdjwtvcverifier/sdjwtvcverifier.service.ts
@@ -1,10 +1,11 @@
 import { createHash } from "node:crypto";
-import { BadRequestException, Injectable, Logger } from "@nestjs/common";
+import { BadRequestException, Injectable } from "@nestjs/common";
 import { digest } from "@sd-jwt/crypto-nodejs";
 import { SDJwtVcInstance, VerificationResult } from "@sd-jwt/sd-jwt-vc";
 import { KbVerifier } from "@sd-jwt/types";
 import { base64url, JWK } from "jose";
 import { Span } from "nestjs-otel";
+import { PinoLogger } from "nestjs-pino";
 import { CryptoImplementationService } from "../../../../crypto/key/crypto-implementation/crypto-implementation.service";
 import { VerifierOptions } from "../../../../shared/trust/types";
 import { MatchedTrustedEntity } from "../../../../shared/trust/x509-validation.service";
@@ -13,13 +14,14 @@ import { CredentialChainValidationService } from "../credential-chain-validation
 
 @Injectable()
 export class SdjwtvcverifierService {
-    private readonly logger = new Logger(SdjwtvcverifierService.name);
-
     constructor(
         private readonly resolverService: ResolverService,
         private readonly cryptoService: CryptoImplementationService,
         private readonly chainValidation: CredentialChainValidationService,
-    ) {}
+        private readonly logger: PinoLogger,
+    ) {
+        this.logger.setContext(SdjwtvcverifierService.name);
+    }
 
     /**
      * Verifies an SD-JWT-VC credential.

--- a/apps/backend/src/verifier/presentations/presentations.service.ts
+++ b/apps/backend/src/verifier/presentations/presentations.service.ts
@@ -1,10 +1,15 @@
 import { readFileSync } from "node:fs";
-import { ConflictException, Injectable } from "@nestjs/common";
+import {
+    BadRequestException,
+    ConflictException,
+    Injectable,
+} from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { InjectRepository } from "@nestjs/typeorm";
 import { plainToClass } from "class-transformer";
 import { base64url, decodeJwt } from "jose";
-import { Span } from "nestjs-otel";
+import { Span, TraceService } from "nestjs-otel";
+import { PinoLogger } from "nestjs-pino";
 import { Repository } from "typeorm";
 import { ServiceTypeIdentifier } from "../../issuer/trust-list/trustlist.service";
 import { Session } from "../../session/entities/session.entity";
@@ -49,7 +54,10 @@ export class PresentationsService {
         private readonly sdjwtvcverifierService: SdjwtvcverifierService,
         private readonly mdocverifierService: MdocverifierService,
         private readonly configService: ConfigService,
+        private readonly logger: PinoLogger,
+        private readonly traceService: TraceService,
     ) {
+        this.logger.setContext(PresentationsService.name);
         // Register presentation config import in REFERENCES phase
         // This runs after CORE (keys, certs) and CONFIGURATION phases
         this.configImportOrchestrator.register(
@@ -211,6 +219,21 @@ export class PresentationsService {
         presentationConfig: PresentationConfig,
         session: Session,
     ) {
+        // Add session context to logs (Loki) and span attributes (Tempo)
+        // assign() requires nestjs-pino request scope; the @Span decorator may
+        // run the method in a separate AsyncLocalStorage context, so guard it.
+        try {
+            this.logger.assign({ sessionId: session.id });
+        } catch {
+            // Outside HTTP request scope — sessionId won't appear in logs,
+            // but span attributes below still carry it for Tempo.
+        }
+        this.traceService.getSpan()?.setAttributes({
+            "session.id": session.id,
+            "session.tenantId": session.tenantId,
+            "session.requestId": session.requestId ?? "",
+        });
+
         const attestationIds = Object.keys(res.vp_token);
         const host = this.configService.getOrThrow<string>("PUBLIC_URL");
         const tenantHost = `${host}/${presentationConfig.tenantId}`;
@@ -314,6 +337,12 @@ export class PresentationsService {
                                     },
                                     verifyOptions,
                                 );
+
+                            if (!result.verified) {
+                                throw new BadRequestException(
+                                    `mDOC verification failed for credential "${attId}"`,
+                                );
+                            }
 
                             // Validate all required claims are present in mDOC
                             this.validateMdocClaims(
@@ -480,6 +509,7 @@ export class PresentationsService {
             const claimName =
                 claim.path.length > 1 ? claim.path[1] : claim.path[0];
 
+            console.log(receivedClaims);
             // Check if claim exists in received claims
             if (!(claimName in receivedClaims)) {
                 // Format as namespace.claimName for better error message

--- a/apps/client/src/app/dashboard/dashboard.component.html
+++ b/apps/client/src/app/dashboard/dashboard.component.html
@@ -317,6 +317,11 @@
         <a mat-button color="primary" routerLink="/session-management">
           <mat-icon>visibility</mat-icon> View All Sessions
         </a>
+        @if (grafanaEnabled) {
+          <button mat-button (click)="openGrafana()">
+            <mat-icon>monitoring</mat-icon> Open Grafana
+          </button>
+        }
       </mat-card-actions>
     </mat-card>
   }
@@ -430,6 +435,11 @@
         <a mat-stroked-button href="https://discord.gg/58ys8XfXDu" target="_blank" rel="noopener">
           <mat-icon>forum</mat-icon> Discord Community
         </a>
+        @if (grafanaEnabled) {
+          <button mat-stroked-button (click)="openGrafana()">
+            <mat-icon>monitoring</mat-icon> Grafana Dashboard
+          </button>
+        }
       </div>
     </mat-card-content>
   </mat-card>

--- a/apps/client/src/app/dashboard/dashboard.component.ts
+++ b/apps/client/src/app/dashboard/dashboard.component.ts
@@ -16,6 +16,7 @@ import { Router, RouterModule } from '@angular/router';
 import { FlexLayoutModule } from 'ngx-flexible-layout';
 import { EnvironmentService } from '../services/environment.service';
 import { JwtService } from '../services/jwt.service';
+import { GrafanaLinkService } from '../services/grafana-link.service';
 import { appControllerGetVersion } from '@eudiplo/sdk-core';
 import { ApiService } from '../core';
 import { MatGridListModule } from '@angular/material/grid-list';
@@ -49,11 +50,13 @@ export class DashboardComponent implements OnInit, OnDestroy {
   private tokenCheckInterval?: NodeJS.Timeout;
   backendVersion: string | null = null;
   clientVersion: string | null = null;
+  grafanaEnabled = false;
 
   constructor(
     public apiService: ApiService,
     public environmentService: EnvironmentService,
     public dashboardService: DashboardService,
+    public grafanaLinkService: GrafanaLinkService,
     public jwtService: JwtService,
     private readonly router: Router,
     private readonly snackBar: MatSnackBar
@@ -74,6 +77,11 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
     // Fetch dashboard stats
     this.dashboardService.getCounters();
+
+    // Load Grafana config
+    this.grafanaLinkService.getConfig().then(() => {
+      this.grafanaEnabled = this.grafanaLinkService.isEnabled();
+    });
   }
 
   ngOnDestroy(): void {
@@ -179,6 +187,13 @@ export class DashboardComponent implements OnInit, OnDestroy {
         duration: 3000,
         panelClass: ['error-snackbar'],
       });
+    }
+  }
+
+  openGrafana(): void {
+    const url = this.grafanaLinkService.getBaseUrl();
+    if (url) {
+      window.open(url, '_blank', 'noopener,noreferrer');
     }
   }
 }

--- a/apps/client/src/app/services/grafana-link.service.ts
+++ b/apps/client/src/app/services/grafana-link.service.ts
@@ -1,0 +1,138 @@
+import { Injectable } from '@angular/core';
+import { client } from '@eudiplo/sdk-core';
+
+export interface GrafanaConfig {
+  url?: string;
+  tempoUid: string;
+  lokiUid: string;
+}
+
+interface FrontendConfig {
+  grafana: GrafanaConfig;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class GrafanaLinkService {
+  private config: GrafanaConfig | null = null;
+  private configPromise: Promise<GrafanaConfig | null> | null = null;
+
+  /**
+   * Fetches and caches the Grafana configuration from the backend.
+   */
+  async getConfig(): Promise<GrafanaConfig | null> {
+    if (this.config !== null) {
+      return this.config;
+    }
+    if (this.configPromise) {
+      return this.configPromise;
+    }
+
+    this.configPromise = client
+      .get<FrontendConfig>({
+        security: [{ scheme: 'bearer', type: 'http' }],
+        url: '/api/frontend-config',
+      })
+      .then((response) => {
+        this.config = (response.data as FrontendConfig)?.grafana ?? null;
+        return this.config;
+      })
+      .catch(() => {
+        this.config = null;
+        return null;
+      })
+      .finally(() => {
+        this.configPromise = null;
+      });
+
+    return this.configPromise;
+  }
+
+  /**
+   * Whether Grafana deep linking is available.
+   */
+  isEnabled(): boolean {
+    return !!this.config?.url;
+  }
+
+  /**
+   * Returns the base Grafana URL, or null if not configured.
+   */
+  getBaseUrl(): string | null {
+    return this.config?.url ?? null;
+  }
+
+  /**
+   * Build a Grafana Explore URL for viewing a trace by its ID in Tempo.
+   */
+  buildTraceUrl(traceId: string): string | null {
+    if (!this.config?.url) return null;
+
+    const panes = JSON.stringify({
+      x: {
+        datasource: this.config.tempoUid,
+        queries: [{ refId: 'A', queryType: 'traceql', query: traceId }],
+        range: { from: 'now-1h', to: 'now' },
+      },
+    });
+
+    return `${this.config.url}/explore?schemaVersion=1&panes=${encodeURIComponent(panes)}`;
+  }
+
+  /**
+   * Build a Grafana Explore URL for viewing logs filtered by session ID in Loki.
+   */
+  buildSessionLogsUrl(sessionId: string, from?: Date, to?: Date): string | null {
+    if (!this.config?.url) return null;
+
+    const fromStr = from ? String(from.getTime()) : 'now-1h';
+    const toStr = to ? String(to.getTime()) : 'now';
+
+    const panes = JSON.stringify({
+      x: {
+        datasource: this.config.lokiUid,
+        queries: [
+          {
+            refId: 'A',
+            expr: `{service_name="eudiplo-backend"} |= "${sessionId}"`,
+          },
+        ],
+        range: { from: fromStr, to: toStr },
+      },
+    });
+
+    return `${this.config.url}/explore?schemaVersion=1&panes=${encodeURIComponent(panes)}`;
+  }
+
+  /**
+   * Build a Grafana Explore URL for viewing traces filtered by session ID in Tempo.
+   */
+  buildSessionTracesUrl(sessionId: string): string | null {
+    if (!this.config?.url) return null;
+
+    const panes = JSON.stringify({
+      x: {
+        datasource: this.config.tempoUid,
+        queries: [
+          {
+            refId: 'A',
+            queryType: 'traceql',
+            query: `{span.session.id="${sessionId}"}`,
+          },
+        ],
+        range: { from: 'now-1h', to: 'now' },
+      },
+    });
+
+    return `${this.config.url}/explore?schemaVersion=1&panes=${encodeURIComponent(panes)}`;
+  }
+
+  /**
+   * Reset the cached config (e.g., on logout).
+   */
+  reset(): void {
+    this.config = null;
+    this.configPromise = null;
+  }
+}

--- a/apps/client/src/app/session-management/session-management-show/session-management-show.component.html
+++ b/apps/client/src/app/session-management/session-management-show/session-management-show.component.html
@@ -4,6 +4,24 @@
     <div fxLayout="row" fxLayoutAlign="space-between center">
       <h2>Session Details: {{ session.id }}</h2>
       <div fxLayout="row" fxLayoutGap="8px">
+        @if (grafanaEnabled) {
+          <button
+            mat-button
+            (click)="openGrafanaLogs()"
+            matTooltip="View related logs in Grafana Loki"
+          >
+            <mat-icon>description</mat-icon>
+            Logs
+          </button>
+          <button
+            mat-button
+            (click)="openGrafanaTraces()"
+            matTooltip="View related traces in Grafana Tempo"
+          >
+            <mat-icon>timeline</mat-icon>
+            Traces
+          </button>
+        }
         @if (canRecreateOffer()) {
           <button
             mat-button
@@ -398,6 +416,23 @@
       @if (sessionLogs.length > 0) {
         <mat-tab label="Logs ({{ sessionLogs.length }})">
           <div class="tab-content">
+            @if (grafanaEnabled) {
+              <div
+                class="grafana-links"
+                fxLayout="row"
+                fxLayoutGap="8px"
+                fxLayoutAlign="end center"
+              >
+                <button
+                  mat-stroked-button
+                  (click)="openGrafanaLogs()"
+                  matTooltip="View full logs in Grafana Loki"
+                >
+                  <mat-icon>open_in_new</mat-icon>
+                  View in Grafana
+                </button>
+              </div>
+            }
             <div class="log-entries">
               @for (log of sessionLogs; track log.id) {
                 <div class="log-entry" [class]="getLogLevelClass(log.level)">
@@ -409,6 +444,16 @@
                       <span class="log-stage">{{ log.stage }}</span>
                     }
                     <span class="log-timestamp">{{ formatDate(log.timestamp) }}</span>
+                    @if (grafanaEnabled && getTraceIdFromDetail(log.detail)) {
+                      <button
+                        mat-icon-button
+                        (click)="openGrafanaTrace(getTraceIdFromDetail(log.detail)!)"
+                        matTooltip="View trace in Grafana Tempo"
+                        class="trace-link-btn"
+                      >
+                        <mat-icon>timeline</mat-icon>
+                      </button>
+                    }
                   </div>
                   <div class="log-message">{{ log.message }}</div>
                   @if (log.detail) {

--- a/apps/client/src/app/session-management/session-management-show/session-management-show.component.scss
+++ b/apps/client/src/app/session-management/session-management-show/session-management-show.component.scss
@@ -249,3 +249,20 @@
   font-size: 12px;
   padding: 8px;
 }
+
+// Grafana deep links
+.grafana-links {
+  margin-bottom: 12px;
+}
+
+.trace-link-btn {
+  width: 24px;
+  height: 24px;
+  line-height: 24px;
+
+  mat-icon {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+  }
+}

--- a/apps/client/src/app/session-management/session-management-show/session-management-show.component.ts
+++ b/apps/client/src/app/session-management/session-management-show/session-management-show.component.ts
@@ -13,6 +13,7 @@ import { FlexLayoutModule } from 'ngx-flexible-layout';
 import * as QRCode from 'qrcode';
 import { Session, isDcApiAvailable, type DigitalCredentialResponse } from '@eudiplo/sdk-core';
 import { SessionManagementService, type SessionLogEntry } from '../session-management.service';
+import { GrafanaLinkService } from '../../services/grafana-link.service';
 import { HttpClient } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 import { decodeJwt } from 'jose';
@@ -37,6 +38,7 @@ export class SessionManagementShowComponent implements OnInit, OnDestroy {
   session: Session | null = null;
   loading = false;
   sessionLogs: SessionLogEntry[] = [];
+  grafanaEnabled = false;
 
   // QR Code functionality
   qrCodeDataUrl: string | null = null;
@@ -73,7 +75,8 @@ export class SessionManagementShowComponent implements OnInit, OnDestroy {
     private route: ActivatedRoute,
     private snackBar: MatSnackBar,
     private router: Router,
-    private httpClient: HttpClient
+    private httpClient: HttpClient,
+    public grafanaLinkService: GrafanaLinkService
   ) {}
 
   async ngOnInit(): Promise<void> {
@@ -81,6 +84,9 @@ export class SessionManagementShowComponent implements OnInit, OnDestroy {
     await this.loadSession(sessionId);
     this.loadSessionLogs(sessionId);
     await this.startPolling(sessionId);
+    this.grafanaLinkService.getConfig().then(() => {
+      this.grafanaEnabled = this.grafanaLinkService.isEnabled();
+    });
   }
 
   ngOnDestroy(): void {
@@ -403,5 +409,29 @@ export class SessionManagementShowComponent implements OnInit, OnDestroy {
       default:
         return 'log-info';
     }
+  }
+
+  openGrafanaLogs(): void {
+    if (!this.session) return;
+    const from = this.session.createdAt ? new Date(this.session.createdAt) : undefined;
+    const url = this.grafanaLinkService.buildSessionLogsUrl(this.session.id, from);
+    if (url) window.open(url, '_blank', 'noopener,noreferrer');
+  }
+
+  openGrafanaTraces(): void {
+    if (!this.session) return;
+    const url = this.grafanaLinkService.buildSessionTracesUrl(this.session.id);
+    if (url) window.open(url, '_blank', 'noopener,noreferrer');
+  }
+
+  openGrafanaTrace(traceId: string): void {
+    const url = this.grafanaLinkService.buildTraceUrl(traceId);
+    if (url) window.open(url, '_blank', 'noopener,noreferrer');
+  }
+
+  getTraceIdFromDetail(detail: Record<string, unknown> | undefined): string | null {
+    if (!detail) return null;
+    const traceId = detail['traceId'] ?? detail['trace_id'];
+    return typeof traceId === 'string' ? traceId : null;
   }
 }

--- a/deployment/docker-compose/.env.full.example
+++ b/deployment/docker-compose/.env.full.example
@@ -104,6 +104,13 @@ MINIO_ROOT_PASSWORD=changeme-strong-password
 # OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
 # OTEL_SDK_DISABLED=false
 
+# Grafana Deep Links (optional)
+# Set GRAFANA_URL to enable deep links from the dashboard to Grafana for logs and traces.
+# The datasource UIDs default to "tempo" and "loki" (matching the provisioned datasources).
+# GRAFANA_URL=http://localhost:3001
+# GRAFANA_DATASOURCE_TEMPO_UID=tempo
+# GRAFANA_DATASOURCE_LOKI_UID=loki
+
 # =============================================================================
 # Client: Subpath Configuration (optional)
 # Uncomment to serve the client from a reverse proxy subpath.

--- a/deployment/docker-compose/.env.standard.example
+++ b/deployment/docker-compose/.env.standard.example
@@ -83,6 +83,13 @@ MINIO_ROOT_PASSWORD=minioadmin
 # OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
 # OTEL_SDK_DISABLED=false
 
+# Grafana Deep Links (optional)
+# Set GRAFANA_URL to enable deep links from the dashboard to Grafana for logs and traces.
+# The datasource UIDs default to "tempo" and "loki" (matching the provisioned datasources).
+# GRAFANA_URL=http://localhost:3001
+# GRAFANA_DATASOURCE_TEMPO_UID=tempo
+# GRAFANA_DATASOURCE_LOKI_UID=loki
+
 # =============================================================================
 # Client: Subpath Configuration (optional)
 # Uncomment to serve the client from a reverse proxy subpath.

--- a/docs/getting-started/monitor.md
+++ b/docs/getting-started/monitor.md
@@ -118,11 +118,14 @@ docker-compose up -d
 
 ## Environment Variables
 
-| Variable                      | Description               | Default                 |
-| ----------------------------- | ------------------------- | ----------------------- |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP collector endpoint   | `http://localhost:4318` |
-| `OTEL_SERVICE_NAME`           | Service name in telemetry | `eudiplo-backend`       |
-| `OTEL_SDK_DISABLED`           | Disable OTel SDK entirely | `false`                 |
+| Variable                       | Description                               | Default                 |
+| ------------------------------ | ----------------------------------------- | ----------------------- |
+| `OTEL_EXPORTER_OTLP_ENDPOINT`  | OTLP collector endpoint                   | `http://localhost:4318` |
+| `OTEL_SERVICE_NAME`            | Service name in telemetry                 | `eudiplo-backend`       |
+| `OTEL_SDK_DISABLED`            | Disable OTel SDK entirely                 | `false`                 |
+| `GRAFANA_URL`                  | Grafana base URL for dashboard deep links | _(not set)_             |
+| `GRAFANA_DATASOURCE_TEMPO_UID` | UID of the Tempo datasource in Grafana    | `tempo`                 |
+| `GRAFANA_DATASOURCE_LOKI_UID`  | UID of the Loki datasource in Grafana     | `loki`                  |
 
 Set `OTEL_SDK_DISABLED=true` for local development without a collector running.
 
@@ -219,6 +222,63 @@ All configuration files are in the `monitor/` directory:
 
 Set `OTEL_SDK_DISABLED=true` in your environment to disable all OpenTelemetry
 instrumentation when running without a collector.
+
+## Grafana Deep Links from the Dashboard
+
+The EUDIPLO client UI can link directly to Grafana for viewing logs and traces
+related to specific sessions. This improves the debugging experience by
+providing one-click navigation from the dashboard to Grafana Explore.
+
+### Setup
+
+Set the `GRAFANA_URL` environment variable on the backend to the base URL of
+your Grafana instance:
+
+```bash
+# Local development (default monitor stack)
+GRAFANA_URL=http://localhost:3001
+
+# Production example
+GRAFANA_URL=https://grafana.example.com
+```
+
+If your Grafana datasource UIDs differ from the defaults (`tempo` for Tempo,
+`loki` for Loki), also set:
+
+```bash
+GRAFANA_DATASOURCE_TEMPO_UID=my-tempo-uid
+GRAFANA_DATASOURCE_LOKI_UID=my-loki-uid
+```
+
+### Where Deep Links Appear
+
+When `GRAFANA_URL` is configured, the following links are available:
+
+| Location                     | Link                   | Opens                                          |
+| ---------------------------- | ---------------------- | ---------------------------------------------- |
+| **Dashboard** (main page)    | _Open Grafana_         | Grafana home                                   |
+| **Dashboard** (Resources)    | _Grafana Dashboard_    | Grafana home                                   |
+| **Session Details** (header) | _Logs_                 | Grafana Explore → Loki filtered by session ID  |
+| **Session Details** (header) | _Traces_               | Grafana Explore → Tempo filtered by session ID |
+| **Session Logs** tab         | _View in Grafana_      | Grafana Explore → Loki filtered by session ID  |
+| **Session Log entry**        | Trace icon (per entry) | Grafana Explore → Tempo for that trace ID      |
+
+### Graceful Degradation
+
+When `GRAFANA_URL` is **not set**, all Grafana-related links are hidden
+automatically. No configuration is required to disable the feature — it is
+opt-in by default.
+
+### Datasource UID Discovery
+
+To find your Grafana datasource UIDs:
+
+1. Open Grafana → **Connections → Data sources**
+2. Click on Tempo or Loki
+3. The UID is in the URL: `http://grafana:3000/connections/datasources/edit/<uid>`
+
+The default provisioned UIDs for the included monitor stack are `tempo` and
+`loki` (set in `monitor/grafana/provisioning/datasources/`).
 
 ## Clean Up
 


### PR DESCRIPTION
## Summary

Adds Grafana deep links from the dashboard and session detail pages, and improves session observability so that logs and traces carry the `sessionId` for filtering in Loki and Tempo.

Closes #630

## Changes

### Grafana Deep Links (Frontend)
- **New `GrafanaLinkService`** — builds deep links to Grafana for Loki (logs) and Tempo (traces) filtered by session ID
- **Dashboard** — added "View Logs" button linking to Grafana/Loki filtered by `service_name`
- **Session detail page** — added "Logs" and "Traces" buttons that deep link to Grafana filtered by the specific session ID
- **Backend `/api/frontend-config` endpoint** — exposes `grafanaUrl`, `grafanaDatasourceTempoUid`, and `grafanaDatasourceLokiUid` to the frontend, controlled via env vars

### Session Observability (Backend)
- **PinoLogger migration** — switched `MdocverifierService`, `SdjwtvcverifierService`, and `CredentialChainValidationService` from NestJS basic `Logger` (string-only) to `PinoLogger` (structured JSON). This ensures verification error details appear in Loki with full context.
- **Session context in logs** — added `PinoLogger.assign({ sessionId })` in `PresentationsService.parseResponse()` so all downstream log calls include the session ID
- **Span attributes for Tempo** — added `TraceService.getSpan()?.setAttributes({ "session.id", "session.tenantId", "session.requestId" })` in `PresentationsService.parseResponse()` for trace correlation in Tempo
- **SessionLoggerService integration** — replaced `AuditLogService` (DB-only) with `SessionLoggerService` (DB + PinoLogger) in `Oid4vpService` and `Oid4vciService`. Session lifecycle events (flow_start, flow_error, flow_complete, credential_verification) now appear in Loki.
- **mDOC verification fix** — added missing check for `result.verified === false` before proceeding to claim validation

### Configuration & Docs
- Added `GRAFANA_URL`, `GRAFANA_DATASOURCE_TEMPO_UID`, `GRAFANA_DATASOURCE_LOKI_UID` to validation schema and all `.env.example` files
- Updated [monitor.md](docs/getting-started/monitor.md) with Grafana deep link documentation and LogQL query examples

## How to Test

1. Start the monitoring stack: `cd monitor && docker compose up -d`
2. Set `GRAFANA_URL=http://localhost:3001` in backend `.env`
3. Start the backend and client
4. Create a verification session — the dashboard and session detail pages should show Grafana buttons
5. In Loki, query: `{service_name="eudiplo-backend"} | sessionId=` + backtick + session UUID + backtick
6. In Tempo, search for spans with attribute `session.id` = session UUID

## Breaking Changes

None