### PR TITLE
fix: trust list parsing and public URL

### DIFF
--- a/apps/backend/src/shared/trust/trust-store.service.ts
+++ b/apps/backend/src/shared/trust/trust-store.service.ts
@@ -39,13 +39,13 @@ export class TrustStoreService {
             this.logger.debug(`Fetching trust list from: ${ref.url}`);
             const jwt = await this.trustListJwt.fetchJwt(ref.url);
             await this.trustListJwt.verifyTrustListJwt(ref, jwt); // hook
-            const decoded = decodeJwt<LoTE>(jwt);
+            const decoded = decodeJwt<{ LoTE: LoTE }>(jwt);
 
             this.logger.debug(
-                `Decoded LoTE from ${ref.url}: TrustedEntitiesList has ${decoded.TrustedEntitiesList?.length ?? 0} raw entries`,
+                `Decoded LoTE from ${ref.url}: TrustedEntitiesList has ${decoded.LoTE.TrustedEntitiesList?.length ?? 0} raw entries`,
             );
 
-            let parsed = this.loteParser.parse(decoded);
+            let parsed = this.loteParser.parse(decoded.LoTE);
             this.logger.debug(
                 `Parsed ${parsed.entities.length} entities from ${ref.url}`,
             );

--- a/apps/backend/src/verifier/presentations/presentations.service.ts
+++ b/apps/backend/src/verifier/presentations/presentations.service.ts
@@ -236,7 +236,7 @@ export class PresentationsService {
 
         const attestationIds = Object.keys(res.vp_token);
         const host = this.configService.getOrThrow<string>("PUBLIC_URL");
-        const tenantHost = `${host}/${presentationConfig.tenantId}`;
+        const tenantHost = `${host}/issuers/${presentationConfig.tenantId}`;
 
         // Validate credential completeness - ensure all required credentials are present
         this.validateCredentialCompleteness(

--- a/apps/backend/test/issuance/wallet-attestation.e2e-spec.ts
+++ b/apps/backend/test/issuance/wallet-attestation.e2e-spec.ts
@@ -146,27 +146,30 @@ async function createMockTrustListJwt(
     }
 
     const lotePayload = {
-        ListAndSchemeInformation: {
-            LoTEVersionIdentifier: 1,
-            LoTESequenceNumber: 1,
-            LoTEType: "http://uri.etsi.org/19602/LoTEType/EUEAAProvidersList",
-            StatusDeterminationApproach:
-                "http://uri.etsi.org/19602/EUEAAProvidersList/StatusDetn/EU",
-            SchemeTerritory: "EU",
-            NextUpdate: new Date(
-                Date.now() + 365 * 24 * 60 * 60 * 1000,
-            ).toISOString(),
-            ListIssueDateTime: new Date().toISOString(),
-            SchemeOperatorName: [{ lang: "en", value: "Test Operator" }],
-        },
-        TrustedEntitiesList: [
-            {
-                TrustedEntityInformation: {
-                    TEName: [{ lang: "en", value: "Test Wallet Provider" }],
-                },
-                TrustedEntityServices: services,
+        LoTE: {
+            ListAndSchemeInformation: {
+                LoTEVersionIdentifier: 1,
+                LoTESequenceNumber: 1,
+                LoTEType:
+                    "http://uri.etsi.org/19602/LoTEType/EUEAAProvidersList",
+                StatusDeterminationApproach:
+                    "http://uri.etsi.org/19602/EUEAAProvidersList/StatusDetn/EU",
+                SchemeTerritory: "EU",
+                NextUpdate: new Date(
+                    Date.now() + 365 * 24 * 60 * 60 * 1000,
+                ).toISOString(),
+                ListIssueDateTime: new Date().toISOString(),
+                SchemeOperatorName: [{ lang: "en", value: "Test Operator" }],
             },
-        ],
+            TrustedEntitiesList: [
+                {
+                    TrustedEntityInformation: {
+                        TEName: [{ lang: "en", value: "Test Wallet Provider" }],
+                    },
+                    TrustedEntityServices: services,
+                },
+            ],
+        },
     };
 
     const jwt = await new SignJWT(lotePayload)

--- a/apps/backend/test/presentation/presentation-mdoc.e2e-spec.ts
+++ b/apps/backend/test/presentation/presentation-mdoc.e2e-spec.ts
@@ -1,9 +1,11 @@
+import "reflect-metadata";
 import { INestApplication } from "@nestjs/common";
 import {
     Openid4vpAuthorizationRequest,
     Openid4vpClient,
 } from "@openid4vc/openid4vp";
-import { CryptoKey } from "jose";
+import * as x509Lib from "@peculiar/x509";
+import { CryptoKey, generateKeyPair } from "jose";
 import request from "supertest";
 import { App } from "supertest/types";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
@@ -163,5 +165,99 @@ describe("Presentation - mDOC Credential", () => {
         const claims = credentialSet.values[0];
         expect(claims.first_name).toBe("First");
         expect(claims.last_name).toBe("Last");
+    });
+
+    test("should reject mDOC credential signed by untrusted issuer (not in trust list)", async () => {
+        // Generate a new key pair that is NOT in the trust list
+        const untrustedKeyPair = await generateKeyPair("ES256", {
+            extractable: true,
+        });
+
+        // Generate a self-signed certificate for the untrusted key
+        x509Lib.cryptoProvider.set(globalThis.crypto);
+        const untrustedCert =
+            await x509Lib.X509CertificateGenerator.createSelfSigned({
+                serialNumber: "01",
+                name: "CN=Untrusted mDOC Issuer",
+                notBefore: new Date(),
+                notAfter: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
+                signingAlgorithm: { name: "ECDSA", hash: "SHA-256" },
+                keys: {
+                    privateKey: untrustedKeyPair.privateKey,
+                    publicKey: untrustedKeyPair.publicKey,
+                },
+            });
+
+        // Convert certificate to PEM for mDOC
+        const untrustedCertPem = untrustedCert.toString("pem");
+
+        // Create a presentation request
+        const requestBody: PresentationRequest = {
+            response_type: ResponseType.URI,
+            requestId: "pid-de",
+        };
+
+        const res = await createPresentationRequest(
+            app,
+            authToken,
+            requestBody,
+        );
+
+        const sessionId = res.body.session;
+
+        const authRequest = client.parseOpenid4vpAuthorizationRequest({
+            authorizationRequest: res.body.uri,
+        });
+
+        const resolved = await client.resolveOpenId4vpAuthorizationRequest({
+            authorizationRequestPayload: authRequest.params,
+            responseMode: { type: "direct_post" },
+        });
+
+        // Create mDOC credential signed with the UNTRUSTED key
+        const vp_token = await prepareMdocPresentation(
+            resolved.authorizationRequestPayload.nonce,
+            untrustedKeyPair.privateKey,
+            untrustedCertPem,
+            resolved.authorizationRequestPayload.client_id!,
+            resolved.authorizationRequestPayload.response_uri as string,
+        );
+
+        const jwt = await encryptVpToken(vp_token, "pid-mso-mdoc", resolved);
+
+        const authorizationResponse =
+            await client.createOpenid4vpAuthorizationResponse({
+                authorizationRequestPayload: authRequest.params,
+                authorizationResponsePayload: {
+                    response: jwt,
+                },
+                ...callbacks,
+            });
+
+        // Submit the presentation - should fail
+        const submitRes = await client.submitOpenid4vpAuthorizationResponse({
+            authorizationResponsePayload:
+                authorizationResponse.authorizationResponsePayload,
+            authorizationRequestPayload:
+                resolved.authorizationRequestPayload as Openid4vpAuthorizationRequest,
+        });
+
+        // The submission should succeed (200 per OID4VP spec) but session should fail
+        expect(submitRes.response.status).toBe(200);
+
+        // Verify the session is marked as failed with trust-related error
+        const sessionRes = await request(app.getHttpServer())
+            .get(`/session/${sessionId}`)
+            .trustLocalhost()
+            .set("Authorization", `Bearer ${authToken}`)
+            .expect(200);
+
+        expect(sessionRes.body.status).toBe("failed");
+        // Error should mention trust chain, signature validation, or untrusted issuer
+        // The system may fail at signature verification (when x5c doesn't chain to trust anchor)
+        // or at trust list matching - both indicate credential rejection from untrusted source
+        expect(sessionRes.body.errorReason).toMatch(
+            /trust|chain|no_trusted_entity_match|invalid|failed/i,
+        );
     });
 });

--- a/apps/backend/test/presentation/presentation-sdjwt.e2e-spec.ts
+++ b/apps/backend/test/presentation/presentation-sdjwt.e2e-spec.ts
@@ -1,9 +1,11 @@
+import "reflect-metadata";
 import { INestApplication } from "@nestjs/common";
 import {
     Openid4vpAuthorizationRequest,
     Openid4vpClient,
 } from "@openid4vc/openid4vp";
-import { CryptoKey } from "jose";
+import * as x509Lib from "@peculiar/x509";
+import { CryptoKey, generateKeyPair } from "jose";
 import request from "supertest";
 import { App } from "supertest/types";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
@@ -247,6 +249,104 @@ describe("Presentation - SD-JWT Credential", () => {
         expect(sessionRes.body.errorReason).toContain("access_denied");
         expect(sessionRes.body.errorReason).toContain(
             "User cancelled the presentation request",
+        );
+    });
+
+    test("should reject credential signed by untrusted issuer (not in trust list)", async () => {
+        // Generate a new key pair that is NOT in the trust list
+        const untrustedKeyPair = await generateKeyPair("ES256", {
+            extractable: true,
+        });
+
+        // Generate a self-signed certificate for the untrusted key
+        x509Lib.cryptoProvider.set(globalThis.crypto);
+        const untrustedCert =
+            await x509Lib.X509CertificateGenerator.createSelfSigned({
+                serialNumber: "01",
+                name: "CN=Untrusted Issuer",
+                notBefore: new Date(),
+                notAfter: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
+                signingAlgorithm: { name: "ECDSA", hash: "SHA-256" },
+                keys: {
+                    privateKey: untrustedKeyPair.privateKey,
+                    publicKey: untrustedKeyPair.publicKey,
+                },
+            });
+
+        // Convert certificate to base64 for x5c header
+        const untrustedCertChain = [untrustedCert.toString("base64")];
+
+        // Create a presentation request
+        const requestBody: PresentationRequest = {
+            response_type: ResponseType.URI,
+            requestId: "pid-no-hook",
+        };
+
+        const res = await createPresentationRequest(
+            app,
+            authToken,
+            requestBody,
+        );
+
+        const sessionId = res.body.session;
+
+        const authRequest = client.parseOpenid4vpAuthorizationRequest({
+            authorizationRequest: res.body.uri,
+        });
+
+        const resolved = await client.resolveOpenId4vpAuthorizationRequest({
+            authorizationRequestPayload: authRequest.params,
+            responseMode: { type: "direct_post" },
+        });
+
+        // Create a credential signed with the UNTRUSTED key
+        const vp_token = await preparePresentation(
+            {
+                iat: Math.floor(Date.now() / 1000),
+                aud: resolved.authorizationRequestPayload.aud as string,
+                nonce: resolved.authorizationRequestPayload.nonce,
+            },
+            untrustedKeyPair.privateKey,
+            untrustedCertChain,
+            statusListService,
+            credentialConfigId,
+        );
+
+        const jwt = await encryptVpToken(vp_token, "pid", resolved);
+
+        const authorizationResponse =
+            await client.createOpenid4vpAuthorizationResponse({
+                authorizationRequestPayload: authRequest.params,
+                authorizationResponsePayload: {
+                    response: jwt,
+                },
+                ...callbacks,
+            });
+
+        // Submit the presentation - should fail
+        const submitRes = await client.submitOpenid4vpAuthorizationResponse({
+            authorizationResponsePayload:
+                authorizationResponse.authorizationResponsePayload,
+            authorizationRequestPayload:
+                resolved.authorizationRequestPayload as Openid4vpAuthorizationRequest,
+        });
+
+        // The submission should succeed (200 per OID4VP spec) but session should fail
+        expect(submitRes.response.status).toBe(200);
+
+        // Verify the session is marked as failed with trust-related error
+        const sessionRes = await request(app.getHttpServer())
+            .get(`/session/${sessionId}`)
+            .trustLocalhost()
+            .set("Authorization", `Bearer ${authToken}`)
+            .expect(200);
+
+        expect(sessionRes.body.status).toBe("failed");
+        // Error should mention trust chain, signature validation, or untrusted issuer
+        // The system may fail at signature verification (when x5c doesn't chain to trust anchor)
+        // or at trust list matching - both indicate credential rejection from untrusted source
+        expect(sessionRes.body.errorReason).toMatch(
+            /trust|chain|no_trusted_entity_match|Invalid.*Signature/i,
         );
     });
 });

--- a/apps/backend/test/trust-list/trust-list.e2e-spec.ts
+++ b/apps/backend/test/trust-list/trust-list.e2e-spec.ts
@@ -1,0 +1,543 @@
+import "reflect-metadata";
+import { rmSync } from "node:fs";
+import { resolve, join } from "node:path";
+import { INestApplication, ValidationPipe } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { Test, TestingModule } from "@nestjs/testing";
+import { decodeJwt, decodeProtectedHeader, jwtVerify, importX509 } from "jose";
+import request from "supertest";
+import { App } from "supertest/types";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { AppModule } from "../../src/app.module";
+import { KeyChainImportDto } from "../../src/crypto/key/dto/key-chain-import.dto";
+import { TrustListCreateDto } from "../../src/issuer/trust-list/dto/trust-list-create.dto";
+import { getToken, readConfig } from "../utils";
+
+interface TestContext {
+    app: INestApplication<App>;
+    authToken: string;
+    configFolder: string;
+}
+
+describe("Trust List e2e Tests", () => {
+    let ctx: TestContext;
+
+    beforeAll(async () => {
+        // Delete the database
+        rmSync("../../tmp/service.db", { force: true });
+
+        const moduleFixture: TestingModule = await Test.createTestingModule({
+            imports: [AppModule],
+        }).compile();
+
+        const app = moduleFixture.createNestApplication();
+        app.useGlobalPipes(
+            new ValidationPipe({
+                whitelist: true,
+                transform: true,
+            }),
+        );
+
+        const configService = app.get(ConfigService);
+        const configFolder = resolve(__dirname + "/../fixtures");
+        configService.set("CONFIG_IMPORT", false);
+        configService.set("LOG_LEVEL", "debug");
+        const clientId = configService.getOrThrow<string>("AUTH_CLIENT_ID");
+        const clientSecret =
+            configService.getOrThrow<string>("AUTH_CLIENT_SECRET");
+
+        await app.init();
+        await app.listen(3000);
+
+        const authToken = await getToken(app, clientId, clientSecret);
+
+        // Import trust list key chain
+        const trustListKeyChain = readConfig<KeyChainImportDto>(
+            join(configFolder, "haip/key-chains/trust-list.json"),
+        );
+        await request(app.getHttpServer())
+            .post("/key-chain/import")
+            .set("Authorization", `Bearer ${authToken}`)
+            .send(trustListKeyChain)
+            .expect(201);
+
+        // Import attestation key chain (for internal entity issuance references)
+        const attestationKeyChain = readConfig<KeyChainImportDto>(
+            join(configFolder, "haip/key-chains/attestation.json"),
+        );
+        await request(app.getHttpServer())
+            .post("/key-chain/import")
+            .set("Authorization", `Bearer ${authToken}`)
+            .send(attestationKeyChain)
+            .expect(201);
+
+        // Import status list key chain (for internal entity revocation references)
+        const statusListKeyChain = readConfig<KeyChainImportDto>(
+            join(configFolder, "haip/key-chains/status-list.json"),
+        );
+        await request(app.getHttpServer())
+            .post("/key-chain/import")
+            .set("Authorization", `Bearer ${authToken}`)
+            .send(statusListKeyChain)
+            .expect(201);
+
+        ctx = { app, authToken, configFolder };
+    });
+
+    afterAll(async () => {
+        await ctx.app.close();
+    });
+
+    describe("CRUD Operations", () => {
+        const testTrustListId = "test-crud-trust-list";
+
+        test("should create a trust list", async () => {
+            const createDto: TrustListCreateDto = {
+                id: testTrustListId,
+                description: "Test Trust List for CRUD",
+                keyChainId: "570852d7-7e7f-40af-a0e3-a6ebffd75ed0",
+                entities: [
+                    {
+                        type: "internal",
+                        issuerKeyChainId:
+                            "9687a941-3f89-476b-b383-aa5fea1bac8e",
+                        revocationKeyChainId:
+                            "9687a941-3f89-476b-b383-aa5fea1baa8e",
+                        info: {
+                            name: "Test Provider",
+                            lang: "en",
+                        },
+                    },
+                ],
+            };
+
+            const response = await request(ctx.app.getHttpServer())
+                .post("/trust-list")
+                .set("Authorization", `Bearer ${ctx.authToken}`)
+                .send(createDto)
+                .expect(201);
+
+            expect(response.body.id).toBe(testTrustListId);
+            expect(response.body.description).toBe("Test Trust List for CRUD");
+            expect(response.body.jwt).toBeDefined();
+            expect(response.body.sequenceNumber).toBe(1);
+        });
+
+        test("should get all trust lists", async () => {
+            const response = await request(ctx.app.getHttpServer())
+                .get("/trust-list")
+                .set("Authorization", `Bearer ${ctx.authToken}`)
+                .expect(200);
+
+            expect(Array.isArray(response.body)).toBe(true);
+            expect(response.body.length).toBeGreaterThanOrEqual(1);
+        });
+
+        test("should get a single trust list by id", async () => {
+            const response = await request(ctx.app.getHttpServer())
+                .get(`/trust-list/${testTrustListId}`)
+                .set("Authorization", `Bearer ${ctx.authToken}`)
+                .expect(200);
+
+            expect(response.body.id).toBe(testTrustListId);
+        });
+
+        test("should update a trust list and increment sequence number", async () => {
+            const updateDto: TrustListCreateDto = {
+                description: "Updated Test Trust List",
+                entities: [
+                    {
+                        type: "internal",
+                        issuerKeyChainId:
+                            "9687a941-3f89-476b-b383-aa5fea1bac8e",
+                        revocationKeyChainId:
+                            "9687a941-3f89-476b-b383-aa5fea1baa8e",
+                        info: {
+                            name: "Updated Provider",
+                            lang: "en",
+                        },
+                    },
+                ],
+            };
+
+            const response = await request(ctx.app.getHttpServer())
+                .put(`/trust-list/${testTrustListId}`)
+                .set("Authorization", `Bearer ${ctx.authToken}`)
+                .send(updateDto)
+                .expect(200);
+
+            expect(response.body.description).toBe("Updated Test Trust List");
+            expect(response.body.sequenceNumber).toBe(2);
+        });
+
+        test("should export a trust list in LoTE format", async () => {
+            const response = await request(ctx.app.getHttpServer())
+                .get(`/trust-list/${testTrustListId}/export`)
+                .set("Authorization", `Bearer ${ctx.authToken}`)
+                .expect(200);
+
+            expect(response.body.id).toBe(testTrustListId);
+            expect(response.body.entities).toBeDefined();
+            expect(response.body.data).toBeDefined();
+        });
+
+        test("should get version history for a trust list", async () => {
+            const response = await request(ctx.app.getHttpServer())
+                .get(`/trust-list/${testTrustListId}/versions`)
+                .set("Authorization", `Bearer ${ctx.authToken}`)
+                .expect(200);
+
+            expect(Array.isArray(response.body)).toBe(true);
+            // Should have at least one version from the update
+            expect(response.body.length).toBeGreaterThanOrEqual(1);
+        });
+
+        test("should delete a trust list", async () => {
+            await request(ctx.app.getHttpServer())
+                .delete(`/trust-list/${testTrustListId}`)
+                .set("Authorization", `Bearer ${ctx.authToken}`)
+                .expect(200);
+
+            // Verify it's deleted
+            await request(ctx.app.getHttpServer())
+                .get(`/trust-list/${testTrustListId}`)
+                .set("Authorization", `Bearer ${ctx.authToken}`)
+                .expect(409);
+        });
+    });
+
+    describe("LoTE JWT Signing", () => {
+        const jwtTestId = "jwt-signing-test";
+
+        test("should create trust list with valid JWT structure", async () => {
+            const createDto: TrustListCreateDto = {
+                id: jwtTestId,
+                description: "JWT Signing Test",
+                keyChainId: "570852d7-7e7f-40af-a0e3-a6ebffd75ed0",
+                entities: [
+                    {
+                        type: "internal",
+                        issuerKeyChainId:
+                            "9687a941-3f89-476b-b383-aa5fea1bac8e",
+                        revocationKeyChainId:
+                            "9687a941-3f89-476b-b383-aa5fea1baa8e",
+                        info: {
+                            name: "JWT Test Provider",
+                            lang: "en",
+                        },
+                    },
+                ],
+            };
+
+            const response = await request(ctx.app.getHttpServer())
+                .post("/trust-list")
+                .set("Authorization", `Bearer ${ctx.authToken}`)
+                .send(createDto)
+                .expect(201);
+
+            const jwt = response.body.jwt;
+            expect(jwt).toBeDefined();
+
+            // Decode and verify JWT structure
+            const header = decodeProtectedHeader(jwt);
+            expect(header.alg).toBe("ES256");
+            expect(header.x5c).toBeDefined();
+            expect(Array.isArray(header.x5c)).toBe(true);
+            expect((header.x5c as string[]).length).toBeGreaterThanOrEqual(1);
+
+            // Decode payload and verify LoTE structure
+            const payload = decodeJwt<{ LoTE: unknown }>(jwt);
+            expect(payload.LoTE).toBeDefined();
+        });
+
+        test("should include ETSI TS 119 602 compliant LoTE structure in JWT", async () => {
+            const response = await request(ctx.app.getHttpServer())
+                .get(`/trust-list/${jwtTestId}`)
+                .set("Authorization", `Bearer ${ctx.authToken}`)
+                .expect(200);
+
+            const payload = decodeJwt<{
+                LoTE: {
+                    ListAndSchemeInformation: {
+                        LoTEVersionIdentifier: number;
+                        LoTESequenceNumber: number;
+                        LoTEType: string;
+                        SchemeTerritory: string;
+                    };
+                    TrustedEntitiesList: unknown[];
+                };
+            }>(response.body.jwt);
+
+            const lote = payload.LoTE;
+            expect(lote.ListAndSchemeInformation).toBeDefined();
+            expect(
+                lote.ListAndSchemeInformation.LoTEVersionIdentifier,
+            ).toBeDefined();
+            expect(
+                lote.ListAndSchemeInformation.LoTESequenceNumber,
+            ).toBeDefined();
+            expect(lote.ListAndSchemeInformation.LoTEType).toBe(
+                "http://uri.etsi.org/19602/LoTEType/EUEAAProvidersList",
+            );
+            expect(lote.TrustedEntitiesList).toBeDefined();
+        });
+
+        test("should verify JWT signature with embedded certificate", async () => {
+            const response = await request(ctx.app.getHttpServer())
+                .get(`/trust-list/${jwtTestId}`)
+                .set("Authorization", `Bearer ${ctx.authToken}`)
+                .expect(200);
+
+            const jwt = response.body.jwt;
+            const header = decodeProtectedHeader(jwt);
+            const x5c = header.x5c as string[];
+
+            // Import the certificate from x5c and verify the signature
+            const certPem = `-----BEGIN CERTIFICATE-----\n${x5c[0]}\n-----END CERTIFICATE-----`;
+            const publicKey = await importX509(certPem, "ES256");
+
+            const { payload } = await jwtVerify(jwt, publicKey);
+            expect(payload.LoTE).toBeDefined();
+        });
+    });
+
+    describe("LoTE Parsing and Entity Count", () => {
+        const parsingTestId = "parsing-test";
+
+        test("should correctly count TrustedEntities in the list", async () => {
+            // Create trust list with multiple entities
+            const createDto: TrustListCreateDto = {
+                id: parsingTestId,
+                description: "Parsing Test",
+                keyChainId: "570852d7-7e7f-40af-a0e3-a6ebffd75ed0",
+                entities: [
+                    {
+                        type: "internal",
+                        issuerKeyChainId:
+                            "9687a941-3f89-476b-b383-aa5fea1bac8e",
+                        revocationKeyChainId:
+                            "9687a941-3f89-476b-b383-aa5fea1baa8e",
+                        info: { name: "Provider 1", lang: "en" },
+                    },
+                ],
+            };
+
+            await request(ctx.app.getHttpServer())
+                .post("/trust-list")
+                .set("Authorization", `Bearer ${ctx.authToken}`)
+                .send(createDto)
+                .expect(201);
+
+            const response = await request(ctx.app.getHttpServer())
+                .get(`/trust-list/${parsingTestId}`)
+                .set("Authorization", `Bearer ${ctx.authToken}`)
+                .expect(200);
+
+            const payload = decodeJwt<{
+                LoTE: { TrustedEntitiesList: unknown[] };
+            }>(response.body.jwt);
+            expect(payload.LoTE.TrustedEntitiesList.length).toBe(1);
+        });
+
+        test("should include issuance and revocation services per entity", async () => {
+            const response = await request(ctx.app.getHttpServer())
+                .get(`/trust-list/${parsingTestId}`)
+                .set("Authorization", `Bearer ${ctx.authToken}`)
+                .expect(200);
+
+            const payload = decodeJwt<{
+                LoTE: {
+                    TrustedEntitiesList: Array<{
+                        TrustedEntityServices: Array<{
+                            ServiceInformation: {
+                                ServiceTypeIdentifier: string;
+                            };
+                        }>;
+                    }>;
+                };
+            }>(response.body.jwt);
+
+            const entity = payload.LoTE.TrustedEntitiesList[0];
+            const serviceTypes = entity.TrustedEntityServices.map(
+                (s) => s.ServiceInformation.ServiceTypeIdentifier,
+            );
+
+            // Should have both issuance and revocation services
+            expect(serviceTypes.some((t) => t.includes("Issuance"))).toBe(true);
+            expect(serviceTypes.some((t) => t.includes("Revocation"))).toBe(
+                true,
+            );
+        });
+    });
+
+    describe("Public URL Resolution", () => {
+        const publicUrlTestId = "public-url-test";
+
+        beforeAll(async () => {
+            const createDto: TrustListCreateDto = {
+                id: publicUrlTestId,
+                description: "Public URL Test",
+                keyChainId: "570852d7-7e7f-40af-a0e3-a6ebffd75ed0",
+                entities: [
+                    {
+                        type: "internal",
+                        issuerKeyChainId:
+                            "9687a941-3f89-476b-b383-aa5fea1bac8e",
+                        revocationKeyChainId:
+                            "9687a941-3f89-476b-b383-aa5fea1baa8e",
+                        info: { name: "Public URL Provider", lang: "en" },
+                    },
+                ],
+            };
+
+            await request(ctx.app.getHttpServer())
+                .post("/trust-list")
+                .set("Authorization", `Bearer ${ctx.authToken}`)
+                .send(createDto)
+                .expect(201);
+        });
+
+        test("should return JWT from public URL endpoint", async () => {
+            const response = await request(ctx.app.getHttpServer())
+                .get(`/issuers/root/trust-list/${publicUrlTestId}`)
+                .expect(200);
+
+            // Response should be the raw JWT string
+            expect(typeof response.text).toBe("string");
+            expect(response.text.split(".").length).toBe(3); // JWT has 3 parts
+        });
+
+        test("should return same JWT from public and authenticated endpoints", async () => {
+            const publicResponse = await request(ctx.app.getHttpServer())
+                .get(`/issuers/root/trust-list/${publicUrlTestId}`)
+                .expect(200);
+
+            const authResponse = await request(ctx.app.getHttpServer())
+                .get(`/trust-list/${publicUrlTestId}`)
+                .set("Authorization", `Bearer ${ctx.authToken}`)
+                .expect(200);
+
+            expect(publicResponse.text).toBe(authResponse.body.jwt);
+        });
+
+        test("should return 400 for non-existent trust list via public URL", async () => {
+            await request(ctx.app.getHttpServer())
+                .get("/issuers/root/trust-list/non-existent-id")
+                .expect(400);
+        });
+    });
+
+    describe("Error Handling", () => {
+        test("should reject trust list with invalid key chain id", async () => {
+            const createDto: TrustListCreateDto = {
+                id: "invalid-keychain-test",
+                description: "Invalid Key Chain Test",
+                keyChainId: "non-existent-key-chain",
+                entities: [],
+            };
+
+            await request(ctx.app.getHttpServer())
+                .post("/trust-list")
+                .set("Authorization", `Bearer ${ctx.authToken}`)
+                .send(createDto)
+                .expect(409);
+        });
+
+        test("should reject trust list with key chain that lacks TrustList usage", async () => {
+            // attestation key chain has Attestation usage, not TrustList
+            const createDto: TrustListCreateDto = {
+                id: "wrong-usage-test",
+                description: "Wrong Usage Test",
+                keyChainId: "9687a941-3f89-476b-b383-aa5fea1bac8e", // attestation key
+                entities: [],
+            };
+
+            await request(ctx.app.getHttpServer())
+                .post("/trust-list")
+                .set("Authorization", `Bearer ${ctx.authToken}`)
+                .send(createDto)
+                .expect(409);
+        });
+
+        test("should reject external entity with invalid PEM certificate", async () => {
+            const createDto: TrustListCreateDto = {
+                id: "invalid-pem-test",
+                description: "Invalid PEM Test",
+                entities: [
+                    {
+                        type: "external",
+                        issuerCertPem: "not-a-valid-pem",
+                        revocationCertPem: "also-not-valid",
+                        info: { name: "Invalid Provider" },
+                    },
+                ],
+            };
+
+            await request(ctx.app.getHttpServer())
+                .post("/trust-list")
+                .set("Authorization", `Bearer ${ctx.authToken}`)
+                .send(createDto)
+                .expect(409);
+        });
+
+        test("should return 409 when getting non-existent trust list", async () => {
+            await request(ctx.app.getHttpServer())
+                .get("/trust-list/does-not-exist")
+                .set("Authorization", `Bearer ${ctx.authToken}`)
+                .expect(409);
+        });
+    });
+
+    describe("Authentication", () => {
+        test("should reject unauthenticated request to create trust list", async () => {
+            const createDto: TrustListCreateDto = {
+                id: "unauth-test",
+                description: "Unauthenticated Test",
+                entities: [],
+            };
+
+            await request(ctx.app.getHttpServer())
+                .post("/trust-list")
+                .send(createDto)
+                .expect(401);
+        });
+
+        test("should reject unauthenticated request to list trust lists", async () => {
+            await request(ctx.app.getHttpServer())
+                .get("/trust-list")
+                .expect(401);
+        });
+
+        test("public URL should be accessible without authentication", async () => {
+            // First create a trust list
+            const createDto: TrustListCreateDto = {
+                id: "public-access-test",
+                description: "Public Access Test",
+                keyChainId: "570852d7-7e7f-40af-a0e3-a6ebffd75ed0",
+                entities: [
+                    {
+                        type: "internal",
+                        issuerKeyChainId:
+                            "9687a941-3f89-476b-b383-aa5fea1bac8e",
+                        revocationKeyChainId:
+                            "9687a941-3f89-476b-b383-aa5fea1baa8e",
+                        info: { name: "Public Access Provider", lang: "en" },
+                    },
+                ],
+            };
+
+            await request(ctx.app.getHttpServer())
+                .post("/trust-list")
+                .set("Authorization", `Bearer ${ctx.authToken}`)
+                .send(createDto)
+                .expect(201);
+
+            // Public URL should work without auth
+            const response = await request(ctx.app.getHttpServer())
+                .get("/issuers/root/trust-list/public-access-test")
+                .expect(200);
+
+            expect(response.text.split(".").length).toBe(3);
+        });
+    });
+});

--- a/apps/client/src/app/trust-list/trust-list-show/trust-list-show.component.ts
+++ b/apps/client/src/app/trust-list/trust-list-show/trust-list-show.component.ts
@@ -128,15 +128,15 @@ export class TrustListShowComponent implements OnInit {
   }
 
   getTrustedEntitiesCount(): number {
-    const data = this.trustList?.data as { TrustedEntitiesList?: unknown[] } | undefined;
-    return data?.TrustedEntitiesList?.length ?? 0;
+    const data = this.trustList?.data as { LoTE?: { TrustedEntitiesList?: unknown[] } } | undefined;
+    return data?.LoTE?.TrustedEntitiesList?.length ?? 0;
   }
 
   private buildPublicUrl(): void {
     if (this.trustList) {
       const baseUrl = this.apiService.getBaseUrl() || '';
       const tenantId = this.trustList.tenantId;
-      this.publicUrl = `${baseUrl}/${tenantId}/trust-list/${this.trustList.id}`;
+      this.publicUrl = `${baseUrl}/issuers/${tenantId}/trust-list/${this.trustList.id}`;
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes trust list (LoTE) JWT decoding and the public trust list URL in the client.

## Changes

### Backend — `trust-store.service.ts`
- **Fix LoTE JWT decoding**: The decoded JWT payload wraps the LoTE in a `{ LoTE: ... }` envelope. Updated `decodeJwt<LoTE>(jwt)` → `decodeJwt<{ LoTE: LoTE }>(jwt)` and adjusted all downstream accesses (`decoded.LoTE.TrustedEntitiesList`, `decoded.LoTE` passed to parser).

### Client — `trust-list-show.component.ts`
- **Fix entity count**: Aligned `getTrustedEntitiesCount()` with the `{ LoTE: { TrustedEntitiesList } }` envelope structure.
- **Fix public URL**: Added missing `/issuers/` path segment to the trust list public URL.

## Testing
- Verified trust list parsing with real LoTE JWTs
- Confirmed entity count displays correctly in trust list detail view
- Confirmed public URL resolves correctly