### PR TITLE
fix: recreate offer for issuance and presentation sessions

### DIFF
--- a/apps/client/src/app/issuance/issuance-offer/issuance-offer.component.ts
+++ b/apps/client/src/app/issuance/issuance-offer/issuance-offer.component.ts
@@ -252,11 +252,26 @@ export class IssuanceOfferComponent implements OnInit {
     this.form = new FormGroup({});
   }
 
-  ngOnInit() {
+  async ngOnInit() {
+    // Load required data first
+    const [configs, , issuanceConfig] = await Promise.all([
+      this.credentialConfigService.loadConfigurations(),
+      this.attributeProviderService
+        .getAll()
+        .then((providers) => (this.availableAttributeProviders = providers))
+        .catch(() => (this.availableAttributeProviders = [])),
+      this.issuanceConfigService.getConfig(),
+    ]);
+
+    this.credentialConfigs = configs;
+    this.issuanceConfig = issuanceConfig;
+    this.availableAuthServers = issuanceConfig?.authServers || [];
+
     // Check for pre-fill data from navigation state (recreate offer flow)
+    // Must be done BEFORE setting up subscriptions to avoid interference
     const prefillData = history.state?.offerRequest as OfferRequestDto | undefined;
     if (prefillData) {
-      this.prefillFromOffer(prefillData);
+      await this.prefillFromOffer(prefillData);
     }
 
     // Listen for credential config selection changes
@@ -287,28 +302,12 @@ export class IssuanceOfferComponent implements OnInit {
       });
     });
 
-    this.credentialConfigService
-      .loadConfigurations()
-      .then((response) => (this.credentialConfigs = response));
-
-    // Load available attribute providers
-    this.attributeProviderService
-      .getAll()
-      .then((providers) => (this.availableAttributeProviders = providers))
-      .catch(() => (this.availableAttributeProviders = []));
-
-    // Load issuance config to get available auth servers
-    this.issuanceConfigService.getConfig().then((config) => {
-      this.issuanceConfig = config;
-      this.availableAuthServers = config?.authServers || [];
-
-      // Pre-select preferred AS if set and we're already on auth-code-external flow
-      if (this.isAuthCodeExternalFlow && this.availableAuthServers.length > 0) {
-        this.configStepForm.patchValue({
-          authorization_server: this.getDefaultAuthServer(),
-        });
-      }
-    });
+    // Pre-select preferred AS if set and we're already on auth-code-external flow (and not prefilling)
+    if (!prefillData && this.isAuthCodeExternalFlow && this.availableAuthServers.length > 0) {
+      this.configStepForm.patchValue({
+        authorization_server: this.getDefaultAuthServer(),
+      });
+    }
   }
 
   async setClaimFormFields(credentialConfigIds: string[]) {
@@ -573,43 +572,114 @@ export class IssuanceOfferComponent implements OnInit {
   }
 
   /**
-   * Pre-fill the form from an existing offer request (recreate offer flow)
+   * Pre-fill the form from an existing offer request (recreate offer flow).
+   * This method is called before valueChanges subscriptions are set up,
+   * so we need to manually trigger form field setup.
    */
   private async prefillFromOffer(offer: OfferRequestDto): Promise<void> {
-    // Wait for credential configs to load
-    await this.credentialConfigService.loadConfigurations().then((configs) => {
-      this.credentialConfigs = configs;
-    });
+    // Configs are already loaded in ngOnInit before this is called
 
-    // Set form values across all steps
+    // Determine the correct flow type for the form
+    // The stored offer only has 'authorization_code' or 'pre_authorized_code',
+    // but the form distinguishes between 'authorization_code_external' and 'authorization_code_iae'
+    let formFlow: string = offer.flow || 'pre_authorized_code';
+    if (offer.flow === 'authorization_code') {
+      // Check if any selected credential configs have IAE configured
+      const hasIae = offer.credentialConfigurationIds?.some((id) => {
+        const config = this.credentialConfigs.find((c) => c.id === id);
+        return (config?.iaeActions?.length || 0) > 0;
+      });
+
+      // If configs have IAE and no external AS was specified, it was an IAE flow
+      // If an external AS was specified, it was an external AS flow
+      if (hasIae && !offer.authorization_server) {
+        formFlow = 'authorization_code_iae';
+      } else {
+        formFlow = 'authorization_code_external';
+      }
+    }
+
+    // Set flow (triggers no subscription since we haven't set them up yet)
     this.flowStepForm.patchValue({
-      flow: offer.flow || 'pre_authorized_code',
+      flow: formFlow,
     });
 
+    // Set credential configuration IDs
     this.credentialStepForm.patchValue({
       credentialConfigurationIds: offer.credentialConfigurationIds || [],
     });
 
+    // Manually set up claim form fields (normally done by valueChanges subscription)
+    await this.setClaimFormFields(offer.credentialConfigurationIds || []);
+
+    // Determine AS type for external AS flow
+    let asType = 'external';
+    if (formFlow === 'authorization_code_external') {
+      // If no authorization_server was specified but chained AS is enabled, it was chained
+      if (!offer.authorization_server && this.isChainedAsEnabled) {
+        asType = 'chained';
+      }
+    }
+
+    // Set config step values
     this.configStepForm.patchValue({
       tx_code: offer.tx_code || '',
-      authorization_server: offer.authorization_server || '',
+      tx_code_description: offer.tx_code_description || '',
+      authorization_server: offer.authorization_server || this.getDefaultAuthServer(),
+      as_type: asType,
     });
 
-    // Pre-fill claims after the form fields are generated (only for pre-auth flow)
-    if (offer.credentialClaims && offer.flow === 'pre_authorized_code') {
-      // Wait for form fields to be set up
-      setTimeout(() => {
-        for (const [credId, claimData] of Object.entries(offer.credentialClaims || {})) {
-          const element = this.elements.find((e) => e.id === credId);
-          if (element && claimData.type === 'inline') {
+    // Pre-fill claims for pre-auth flow
+    if (offer.credentialClaims && formFlow === 'pre_authorized_code') {
+      for (const [credId, claimData] of Object.entries(offer.credentialClaims)) {
+        const element = this.elements.find((e) => e.id === credId);
+        if (element && claimData && typeof claimData === 'object') {
+          if ('type' in claimData && claimData.type === 'inline' && 'claims' in claimData) {
             element.claimSource = 'form';
             this.configStepForm.get('claims')?.patchValue({ [credId]: claimData.claims });
-          } else if (element && claimData.type === 'attributeProvider') {
+          } else if ('type' in claimData && claimData.type === 'attributeProvider') {
             element.claimSource = 'attributeProvider';
           }
         }
-        this.cdr.detectChanges();
-      }, 100);
+      }
+    }
+
+    // Pre-fill attribute provider for auth code flows
+    if (
+      offer.credentialClaims &&
+      (formFlow === 'authorization_code_external' || formFlow === 'authorization_code_iae')
+    ) {
+      for (const [credId, claimData] of Object.entries(offer.credentialClaims)) {
+        if (
+          claimData &&
+          typeof claimData === 'object' &&
+          'type' in claimData &&
+          claimData.type === 'attributeProvider' &&
+          'attributeProviderId' in claimData
+        ) {
+          const webhookForm = this.externalAsWebhooks.get(credId);
+          if (webhookForm) {
+            webhookForm.patchValue({
+              attributeProviderId: claimData.attributeProviderId,
+            });
+          }
+        }
+      }
+    }
+
+    this.cdr.detectChanges();
+
+    // Jump stepper to the last step — by the time prefillFromOffer runs
+    // (after awaiting data loads), the view is already initialized
+    if (this.stepper) {
+      this.stepper.steps.forEach((step, index) => {
+        if (index < this.stepper.steps.length - 1) {
+          step.completed = true;
+          step.interacted = true;
+        }
+      });
+      this.stepper.selectedIndex = this.stepper.steps.length - 1;
+      this.cdr.detectChanges();
     }
 
     this.snackBar.open('Form pre-filled from previous offer', 'Close', { duration: 2000 });

--- a/apps/client/src/app/presentation/presentation-request/presentation-request.component.ts
+++ b/apps/client/src/app/presentation/presentation-request/presentation-request.component.ts
@@ -78,7 +78,14 @@ export class PresentationRequestComponent implements OnInit {
     this.loading = true;
     try {
       this.configs = await this.presentationManagementService.loadConfigurations();
-      if (this.route.snapshot.params['id']) {
+
+      // Check for pre-fill data from navigation state (recreate offer flow)
+      const prefillData = history.state?.presentationRequest as
+        | { requestId: string }
+        | undefined;
+      if (prefillData?.requestId) {
+        this.form.patchValue({ requestId: prefillData.requestId });
+      } else if (this.route.snapshot.params['id']) {
         this.form.patchValue({ requestId: this.route.snapshot.params['id'] });
         //since we do not have any other values for now, we can submit the form
         this.onSubmit();

--- a/apps/client/src/app/presentation/presentation-request/presentation-request.component.ts
+++ b/apps/client/src/app/presentation/presentation-request/presentation-request.component.ts
@@ -80,9 +80,7 @@ export class PresentationRequestComponent implements OnInit {
       this.configs = await this.presentationManagementService.loadConfigurations();
 
       // Check for pre-fill data from navigation state (recreate offer flow)
-      const prefillData = history.state?.presentationRequest as
-        | { requestId: string }
-        | undefined;
+      const prefillData = history.state?.presentationRequest as { requestId: string } | undefined;
       if (prefillData?.requestId) {
         this.form.patchValue({ requestId: prefillData.requestId });
       } else if (this.route.snapshot.params['id']) {

--- a/apps/client/src/app/session-management/session-management-show/session-management-show.component.html
+++ b/apps/client/src/app/session-management/session-management-show/session-management-show.component.html
@@ -26,10 +26,14 @@
           <button
             mat-button
             (click)="recreateOffer()"
-            matTooltip="Create a new offer with the same parameters"
+            [matTooltip]="
+              isIssuanceSession()
+                ? 'Create a new offer with the same parameters'
+                : 'Create a new request with the same parameters'
+            "
           >
             <mat-icon>replay</mat-icon>
-            Recreate Offer
+            {{ isIssuanceSession() ? 'Recreate Offer' : 'Recreate Request' }}
           </button>
         }
         <button matIconButton (click)="goBack()" matTooltip="Go back">

--- a/apps/client/src/app/session-management/session-management-show/session-management-show.component.ts
+++ b/apps/client/src/app/session-management/session-management-show/session-management-show.component.ts
@@ -48,16 +48,23 @@ export class SessionManagementShowComponent implements OnInit, OnDestroy {
    * Check if this session can be recreated as a new offer
    */
   canRecreateOffer(): boolean {
-    return !!(this.session?.credentialPayload && this.isIssuanceSession());
+    if (this.isIssuanceSession()) {
+      return !!this.session?.credentialPayload;
+    }
+    return !!this.session?.requestId;
   }
 
   /**
-   * Navigate to issuance offer page with the stored payload to recreate the offer
+   * Navigate to the appropriate offer page to recreate the offer
    */
   recreateOffer(): void {
-    if (this.session?.credentialPayload) {
+    if (this.isIssuanceSession() && this.session?.credentialPayload) {
       this.router.navigate(['/offer/issuance'], {
         state: { offerRequest: this.session.credentialPayload },
+      });
+    } else if (!this.isIssuanceSession() && this.session?.requestId) {
+      this.router.navigate(['/offer/presentation'], {
+        state: { presentationRequest: { requestId: this.session.requestId } },
       });
     }
   }


### PR DESCRIPTION
## Summary

Fixes #502 — the "Recreate Offer" feature was broken for issuance sessions and missing for presentation sessions.

## Changes

### Issuance recreate offer fix
- **Flow type mapping**: `OfferRequestDto` stores 2 flow types (`authorization_code` | `pre_authorized_code`) but the form UI uses 3 values. `prefillFromOffer()` now correctly maps `authorization_code` → `authorization_code_external` or `authorization_code_iae` based on the credential config's IAE actions and authorization_server field.
- **Race conditions**: Refactored `ngOnInit()` to `async` with `Promise.all()` — all configs are loaded before prefilling. Value change subscriptions are set up *after* prefill to avoid interference.
- **Stepper navigation**: When recreating, the stepper now jumps directly to the last step so the user can review and submit immediately.

### Presentation recreate request (new)
- `canRecreateOffer()` now returns `true` for presentation sessions that have a `requestId`.
- `recreateOffer()` navigates to `/offer/presentation` with the `requestId` in navigation state.
- `PresentationRequestComponent` picks up the prefill data and patches the form.
- Button text dynamically shows "Recreate Offer" or "Recreate Request" depending on session type.

## Files changed
- `apps/client/src/app/issuance/issuance-offer/issuance-offer.component.ts`
- `apps/client/src/app/presentation/presentation-request/presentation-request.component.ts`
- `apps/client/src/app/session-management/session-management-show/session-management-show.component.ts`
- `apps/client/src/app/session-management/session-management-show/session-management-show.component.html`