### PR TITLE
fix: move status_list_aggregation_endpoint to AS metadata

### DIFF
--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
           run_install: false
@@ -67,7 +67,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
           run_install: false
@@ -92,7 +92,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
           run_install: false
@@ -117,7 +117,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
           run_install: false
@@ -145,7 +145,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
           run_install: false
@@ -170,7 +170,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
           run_install: false
@@ -221,7 +221,7 @@ jobs:
         with:
           fetch-depth: 0 # Fetch full history for mike versioning
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
           run_install: false
@@ -272,7 +272,7 @@ jobs:
       - name: Add entry to /etc/hosts
         run: echo "127.0.0.1       host.testcontainers.internal" | sudo tee -a /etc/hosts
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
           run_install: false
@@ -650,7 +650,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
           run_install: false
@@ -705,7 +705,7 @@ jobs:
         with:
           fetch-depth: 0 # Fetch full history for mike versioning
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
           run_install: false

--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -43,7 +43,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Run linter for code
         run: pnpm run lint
@@ -79,7 +79,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build SDK Core
         run: pnpm --filter @eudiplo/sdk-core build
@@ -104,7 +104,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build backend
         run: pnpm --filter @eudiplo/backend build
@@ -129,7 +129,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build sdk core
         run: pnpm --filter @eudiplo/sdk-core build
@@ -157,7 +157,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build webhook
         run: pnpm --filter test-rp build
@@ -182,7 +182,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -233,7 +233,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -284,7 +284,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: setup test webhooks
         run: |
@@ -332,7 +332,7 @@ jobs:
       fail-fast: false
       matrix:
         # Dynamic matrix: include arm64 only on main branch push
-        include: "${{ fromJSON(github.event_name == 'push' && github.ref == 'refs/heads/main' && '[{\"platform\": \"linux/amd64\", \"runner\": \"ubuntu-latest\", \"arch\": \"amd64\"}, {\"platform\": \"linux/arm64\", \"runner\": \"ubuntu-24.04-arm\", \"arch\": \"arm64\"}]' || '[{\"platform\": \"linux/amd64\", \"runner\": \"ubuntu-latest\", \"arch\": \"amd64\"}]') }}"
+        include: '${{ fromJSON(github.event_name == ''push'' && github.ref == ''refs/heads/main'' && ''[{"platform": "linux/amd64", "runner": "ubuntu-latest", "arch": "amd64"}, {"platform": "linux/arm64", "runner": "ubuntu-24.04-arm", "arch": "arm64"}]'' || ''[{"platform": "linux/amd64", "runner": "ubuntu-latest", "arch": "amd64"}]'') }}'
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -527,7 +527,7 @@ jobs:
       fail-fast: false
       matrix:
         # Dynamic matrix: include arm64 only on main branch push
-        include: "${{ fromJSON(github.event_name == 'push' && github.ref == 'refs/heads/main' && '[{\"platform\": \"linux/amd64\", \"runner\": \"ubuntu-latest\", \"arch\": \"amd64\"}, {\"platform\": \"linux/arm64\", \"runner\": \"ubuntu-24.04-arm\", \"arch\": \"arm64\"}]' || '[{\"platform\": \"linux/amd64\", \"runner\": \"ubuntu-latest\", \"arch\": \"amd64\"}]') }}"
+        include: '${{ fromJSON(github.event_name == ''push'' && github.ref == ''refs/heads/main'' && ''[{"platform": "linux/amd64", "runner": "ubuntu-latest", "arch": "amd64"}, {"platform": "linux/arm64", "runner": "ubuntu-24.04-arm", "arch": "arm64"}]'' || ''[{"platform": "linux/amd64", "runner": "ubuntu-latest", "arch": "amd64"}]'') }}'
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -663,7 +663,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build SDK
         run: pnpm --filter @eudiplo/sdk-core build
@@ -718,7 +718,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build SDK
         run: pnpm --filter @eudiplo/sdk-core build

--- a/apps/backend/src/issuer/issuance/oid4vci/authorize/authorize.service.ts
+++ b/apps/backend/src/issuer/issuance/oid4vci/authorize/authorize.service.ts
@@ -21,6 +21,7 @@ import { KeyChainService } from "../../../../crypto/key/key-chain.service";
 import { SessionService } from "../../../../session/session.service";
 import { WalletAttestationService } from "../../../../shared/trust/wallet-attestation.service";
 import { IssuanceService } from "../../../configuration/issuance/issuance.service";
+import { StatusListConfigService } from "../../../lifecycle/status/status-list-config.service";
 import { NonceEntity } from "../entities/nonces.entity";
 import { TokenErrorException } from "../exceptions";
 import { getHeadersFromRequest } from "../util";
@@ -50,6 +51,7 @@ export class AuthorizeService {
         private readonly keyChainService: KeyChainService,
         @InjectRepository(NonceEntity)
         private readonly nonceRepository: Repository<NonceEntity>,
+        private readonly statusListConfigService: StatusListConfigService,
     ) {}
 
     getAuthorizationServer(
@@ -120,7 +122,15 @@ export class AuthorizeService {
 
         const publicUrl = this.configService.getOrThrow<string>("PUBLIC_URL");
         const authServer = this.getAuthzIssuer(tenantId);
-        const metadata: Record<string, unknown> = {
+
+        // Check if status list aggregation is enabled for this tenant
+        const statusListConfig =
+            await this.statusListConfigService.getEffectiveConfig(tenantId);
+        const statusListAggregationEndpoint = statusListConfig.enableAggregation
+            ? `${authServer}/status-management/status-list-aggregation`
+            : undefined;
+
+        const metadata: AuthorizationServerMetadata = {
             issuer: authServer,
             token_endpoint: `${authServer}/authorize/token`,
             authorization_endpoint: `${authServer}/authorize`,
@@ -137,6 +147,7 @@ export class AuthorizeService {
             code_challenge_methods_supported: [PkceCodeChallengeMethod.S256],
             authorization_details_types_supported: ["openid_credential"],
             token_endpoint_auth_methods_supported: ["none"],
+            status_list_aggregation_endpoint: statusListAggregationEndpoint,
         };
 
         if (walletAttestationRequired) {

--- a/apps/backend/src/issuer/issuance/oid4vci/oid4vci.service.ts
+++ b/apps/backend/src/issuer/issuance/oid4vci/oid4vci.service.ts
@@ -48,7 +48,6 @@ import { AuthorizationIdentity } from "../../configuration/credentials/dto/autho
 import { ClaimsWebhookResult } from "../../configuration/credentials/dto/claims-webhook-result";
 import { IssuanceService } from "../../configuration/issuance/issuance.service";
 import { WebhookEndpointEntity } from "../../configuration/webhook-endpoint/entities/webhook-endpoint.entity";
-import { StatusListConfigService } from "../../lifecycle/status/status-list-config.service";
 import { AuthorizeService } from "./authorize/authorize.service";
 import { ChainedAsService } from "./chained-as/chained-as.service";
 import { DeferredCredentialService } from "./deferred-credential.service";
@@ -98,7 +97,6 @@ export class Oid4vciService {
         private readonly issuanceService: IssuanceService,
         private readonly webhookService: WebhookService,
         private readonly httpService: HttpService,
-        private readonly statusListConfigService: StatusListConfigService,
         private readonly chainedAsService: ChainedAsService,
         private readonly deferredCredentialService: DeferredCredentialService,
         private readonly traceService: TraceService,
@@ -240,13 +238,6 @@ export class Oid4vciService {
             }
         }
 
-        // Check if status list aggregation is enabled for this tenant
-        const statusListConfig =
-            await this.statusListConfigService.getEffectiveConfig(tenantId);
-        const statusListAggregationEndpoint = statusListConfig.enableAggregation
-            ? `${credential_issuer}/status-management/status-list-aggregation`
-            : undefined;
-
         const credentialIssuer = issuer.createCredentialIssuerMetadata({
             credential_issuer,
             credential_configurations_supported:
@@ -273,7 +264,6 @@ export class Oid4vciService {
                           batch_size: issuanceConfig?.batchSize,
                       }
                     : undefined,
-            status_list_aggregation_endpoint: statusListAggregationEndpoint,
         });
         return {
             credentialIssuer,

--- a/apps/backend/test/issuance/issuance-iae.e2e-spec.ts
+++ b/apps/backend/test/issuance/issuance-iae.e2e-spec.ts
@@ -379,6 +379,47 @@ describe("Interactive Authorization Endpoint (IAE)", () => {
                 "/authorize/interactive",
             );
         });
+
+        test("should include status_list_aggregation_endpoint in metadata when aggregation is enabled", async () => {
+            const response = await request(app.getHttpServer())
+                .get(
+                    `/.well-known/oauth-authorization-server/issuers/${tenantId}`,
+                )
+                .expect(200);
+
+            expect(
+                response.body.status_list_aggregation_endpoint,
+            ).toBeDefined();
+            expect(response.body.status_list_aggregation_endpoint).toContain(
+                "/status-management/status-list-aggregation",
+            );
+        });
+
+        test("should not include status_list_aggregation_endpoint when aggregation is disabled", async () => {
+            // Disable aggregation for this tenant
+            await request(app.getHttpServer())
+                .put("/status-list-config")
+                .set("Authorization", `Bearer ${authToken}`)
+                .send({ enableAggregation: false })
+                .expect(200);
+
+            const response = await request(app.getHttpServer())
+                .get(
+                    `/.well-known/oauth-authorization-server/issuers/${tenantId}`,
+                )
+                .expect(200);
+
+            expect(
+                response.body.status_list_aggregation_endpoint,
+            ).toBeUndefined();
+
+            // Re-enable aggregation to not affect other tests
+            await request(app.getHttpServer())
+                .put("/status-list-config")
+                .set("Authorization", `Bearer ${authToken}`)
+                .send({ enableAggregation: true })
+                .expect(200);
+        });
     });
 
     describe("Multi-step IAE Flow", () => {


### PR DESCRIPTION
## Summary

Moves the `status_list_aggregation_endpoint` from the credential issuer metadata (`.well-known/openid-credential-issuer`) to the authorization server metadata (`.well-known/oauth-authorization-server`), aligning with RFC 9528.

## Changes

- **authorize.service.ts**: Added `status_list_aggregation_endpoint` to the AS metadata response (conditionally based on tenant's `enableAggregation` config)
- **oid4vci.service.ts**: Removed `status_list_aggregation_endpoint` from credential issuer metadata
- **issuance-iae.e2e-spec.ts**: Added e2e tests verifying:
  - The endpoint is present in AS metadata when aggregation is enabled (default)
  - The endpoint is absent from AS metadata when aggregation is disabled