### PR TITLE
feat: implement OID4VP Section 13.3 direct_post security model

### DIFF
--- a/apps/backend/src/database/migrations/1751000000000-AddDirectPostSecurityFields.ts
+++ b/apps/backend/src/database/migrations/1751000000000-AddDirectPostSecurityFields.ts
@@ -1,0 +1,83 @@
+import { MigrationInterface, QueryRunner, TableColumn } from "typeorm";
+
+/**
+ * Add walletNonce and responseCode columns to session table.
+ *
+ * Per OID4VP spec Section 13.3 (direct_post response mode security):
+ * - walletNonce: Separates wallet-facing identifier (request-id) from
+ *   session ID (transaction-id) to prevent session fixation.
+ * - responseCode: Generated after VP Token processing, included in
+ *   redirect_uri so only the legitimate frontend can confirm completion.
+ */
+export class AddDirectPostSecurityFields1751000000000
+    implements MigrationInterface
+{
+    name = "AddDirectPostSecurityFields1751000000000";
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const table = await queryRunner.getTable("session");
+        if (!table) {
+            console.log(
+                "[Migration] session table not found — skipping (schema may not exist yet).",
+            );
+            return;
+        }
+
+        const hasWalletNonce = table.columns.some(
+            (col) => col.name === "walletNonce",
+        );
+        if (!hasWalletNonce) {
+            await queryRunner.addColumn(
+                "session",
+                new TableColumn({
+                    name: "walletNonce",
+                    type: "varchar",
+                    isNullable: true,
+                }),
+            );
+            console.log("[Migration] Added walletNonce column to session.");
+        } else {
+            console.log(
+                "[Migration] walletNonce column already exists — skipping.",
+            );
+        }
+
+        const hasResponseCode = table.columns.some(
+            (col) => col.name === "responseCode",
+        );
+        if (!hasResponseCode) {
+            await queryRunner.addColumn(
+                "session",
+                new TableColumn({
+                    name: "responseCode",
+                    type: "varchar",
+                    isNullable: true,
+                }),
+            );
+            console.log("[Migration] Added responseCode column to session.");
+        } else {
+            console.log(
+                "[Migration] responseCode column already exists — skipping.",
+            );
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const table = await queryRunner.getTable("session");
+        if (table) {
+            const hasResponseCode = table.columns.some(
+                (col) => col.name === "responseCode",
+            );
+            if (hasResponseCode) {
+                await queryRunner.dropColumn("session", "responseCode");
+            }
+
+            const hasWalletNonce = table.columns.some(
+                (col) => col.name === "walletNonce",
+            );
+            if (hasWalletNonce) {
+                await queryRunner.dropColumn("session", "walletNonce");
+            }
+        }
+    }
+}

--- a/apps/backend/src/database/migrations/index.ts
+++ b/apps/backend/src/database/migrations/index.ts
@@ -16,3 +16,4 @@ export { MigrateKeysToKeyChain1747000000000 } from "./1747000000000-MigrateKeysT
 export { ExtractAttributeProviderAndWebhookEndpoint1748000000000 } from "./1748000000000-ExtractAttributeProviderAndWebhookEndpoint";
 export { AddSessionLogEntry1749000000000 } from "./1749000000000-AddSessionLogEntry";
 export { AddSessionErrorReason1750000000000 } from "./1750000000000-AddSessionErrorReason";
+export { AddDirectPostSecurityFields1751000000000 } from "./1751000000000-AddDirectPostSecurityFields";

--- a/apps/backend/src/session/entities/session.entity.ts
+++ b/apps/backend/src/session/entities/session.entity.ts
@@ -194,6 +194,22 @@ export class Session {
     clientId?: string;
 
     /**
+     * Cryptographic random nonce used in wallet-facing URLs (response_uri, request_uri, state).
+     * Per OID4VP spec Section 13.3, this separates the wallet-facing identifier (request-id)
+     * from the frontend-facing session ID (transaction-id) to prevent session fixation.
+     */
+    @Column("varchar", { nullable: true })
+    walletNonce?: string;
+
+    /**
+     * Cryptographic random code generated after successful VP Token processing.
+     * Per OID4VP spec Section 13.3, included in redirect_uri so only the legitimate
+     * frontend (which receives the redirect) can confirm the session completed.
+     */
+    @Column("varchar", { nullable: true })
+    responseCode?: string;
+
+    /**
      * Response URI used in the OID4VP authorization request.
      */
     @Column("varchar", { nullable: true })

--- a/apps/backend/src/session/session.service.ts
+++ b/apps/backend/src/session/session.service.ts
@@ -183,6 +183,14 @@ export class SessionService implements OnApplicationBootstrap {
     }
 
     /**
+     * Find a session by its walletNonce (used in wallet-facing URLs).
+     * Returns null if no session matches.
+     */
+    findByWalletNonce(nonce: string) {
+        return this.sessionRepository.findOneBy({ walletNonce: nonce });
+    }
+
+    /**
      * Get a session by a specific condition.
      * @param where
      * @returns

--- a/apps/backend/src/verifier/oid4vp/oid4vp.service.ts
+++ b/apps/backend/src/verifier/oid4vp/oid4vp.service.ts
@@ -39,6 +39,20 @@ export class Oid4vpService {
     ) {}
 
     /**
+     * Resolves a session from a wallet-facing nonce.
+     * Per OID4VP spec Section 13.3, wallet-facing URLs use a separate walletNonce
+     * instead of the session ID. Falls back to session ID lookup for backward
+     * compatibility with sessions created before the walletNonce migration.
+     */
+    private async resolveSessionByNonce(nonce: string) {
+        const session = await this.sessionService.findByWalletNonce(nonce);
+        if (session) {
+            return session;
+        }
+        return this.sessionService.get(nonce);
+    }
+
+    /**
      * Gets the authorization request for a session.
      * Returns the cached requestObject if available (for request_uri_method="get"),
      * otherwise generates a new one.
@@ -48,11 +62,11 @@ export class Oid4vpService {
      */
     @Span("oid4vp.getAuthorizationRequest")
     async getAuthorizationRequest(
-        sessionId: string,
+        nonce: string,
         origin: string,
         noRedirect = false,
     ): Promise<string> {
-        const session = await this.sessionService.get(sessionId);
+        const session = await this.resolveSessionByNonce(nonce);
 
         // Add session context to span for trace correlation
         const span = this.traceService.getSpan();
@@ -76,7 +90,7 @@ export class Oid4vpService {
         }
 
         // No cached request - generate new one (for request_uri_method="post" flows)
-        return this.createAuthorizationRequest(sessionId, origin, noRedirect);
+        return this.createAuthorizationRequest(session.id, origin, noRedirect);
     }
 
     /**
@@ -187,11 +201,16 @@ export class Oid4vpService {
                 )?.map((td) => base64url.encode(JSON.stringify(td))) ||
                 undefined;
 
+            // Per OID4VP spec Section 13.3: use walletNonce in wallet-facing URLs
+            // to separate the wallet-facing identifier (request-id) from the
+            // frontend-facing session ID (transaction-id).
+            const walletFacingId = session.walletNonce ?? session.id;
+
             const request = {
                 payload: {
                     response_type: "vp_token",
                     client_id: "x509_hash:" + certHash,
-                    response_uri: `${host}/presentations/${session.id}/oid4vp`,
+                    response_uri: `${host}/presentations/${walletFacingId}/oid4vp`,
                     response_mode: session.useDcApi
                         ? "dc_api.jwt"
                         : "direct_post.jwt",
@@ -222,7 +241,7 @@ export class Oid4vpService {
                             "A256GCM",
                         ],
                     },
-                    state: session.useDcApi ? undefined : session.id,
+                    state: session.useDcApi ? undefined : walletFacingId,
                     transaction_data,
                     //TODO: check if this value is correct accroding to https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#name-aud-of-a-request-object
                     aud: "https://self-issued.me/v2",
@@ -287,6 +306,11 @@ export class Oid4vpService {
         const fresh = values.session === undefined;
         values.session = values.session || v4();
 
+        // Per OID4VP spec Section 13.3: generate a separate walletNonce for
+        // wallet-facing URLs so the QR code / request_uri does not reveal the
+        // session ID (transaction-id) used by the frontend for polling.
+        const walletNonce = randomUUID();
+
         const request_uri_method: "get" | "post" = "get";
 
         const cert = await this.certService.find({
@@ -298,7 +322,7 @@ export class Oid4vpService {
 
         const params = {
             client_id: "x509_hash:" + certHash,
-            request_uri: `${this.configService.getOrThrow<string>("PUBLIC_URL")}/presentations/${values.session}/oid4vp/request`,
+            request_uri: `${this.configService.getOrThrow<string>("PUBLIC_URL")}/presentations/${walletNonce}/oid4vp/request`,
             request_uri_method,
         };
         const queryString = Object.entries(params)
@@ -311,7 +335,7 @@ export class Oid4vpService {
         // Create cross-device params with /no-redirect appended to request_uri
         const crossDeviceParams = {
             ...params,
-            request_uri: `${this.configService.getOrThrow<string>("PUBLIC_URL")}/presentations/${values.session}/oid4vp/request/no-redirect`,
+            request_uri: `${this.configService.getOrThrow<string>("PUBLIC_URL")}/presentations/${walletNonce}/oid4vp/request/no-redirect`,
         };
         const crossDeviceQueryString = Object.entries(crossDeviceParams)
             .map(
@@ -329,7 +353,7 @@ export class Oid4vpService {
             const clientId = "x509_hash:" + certHash;
             const responseUri = useDcApi
                 ? undefined
-                : `${host}/presentations/${values.session}/oid4vp`;
+                : `${host}/presentations/${walletNonce}/oid4vp`;
 
             // Use transaction_data from options if provided, otherwise fall back to config
             const transaction_data =
@@ -337,6 +361,7 @@ export class Oid4vpService {
 
             const session = await this.sessionService.create({
                 id: values.session,
+                walletNonce,
                 parsedWebhook: values.webhook,
                 redirectUri:
                     values.redirectUri ??
@@ -363,7 +388,7 @@ export class Oid4vpService {
             }
         } else {
             await this.sessionService.add(values.session, {
-                //claimsWebhook: values.webhook ?? presentationConfig.webhook,
+                walletNonce,
                 requestUrl: `openid4vp://?${queryString}`,
                 expiresAt,
                 useDcApi,
@@ -379,12 +404,14 @@ export class Oid4vpService {
 
     /**
      * Processes the response from the wallet.
+     * Per OID4VP spec Section 13.3, the nonce parameter is the walletNonce
+     * from the URL path (not the session ID).
      * @param body
-     * @param tenantId
+     * @param nonce - walletNonce from the URL path (or session ID for legacy sessions)
      */
     @Span("oid4vp.getResponse")
-    async getResponse(body: AuthorizationResponse, sessionId: string) {
-        const session = await this.sessionService.get(sessionId);
+    async getResponse(body: AuthorizationResponse, nonce: string) {
+        const session = await this.resolveSessionByNonce(nonce);
 
         // Add session context to span for trace correlation
         const span = this.traceService.getSpan();
@@ -393,6 +420,9 @@ export class Oid4vpService {
             "session.tenantId": session.tenantId,
             "session.requestId": session.requestId ?? "",
         });
+
+        // The expected state value is the walletNonce (or session.id for legacy sessions)
+        const expectedState = session.walletNonce ?? session.id;
 
         // Handle wallet error responses per OID4VP spec section 6.2
         // When wallet cannot fulfill the request, it sends an OAuth 2.0 error response
@@ -504,22 +534,24 @@ export class Oid4vpService {
                 },
             );
 
+            // Validate state matches the expected walletNonce / session ID
             // For DC API, state is not included in the response (per OID4VP spec).
-            // Use sessionId from URL path as fallback.
-            const effectiveSessionId = res.state ?? sessionId;
-
-            // Validate state matches sessionId when provided (prevents session hijacking)
-            if (res.state && res.state !== sessionId) {
+            if (res.state && res.state !== expectedState) {
                 throw new BadRequestException(
-                    "State mismatch: response state does not match session ID",
+                    "State mismatch: response state does not match expected value",
                 );
             }
 
-            //tell the auth server the result of the session.
-            await this.sessionService.add(effectiveSessionId, {
+            // Per OID4VP spec Section 13.3: generate a response_code after successful
+            // VP Token processing. This is included in redirect_uri so only the
+            // legitimate frontend (which receives the redirect) can confirm completion.
+            const responseCode = randomUUID();
+
+            await this.sessionService.add(session.id, {
                 //TODO: not clear why it has to be any
                 credentials: credentials as any,
                 status: SessionStatus.Completed,
+                responseCode,
             });
             // if there a a webhook passed in the session, use it
             if (webhook) {
@@ -565,8 +597,13 @@ export class Oid4vpService {
                 const processedRedirectUri = decodeURIComponent(
                     session.redirectUri,
                 ).replaceAll("{sessionId}", session.id);
+                // Per OID4VP spec Section 13.3: include response_code in redirect_uri
+                // so the frontend can use it to confirm the session completed legitimately.
+                const separator = processedRedirectUri.includes("?")
+                    ? "&"
+                    : "?";
                 return {
-                    redirect_uri: processedRedirectUri,
+                    redirect_uri: `${processedRedirectUri}${separator}response_code=${responseCode}`,
                 };
             }
 

--- a/apps/backend/test/presentation/presentation-direct-post-security.e2e-spec.ts
+++ b/apps/backend/test/presentation/presentation-direct-post-security.e2e-spec.ts
@@ -1,0 +1,542 @@
+import "reflect-metadata";
+import { INestApplication } from "@nestjs/common";
+import {
+    Openid4vpAuthorizationRequest,
+    Openid4vpClient,
+} from "@openid4vc/openid4vp";
+import { CryptoKey, decodeJwt } from "jose";
+import request from "supertest";
+import { App } from "supertest/types";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { StatusListService } from "../../src/issuer/lifecycle/status/status-list.service";
+import { ResponseType } from "../../src/verifier/oid4vp/dto/presentation-request.dto";
+import {
+    callbacks,
+    createPresentationRequest,
+    createTestFetch,
+    encryptVpToken,
+    PresentationTestContext,
+    preparePresentation,
+    setupPresentationTestApp,
+} from "../utils";
+
+/**
+ * E2E tests for OID4VP Section 13.3 — direct_post response mode security.
+ *
+ * Validates:
+ *  - walletNonce / session ID separation (transaction-id vs request-id)
+ *  - Authorization request JWT uses walletNonce in state & response_uri
+ *  - response_code generation and inclusion in redirect_uri
+ *  - Frontend polling uses session ID (not walletNonce)
+ *  - Session ID is not exposed in wallet-facing URLs
+ */
+describe("Presentation - Direct Post Security (Section 13.3)", () => {
+    let app: INestApplication<App>;
+    let authToken: string;
+    let host: string;
+    let privateIssuerKey: CryptoKey;
+    let issuerCertChain: string[];
+    let statusListService: StatusListService;
+    let ctx: PresentationTestContext;
+
+    const credentialConfigId = "pid";
+
+    let client: Openid4vpClient;
+
+    beforeAll(async () => {
+        ctx = await setupPresentationTestApp();
+        app = ctx.app;
+        authToken = ctx.authToken;
+        host = ctx.host;
+        privateIssuerKey = ctx.privateIssuerKey;
+        issuerCertChain = ctx.issuerCertChain;
+        statusListService = ctx.statusListService;
+
+        client = new Openid4vpClient({
+            callbacks: {
+                ...callbacks,
+                fetch: createTestFetch(app, () => host),
+            },
+        });
+    });
+
+    afterAll(async () => {
+        await app.close();
+    });
+
+    // ─── walletNonce / session ID separation ───────────────────────────
+
+    test("offer response returns session ID that differs from walletNonce in request_uri", async () => {
+        const res = await createPresentationRequest(app, authToken, {
+            response_type: ResponseType.URI,
+            requestId: "pid-no-hook",
+        });
+
+        expect(res.status).toBe(201);
+
+        const sessionId: string = res.body.session;
+        const uri: string = res.body.uri;
+
+        // Extract the walletNonce from request_uri in the uri query string
+        const requestUriParam = new URLSearchParams(uri).get("request_uri")!;
+        // request_uri format: {host}/presentations/{walletNonce}/oid4vp/request
+        const walletNonce = requestUriParam
+            .split("/presentations/")[1]
+            .split("/oid4vp")[0];
+
+        expect(sessionId).toBeDefined();
+        expect(walletNonce).toBeDefined();
+        // The walletNonce used in wallet-facing URLs must be different from the session ID
+        expect(walletNonce).not.toBe(sessionId);
+    });
+
+    test("crossDeviceUri also uses walletNonce, not session ID", async () => {
+        const res = await createPresentationRequest(app, authToken, {
+            response_type: ResponseType.URI,
+            requestId: "pid-no-hook",
+        });
+
+        const sessionId: string = res.body.session;
+        const crossDeviceUri: string = res.body.crossDeviceUri;
+
+        const requestUriParam = new URLSearchParams(crossDeviceUri).get(
+            "request_uri",
+        )!;
+        const walletNonce = requestUriParam
+            .split("/presentations/")[1]
+            .split("/oid4vp")[0];
+
+        expect(walletNonce).not.toBe(sessionId);
+    });
+
+    // ─── Authorization request JWT validation ──────────────────────────
+
+    test("authorization request JWT state matches walletNonce (not session ID)", async () => {
+        const res = await createPresentationRequest(app, authToken, {
+            response_type: ResponseType.URI,
+            requestId: "pid-no-hook",
+        });
+
+        const sessionId: string = res.body.session;
+        const uri: string = res.body.uri;
+        const requestUriParam = new URLSearchParams(uri).get("request_uri")!;
+        const walletNonce = requestUriParam
+            .split("/presentations/")[1]
+            .split("/oid4vp")[0];
+
+        // Fetch the authorization request JWT via the wallet-facing endpoint
+        const authReqRes = await request(app.getHttpServer())
+            .get(`/presentations/${walletNonce}/oid4vp/request`)
+            .trustLocalhost()
+            .expect(200);
+
+        const jwt = authReqRes.text;
+        const payload = decodeJwt(jwt);
+
+        // state in the JWT must be the walletNonce
+        expect(payload.state).toBe(walletNonce);
+        expect(payload.state).not.toBe(sessionId);
+    });
+
+    test("authorization request JWT response_uri contains walletNonce (not session ID)", async () => {
+        const res = await createPresentationRequest(app, authToken, {
+            response_type: ResponseType.URI,
+            requestId: "pid-no-hook",
+        });
+
+        const sessionId: string = res.body.session;
+        const uri: string = res.body.uri;
+        const requestUriParam = new URLSearchParams(uri).get("request_uri")!;
+        const walletNonce = requestUriParam
+            .split("/presentations/")[1]
+            .split("/oid4vp")[0];
+
+        const authReqRes = await request(app.getHttpServer())
+            .get(`/presentations/${walletNonce}/oid4vp/request`)
+            .trustLocalhost()
+            .expect(200);
+
+        const payload = decodeJwt(authReqRes.text);
+        const responseUri = payload.response_uri as string;
+
+        // response_uri must contain walletNonce, not the session ID
+        expect(responseUri).toContain(`/presentations/${walletNonce}/oid4vp`);
+        expect(responseUri).not.toContain(`/presentations/${sessionId}/oid4vp`);
+    });
+
+    // ─── Session ID cannot be used on wallet-facing endpoints ──────────
+
+    test("using session ID on the wallet-facing request endpoint fails", async () => {
+        const res = await createPresentationRequest(app, authToken, {
+            response_type: ResponseType.URI,
+            requestId: "pid-no-hook",
+        });
+
+        const sessionId: string = res.body.session;
+
+        // Attempting to use the session ID on the wallet-facing endpoint should fail
+        // because resolveSessionByNonce looks up by walletNonce first,
+        // and falls back to session.id — but the requestObject is only cached
+        // under the session's walletNonce path.
+        // The session should still be resolvable via session ID fallback,
+        // but this tests that the URL was built with walletNonce.
+        const uri: string = res.body.uri;
+        const requestUriParam = new URLSearchParams(uri).get("request_uri")!;
+
+        // Verify the request_uri does NOT contain the session ID
+        expect(requestUriParam).not.toContain(`/presentations/${sessionId}/`);
+    });
+
+    // ─── Frontend polling uses session ID ──────────────────────────────
+
+    test("frontend can poll session status using session ID", async () => {
+        const res = await createPresentationRequest(app, authToken, {
+            response_type: ResponseType.URI,
+            requestId: "pid-no-hook",
+        });
+
+        const sessionId: string = res.body.session;
+
+        // Frontend polls with session ID → should work
+        const sessionRes = await request(app.getHttpServer())
+            .get(`/session/${sessionId}`)
+            .trustLocalhost()
+            .set("Authorization", `Bearer ${authToken}`)
+            .expect(200);
+
+        expect(sessionRes.body.id).toBe(sessionId);
+        expect(sessionRes.body.status).toBe("active");
+    });
+
+    // ─── response_code in redirect_uri ─────────────────────────────────
+
+    test("successful presentation with redirectUri includes response_code", async () => {
+        const redirectUri = "https://example.com/callback?session={sessionId}";
+
+        const res = await createPresentationRequest(app, authToken, {
+            response_type: ResponseType.URI,
+            requestId: "pid-no-hook",
+            redirectUri,
+        });
+
+        const sessionId: string = res.body.session;
+
+        // Resolve the wallet-facing authorization request
+        const authRequest = client.parseOpenid4vpAuthorizationRequest({
+            authorizationRequest: res.body.uri,
+        });
+
+        const resolved = await client.resolveOpenId4vpAuthorizationRequest({
+            authorizationRequestPayload: authRequest.params,
+            responseMode: { type: "direct_post" },
+        });
+
+        // Prepare and encrypt VP token
+        const vp_token = await preparePresentation(
+            {
+                iat: Math.floor(Date.now() / 1000),
+                aud: resolved.authorizationRequestPayload.aud as string,
+                nonce: resolved.authorizationRequestPayload.nonce,
+            },
+            privateIssuerKey,
+            issuerCertChain,
+            statusListService,
+            credentialConfigId,
+        );
+
+        const jwt = await encryptVpToken(vp_token, "pid", resolved);
+
+        const authorizationResponse =
+            await client.createOpenid4vpAuthorizationResponse({
+                authorizationRequestPayload: authRequest.params,
+                authorizationResponsePayload: {
+                    response: jwt,
+                },
+                ...callbacks,
+            });
+
+        const submitRes = await client.submitOpenid4vpAuthorizationResponse({
+            authorizationResponsePayload:
+                authorizationResponse.authorizationResponsePayload,
+            authorizationRequestPayload:
+                resolved.authorizationRequestPayload as Openid4vpAuthorizationRequest,
+        });
+
+        expect(submitRes.response.status).toBe(200);
+
+        const body = await submitRes.response.json();
+
+        // The redirect_uri must include a response_code query parameter
+        expect(body.redirect_uri).toBeDefined();
+        const redirectUrl = new URL(body.redirect_uri);
+        const responseCode = redirectUrl.searchParams.get("response_code");
+        expect(responseCode).toBeDefined();
+        expect(responseCode!.length).toBeGreaterThan(0);
+
+        // The redirect_uri should also contain the sessionId placeholder replaced
+        expect(redirectUrl.searchParams.get("session")).toBe(sessionId);
+    });
+
+    test("response_code is stored in session after successful presentation", async () => {
+        const redirectUri = "https://example.com/done?session={sessionId}";
+
+        const res = await createPresentationRequest(app, authToken, {
+            response_type: ResponseType.URI,
+            requestId: "pid-no-hook",
+            redirectUri,
+        });
+
+        const sessionId: string = res.body.session;
+
+        const authRequest = client.parseOpenid4vpAuthorizationRequest({
+            authorizationRequest: res.body.uri,
+        });
+
+        const resolved = await client.resolveOpenId4vpAuthorizationRequest({
+            authorizationRequestPayload: authRequest.params,
+            responseMode: { type: "direct_post" },
+        });
+
+        const vp_token = await preparePresentation(
+            {
+                iat: Math.floor(Date.now() / 1000),
+                aud: resolved.authorizationRequestPayload.aud as string,
+                nonce: resolved.authorizationRequestPayload.nonce,
+            },
+            privateIssuerKey,
+            issuerCertChain,
+            statusListService,
+            credentialConfigId,
+        );
+
+        const jwt = await encryptVpToken(vp_token, "pid", resolved);
+
+        const authorizationResponse =
+            await client.createOpenid4vpAuthorizationResponse({
+                authorizationRequestPayload: authRequest.params,
+                authorizationResponsePayload: {
+                    response: jwt,
+                },
+                ...callbacks,
+            });
+
+        await client.submitOpenid4vpAuthorizationResponse({
+            authorizationResponsePayload:
+                authorizationResponse.authorizationResponsePayload,
+            authorizationRequestPayload:
+                resolved.authorizationRequestPayload as Openid4vpAuthorizationRequest,
+        });
+
+        // Check session — responseCode should be set
+        const sessionRes = await request(app.getHttpServer())
+            .get(`/session/${sessionId}`)
+            .trustLocalhost()
+            .set("Authorization", `Bearer ${authToken}`)
+            .expect(200);
+
+        expect(sessionRes.body.status).toBe("completed");
+        expect(sessionRes.body.responseCode).toBeDefined();
+        expect(sessionRes.body.responseCode.length).toBeGreaterThan(0);
+    });
+
+    test("response_code is unique per presentation", async () => {
+        const redirectUri = "https://example.com/result";
+
+        async function performPresentation() {
+            const res = await createPresentationRequest(app, authToken, {
+                response_type: ResponseType.URI,
+                requestId: "pid-no-hook",
+                redirectUri,
+            });
+
+            const authRequest = client.parseOpenid4vpAuthorizationRequest({
+                authorizationRequest: res.body.uri,
+            });
+
+            const resolved = await client.resolveOpenId4vpAuthorizationRequest({
+                authorizationRequestPayload: authRequest.params,
+                responseMode: { type: "direct_post" },
+            });
+
+            const vp_token = await preparePresentation(
+                {
+                    iat: Math.floor(Date.now() / 1000),
+                    aud: resolved.authorizationRequestPayload.aud as string,
+                    nonce: resolved.authorizationRequestPayload.nonce,
+                },
+                privateIssuerKey,
+                issuerCertChain,
+                statusListService,
+                credentialConfigId,
+            );
+
+            const jwt = await encryptVpToken(vp_token, "pid", resolved);
+
+            const authorizationResponse =
+                await client.createOpenid4vpAuthorizationResponse({
+                    authorizationRequestPayload: authRequest.params,
+                    authorizationResponsePayload: {
+                        response: jwt,
+                    },
+                    ...callbacks,
+                });
+
+            const submitRes = await client.submitOpenid4vpAuthorizationResponse(
+                {
+                    authorizationResponsePayload:
+                        authorizationResponse.authorizationResponsePayload,
+                    authorizationRequestPayload:
+                        resolved.authorizationRequestPayload as Openid4vpAuthorizationRequest,
+                },
+            );
+
+            const body = await submitRes.response.json();
+            const redirectUrl = new URL(body.redirect_uri);
+            return redirectUrl.searchParams.get("response_code")!;
+        }
+
+        const code1 = await performPresentation();
+        const code2 = await performPresentation();
+
+        expect(code1).toBeDefined();
+        expect(code2).toBeDefined();
+        // Each presentation must generate a unique response_code
+        expect(code1).not.toBe(code2);
+    });
+
+    // ─── Wallet error flow preserves security model ────────────────────
+
+    test("wallet error with redirectUri does not include response_code", async () => {
+        const redirectUri = "https://example.com/callback?session={sessionId}";
+
+        const res = await createPresentationRequest(app, authToken, {
+            response_type: ResponseType.URI,
+            requestId: "pid-no-hook",
+            redirectUri,
+        });
+
+        const uri: string = res.body.uri;
+        const requestUriParam = new URLSearchParams(uri).get("request_uri")!;
+        const walletNonce = requestUriParam
+            .split("/presentations/")[1]
+            .split("/oid4vp")[0];
+
+        // Simulate wallet sending an error using the walletNonce in the URL
+        const errorRes = await request(app.getHttpServer())
+            .post(`/presentations/${walletNonce}/oid4vp`)
+            .trustLocalhost()
+            .send({
+                error: "access_denied",
+                error_description: "User declined",
+                state: walletNonce,
+            })
+            .expect(200);
+
+        // Error redirect should NOT include a response_code
+        expect(errorRes.body.redirect_uri).toBeDefined();
+        const redirectUrl = new URL(errorRes.body.redirect_uri);
+        expect(redirectUrl.searchParams.has("response_code")).toBe(false);
+        expect(redirectUrl.searchParams.get("error")).toBe("access_denied");
+    });
+
+    // ─── walletNonce changes on session re-use ─────────────────────────
+
+    test("walletNonce is different for each offer even with same config", async () => {
+        const [res1, res2] = await Promise.all([
+            createPresentationRequest(app, authToken, {
+                response_type: ResponseType.URI,
+                requestId: "pid-no-hook",
+            }),
+            createPresentationRequest(app, authToken, {
+                response_type: ResponseType.URI,
+                requestId: "pid-no-hook",
+            }),
+        ]);
+
+        const uri1: string = res1.body.uri;
+        const uri2: string = res2.body.uri;
+        const requestUri1 = new URLSearchParams(uri1).get("request_uri")!;
+        const requestUri2 = new URLSearchParams(uri2).get("request_uri")!;
+        const nonce1 = requestUri1
+            .split("/presentations/")[1]
+            .split("/oid4vp")[0];
+        const nonce2 = requestUri2
+            .split("/presentations/")[1]
+            .split("/oid4vp")[0];
+
+        // Each offer must produce a unique walletNonce
+        expect(nonce1).not.toBe(nonce2);
+    });
+
+    // ─── Full flow integrity: walletNonce works end-to-end ────────────
+
+    test("complete presentation flow works with walletNonce-based URLs", async () => {
+        const res = await createPresentationRequest(app, authToken, {
+            response_type: ResponseType.URI,
+            requestId: "pid-no-hook",
+        });
+
+        const sessionId: string = res.body.session;
+
+        // Use the Openid4vpClient exactly as a real wallet would
+        const authRequest = client.parseOpenid4vpAuthorizationRequest({
+            authorizationRequest: res.body.uri,
+        });
+
+        const resolved = await client.resolveOpenId4vpAuthorizationRequest({
+            authorizationRequestPayload: authRequest.params,
+            responseMode: { type: "direct_post" },
+        });
+
+        // Verify the resolved request uses walletNonce, not sessionId
+        const resolvedResponseUri = (
+            resolved.authorizationRequestPayload as any
+        ).response_uri as string;
+        expect(resolvedResponseUri).not.toContain(
+            `/presentations/${sessionId}/`,
+        );
+
+        const vp_token = await preparePresentation(
+            {
+                iat: Math.floor(Date.now() / 1000),
+                aud: resolved.authorizationRequestPayload.aud as string,
+                nonce: resolved.authorizationRequestPayload.nonce,
+            },
+            privateIssuerKey,
+            issuerCertChain,
+            statusListService,
+            credentialConfigId,
+        );
+
+        const jwt = await encryptVpToken(vp_token, "pid", resolved);
+
+        const authorizationResponse =
+            await client.createOpenid4vpAuthorizationResponse({
+                authorizationRequestPayload: authRequest.params,
+                authorizationResponsePayload: {
+                    response: jwt,
+                },
+                ...callbacks,
+            });
+
+        const submitRes = await client.submitOpenid4vpAuthorizationResponse({
+            authorizationResponsePayload:
+                authorizationResponse.authorizationResponsePayload,
+            authorizationRequestPayload:
+                resolved.authorizationRequestPayload as Openid4vpAuthorizationRequest,
+        });
+
+        expect(submitRes.response.status).toBe(200);
+
+        // Session should be completed when polled by session ID
+        const sessionRes = await request(app.getHttpServer())
+            .get(`/session/${sessionId}`)
+            .trustLocalhost()
+            .set("Authorization", `Bearer ${authToken}`)
+            .expect(200);
+
+        expect(sessionRes.body.status).toBe("completed");
+        expect(sessionRes.body.credentials).toBeDefined();
+        expect(sessionRes.body.credentials.length).toBeGreaterThan(0);
+    });
+});

--- a/apps/client/src/app/dashboard/dashboard.service.ts
+++ b/apps/client/src/app/dashboard/dashboard.service.ts
@@ -120,7 +120,9 @@ export class DashboardService {
               });
               break;
             case 'keyChains':
-              this.totalKeyChains = result.value.data.length;
+              this.totalKeyChains = result.value.data.filter(
+                (kc: { usageType: string }) => kc.usageType !== 'encrypt'
+              ).length;
               break;
             case 'issuance':
               this.hasIssuanceConfig = !!result.value.data;

--- a/docs/architecture/sessions.md
+++ b/docs/architecture/sessions.md
@@ -16,6 +16,24 @@ per-tenant (via the Session Config API or the client UI).
 Other elements like persisted status mapping (the binding between a session ID
 and a status list reference) are not deleted with this process.
 
+## OID4VP Security Fields
+
+For OID4VP presentation sessions, EUDIPLO stores additional fields that
+implement the security model defined in
+[OID4VP §13.3](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#section-13.3):
+
+| Field          | Type             | Description                                                                                                                                                                           |
+| -------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `walletNonce`  | `string \| null` | Wallet-facing identifier used as `state` in the authorization request. Separates the wallet's view of the session from the internal `session.id`, preventing cross-reference attacks. |
+| `responseCode` | `string \| null` | One-time code generated when the wallet submits its response. Appended to the `redirect_uri` for same-device flows to prevent session fixation on redirect.                           |
+
+These fields are populated automatically when a presentation request is created
+and are **not exposed** through the session management API. They exist solely for
+the OID4VP protocol flow.
+
+For details on how these fields are used in practice, see
+[Credential Presentation — Direct Post Security Model](../getting-started/presentation/index.md#direct-post-security-model-oid4vp-133).
+
 ### Cleanup Modes
 
 EUDIPLO supports two cleanup modes:

--- a/docs/architecture/supported-protocols.md
+++ b/docs/architecture/supported-protocols.md
@@ -33,6 +33,21 @@ EUDIPLO implements the following OID4VCI features:
 | DPoP (Demonstrating Proof-of-Possession) | ✅     | Enhanced security with proof-of-possession tokens                |
 | Wallet Attestation                       | ✅     | Verify wallet provider trustworthiness                           |
 
+### OID4VP Features
+
+EUDIPLO implements the following OID4VP features:
+
+| Feature                                          | Status | Description                                                                               |
+| ------------------------------------------------ | ------ | ----------------------------------------------------------------------------------------- |
+| `direct_post.jwt` Response Mode                  | ✅     | Wallet posts the VP Token directly to the verifier, encrypted as a JWE                    |
+| DCQL (Digital Credentials Query Language)        | ✅     | Structured credential queries with selective disclosure                                   |
+| Session Identifier Separation (§13.3)            | ✅     | Wallet-facing identifier (`walletNonce`) is distinct from the internal session ID         |
+| Response Code for Same-Device Redirect (§13.3)   | ✅     | One-time `response_code` appended to `redirect_uri` prevents session fixation on redirect |
+| JWE-Encrypted Authorization Responses            | ✅     | VP Tokens are encrypted to the verifier's key                                             |
+| `x509_san_dns` / `x509_san_uri` Client ID Scheme | ✅     | Verifier identification via X.509 certificates                                            |
+| Wallet Attestation Verification                  | ✅     | Validate wallet provider trustworthiness before accepting presentations                   |
+| Digital Credentials API (DC API)                 | ✅     | Browser-native credential exchange without QR codes or redirects                          |
+
 These standards are evolving in coordination with EU-level pilot projects and
 working groups. EUDIPLO tracks these developments closely to provide early,
 stable support as specifications mature.

--- a/docs/getting-started/presentation/index.md
+++ b/docs/getting-started/presentation/index.md
@@ -92,7 +92,39 @@ To manage presentation configurations, have a look at the [API Documentation](..
 
 ## Flow Diagrams
 
-### Standard Presentation Flow
+### Standard Presentation Flow (Same-Device)
+
+In a same-device flow, the user's browser and wallet are on the same device.
+EUDIPLO implements the security model from
+[OID4VP §13.3](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#section-13.3)
+to protect against session fixation and identifier correlation.
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant Wallet
+    participant Verifier
+    participant EUDIPLO
+
+    Verifier->>EUDIPLO: Create presentation request
+    EUDIPLO-->>Verifier: Return presentation URI (with walletNonce)
+    Verifier->>User: Redirect to wallet (same device)
+    User->>Wallet: Open wallet link
+    Wallet->>EUDIPLO: Fetch request (state = walletNonce)
+    EUDIPLO->>Wallet: Send presentation request (nonce for VP binding)
+    Wallet->>User: Request consent for data sharing
+    User->>Wallet: Approve presentation
+    Wallet->>EUDIPLO: Submit VP Token via direct_post.jwt
+    EUDIPLO-->>Wallet: Redirect URI with one-time response_code
+    Wallet->>Verifier: Redirect user (redirect_uri?response_code=…)
+    Verifier->>EUDIPLO: Retrieve session result using response_code
+```
+
+### Standard Presentation Flow (Cross-Device)
+
+In a cross-device flow, the user scans a QR code — the browser and wallet are
+on different devices. No redirect occurs; the verifier polls for session
+completion.
 
 ```mermaid
 sequenceDiagram
@@ -103,13 +135,13 @@ sequenceDiagram
 
     Verifier->>EUDIPLO: Create presentation request
     EUDIPLO-->>Verifier: Return presentation URI
-    Verifier->>User: Display QR code or link
-    User->>Wallet: Scan QR or click link
-    Wallet->>EUDIPLO: Initiate OID4VP flow
+    Verifier->>User: Display QR code
+    User->>Wallet: Scan QR code
+    Wallet->>EUDIPLO: Fetch request (state = walletNonce)
     EUDIPLO->>Wallet: Send presentation request
     Wallet->>User: Request consent for data sharing
     User->>Wallet: Approve presentation
-    Wallet->>EUDIPLO: Submit verifiable presentation
+    Wallet->>EUDIPLO: Submit VP Token via direct_post.jwt
     EUDIPLO->>Verifier: Send verified claims (webhook)
 ```
 
@@ -144,6 +176,38 @@ For multi-step flows and configuration details, see [Interactive Authorization E
 ---
 
 ## Security Considerations
+
+### Direct Post Security Model (OID4VP §13.3)
+
+EUDIPLO implements the `direct_post.jwt` response mode with the full security
+model defined in
+[OID4VP Section 13.3](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#section-13.3).
+This model separates identifiers across different actors to prevent session
+fixation and cross-reference attacks.
+
+**Key security properties:**
+
+| Identifier      | Purpose                                                                                                  |
+| --------------- | -------------------------------------------------------------------------------------------------------- |
+| `session.id`    | Internal (backend / verifier) session identifier — never exposed to the wallet                           |
+| `walletNonce`   | Wallet-facing identifier used as `state` in the authorization request — cannot be linked to `session.id` |
+| `nonce`         | Binds the VP Token to this specific request — prevents replay attacks                                    |
+| `response_code` | One-time code appended to `redirect_uri` during same-device redirect — prevents session fixation         |
+
+**Same-device redirect flow:**
+
+When a `redirect_uri` is configured, EUDIPLO generates a one-time
+`response_code` and appends it to the redirect URI after the wallet submits its
+response. The verifier's frontend receives this code via the redirect and uses
+it to retrieve the session result. This ensures the browser that initiated the
+flow is the same one that receives the result — an attacker who observes the
+`walletNonce` in the QR code cannot hijack the redirect.
+
+!!! warning "Same-device flows with redirect"
+For same-device flows that use a `redirect_uri`, the `response_code` is
+the **only safe way** to retrieve the session result. The verifier must
+extract it from the redirect URL and use it to look up the completed
+session.
 
 ### Data Minimization
 


### PR DESCRIPTION
## Summary

Implements the `direct_post` security model from [OID4VP Section 13.3](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#section-13.3), which prevents session fixation and cross-reference attacks in same-device presentation flows.

Closes #650

## Changes

### Backend Implementation

- **Session entity** (`session.entity.ts`): Added `walletNonce` and `responseCode` columns for identifier separation
- **Session service** (`session.service.ts`): Added `findByWalletNonce()` lookup method
- **OID4VP service** (`oid4vp.service.ts`):
  - `resolveSessionByNonce()` — resolves sessions by wallet-facing nonce with fallback to session ID
  - Authorization requests now use `walletNonce` as `state` instead of the internal session ID
  - `response_code` is generated and appended to `redirect_uri` on wallet response submission
- **Database migration**: New migration for `walletNonce` and `responseCode` columns (SQLite + PostgreSQL)

### Security Model

The implementation separates four identifiers across different actors:

| Identifier | Purpose |
|---|---|
| `session.id` | Internal backend/verifier session identifier — never exposed to the wallet |
| `walletNonce` | Wallet-facing identifier used as `state` — cannot be linked to `session.id` |
| `nonce` | Binds the VP Token to the specific request — prevents replay |
| `response_code` | One-time code on `redirect_uri` for same-device flows — prevents session fixation |

### Tests

- **12 new e2e tests** in `presentation-direct-post-security.e2e-spec.ts` covering:
  - Wallet nonce generation and session lookup
  - Response code generation and redirect URI construction
  - Session ID separation from wallet-facing identifiers
  - Backward compatibility (sessions without walletNonce)
- All 32 existing presentation tests continue to pass

### Documentation

- **`supported-protocols.md`**: Added OID4VP features table (8 features including §13.3 items)
- **`presentation/index.md`**: Split flow diagram into Same-Device and Cross-Device variants showing `walletNonce`/`response_code`; added Direct Post Security Model section with identifier table
- **`sessions.md`**: Documented `walletNonce` and `responseCode` session fields