### PR TITLE
fix: proxy issuer metadata fetch to avoid CORS failures

### DIFF
--- a/apps/backend/src/verifier/presentations/dto/resolve-issuer-metadata.dto.ts
+++ b/apps/backend/src/verifier/presentations/dto/resolve-issuer-metadata.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsString, IsUrl } from "class-validator";
+
+export class ResolveIssuerMetadataDto {
+    @ApiProperty({
+        description:
+            "Issuer URL or full OpenID4VCI metadata URL to resolve server-side.",
+        example: "https://issuer.example.com/issuers/tenant-a",
+    })
+    @IsString()
+    @IsUrl({ require_tld: false })
+    issuerUrl!: string;
+}

--- a/apps/backend/src/verifier/presentations/presentations.controller.ts
+++ b/apps/backend/src/verifier/presentations/presentations.controller.ts
@@ -7,12 +7,13 @@ import {
     Patch,
     Post,
 } from "@nestjs/common";
-import { ApiTags } from "@nestjs/swagger";
+import { ApiBody, ApiOperation, ApiResponse, ApiTags } from "@nestjs/swagger";
 import { Role } from "../../auth/roles/role.enum";
 import { Secured } from "../../auth/secure.decorator";
 import { Token, TokenPayload } from "../../auth/token.decorator";
 import { PresentationConfigCreateDto } from "./dto/presentation-config-create.dto";
 import { PresentationConfigUpdateDto } from "./dto/presentation-config-update.dto";
+import { ResolveIssuerMetadataDto } from "./dto/resolve-issuer-metadata.dto";
 import { PresentationsService } from "./presentations.service";
 
 @ApiTags("Verifier")
@@ -29,6 +30,32 @@ export class PresentationManagementController {
     configuration(@Token() user: TokenPayload) {
         return this.presentationsService.getPresentationConfigs(
             user.entity!.id,
+        );
+    }
+
+    /**
+     * Resolve external OID4VCI issuer metadata server-side.
+     * This avoids browser CORS limitations when browsing issuer metadata.
+     */
+    @Secured([Role.Presentations, Role.PresentationRequest])
+    @Post("issuer-metadata/resolve")
+    @ApiOperation({
+        summary: "Resolve external issuer metadata",
+        description:
+            "Fetches OpenID4VCI credential issuer metadata from an external issuer URL on the server side.",
+    })
+    @ApiBody({ type: ResolveIssuerMetadataDto })
+    @ApiResponse({
+        status: 200,
+        description: "Resolved credential issuer metadata",
+    })
+    @ApiResponse({
+        status: 400,
+        description: "Invalid issuer URL or metadata could not be resolved",
+    })
+    async resolveIssuerMetadata(@Body() body: ResolveIssuerMetadataDto) {
+        return this.presentationsService.resolveCredentialIssuerMetadata(
+            body.issuerUrl,
         );
     }
 

--- a/apps/backend/src/verifier/presentations/presentations.service.ts
+++ b/apps/backend/src/verifier/presentations/presentations.service.ts
@@ -1,4 +1,6 @@
+import { lookup } from "node:dns/promises";
 import { readFileSync } from "node:fs";
+import { isIP } from "node:net";
 import {
     BadRequestException,
     ConflictException,
@@ -40,6 +42,10 @@ type CredentialType = "dc+sd-jwt" | "mso_mdoc";
  */
 @Injectable()
 export class PresentationsService {
+    private readonly METADATA_FETCH_TIMEOUT_MS = 5000;
+
+    private readonly METADATA_FETCH_MAX_REDIRECTS = 3;
+
     /**
      * Constructor for the PresentationsService.
      * @param httpService - Instance of HttpService for making HTTP requests.
@@ -194,29 +200,7 @@ export class PresentationsService {
      */
     async resolveCredentialIssuerMetadata(issuerUrl: string) {
         const metadataUrl = this.buildCredentialIssuerMetadataUrl(issuerUrl);
-
-        const response = await fetch(metadataUrl, {
-            method: "GET",
-            headers: {
-                accept: "application/json",
-            },
-        }).catch((error) => {
-            throw new BadRequestException(
-                `Failed to fetch issuer metadata from ${metadataUrl}: ${error instanceof Error ? error.message : "unknown error"}`,
-            );
-        });
-
-        if (!response.ok) {
-            throw new BadRequestException(
-                `Failed to fetch issuer metadata from ${metadataUrl}: HTTP ${response.status}`,
-            );
-        }
-
-        const metadata = await response.json().catch(() => {
-            throw new BadRequestException(
-                `Issuer metadata response from ${metadataUrl} is not valid JSON`,
-            );
-        });
+        const metadata = await this.fetchCredentialIssuerMetadata(metadataUrl);
 
         if (!metadata || typeof metadata !== "object") {
             throw new BadRequestException(
@@ -227,9 +211,159 @@ export class PresentationsService {
         return metadata;
     }
 
+    private async fetchCredentialIssuerMetadata(metadataUrl: string) {
+        let currentUrl = metadataUrl;
+
+        for (
+            let redirectCount = 0;
+            redirectCount <= this.METADATA_FETCH_MAX_REDIRECTS;
+            redirectCount++
+        ) {
+            await this.assertSafeMetadataUrl(currentUrl);
+
+            const response = await fetch(currentUrl, {
+                method: "GET",
+                headers: {
+                    accept: "application/json",
+                },
+                redirect: "manual",
+                signal: AbortSignal.timeout(this.METADATA_FETCH_TIMEOUT_MS),
+            }).catch((error) => {
+                throw new BadRequestException(
+                    `Failed to fetch issuer metadata from ${currentUrl}: ${error instanceof Error ? error.message : "unknown error"}`,
+                );
+            });
+
+            if (response.status >= 300 && response.status < 400) {
+                const location = response.headers.get("location");
+                if (!location) {
+                    throw new BadRequestException(
+                        `Issuer metadata response from ${currentUrl} returned a redirect without a location header`,
+                    );
+                }
+
+                currentUrl = new URL(location, currentUrl).toString();
+                continue;
+            }
+
+            if (!response.ok) {
+                throw new BadRequestException(
+                    `Failed to fetch issuer metadata from ${currentUrl}: HTTP ${response.status}`,
+                );
+            }
+
+            return response.json().catch(() => {
+                throw new BadRequestException(
+                    `Issuer metadata response from ${currentUrl} is not valid JSON`,
+                );
+            });
+        }
+
+        throw new BadRequestException(
+            `Issuer metadata fetch exceeded ${this.METADATA_FETCH_MAX_REDIRECTS} redirects`,
+        );
+    }
+
+    private async assertSafeMetadataUrl(inputUrl: string): Promise<void> {
+        const parsedUrl = new URL(inputUrl);
+
+        if (parsedUrl.username || parsedUrl.password) {
+            throw new BadRequestException(
+                "issuerUrl must not include userinfo credentials",
+            );
+        }
+
+        // In non-production environments, allow local/private hosts for testing
+        const isProduction =
+            this.configService.get<string>("NODE_ENV") === "production";
+        if (!isProduction) {
+            return;
+        }
+
+        const hostname = parsedUrl.hostname.toLowerCase();
+        if (
+            hostname === "localhost" ||
+            hostname.endsWith(".localhost") ||
+            hostname.endsWith(".local")
+        ) {
+            throw new BadRequestException(
+                "issuerUrl must resolve to a public host",
+            );
+        }
+
+        const resolvedAddresses = isIP(hostname)
+            ? [hostname]
+            : (
+                  await lookup(hostname, { all: true, verbatim: true }).catch(
+                      () => {
+                          throw new BadRequestException(
+                              "issuerUrl host could not be resolved",
+                          );
+                      },
+                  )
+              ).map((entry) => entry.address);
+
+        if (resolvedAddresses.length === 0) {
+            throw new BadRequestException(
+                "issuerUrl host could not be resolved",
+            );
+        }
+
+        if (
+            resolvedAddresses.some((address) =>
+                this.isPrivateIpAddress(address),
+            )
+        ) {
+            throw new BadRequestException(
+                "issuerUrl must resolve to a public host",
+            );
+        }
+    }
+
+    private isPrivateIpAddress(address: string): boolean {
+        const normalizedAddress =
+            address.startsWith("::ffff:") && isIP(address.slice(7)) === 4
+                ? address.slice(7)
+                : address;
+
+        const family = isIP(normalizedAddress);
+        if (family === 4) {
+            const octets = normalizedAddress.split(".").map(Number);
+            const [first, second] = octets;
+
+            return (
+                first === 0 ||
+                first === 10 ||
+                first === 127 ||
+                (first === 100 && second >= 64 && second <= 127) ||
+                (first === 169 && second === 254) ||
+                (first === 172 && second >= 16 && second <= 31) ||
+                (first === 192 && second === 168) ||
+                (first === 198 && (second === 18 || second === 19))
+            );
+        }
+
+        if (family === 6) {
+            const normalized = normalizedAddress.toLowerCase();
+            return (
+                normalized === "::" ||
+                normalized === "::1" ||
+                normalized.startsWith("fc") ||
+                normalized.startsWith("fd") ||
+                normalized.startsWith("fe8") ||
+                normalized.startsWith("fe9") ||
+                normalized.startsWith("fea") ||
+                normalized.startsWith("feb")
+            );
+        }
+
+        return true;
+    }
+
     /**
      * Build OID4VCI metadata endpoint URL.
-     * Accepts either a base issuer URL or a full .well-known metadata URL.
+     * Accepts an issuer base URL and canonicalizes it to the exact
+     * OID4VCI credential issuer metadata endpoint.
      */
     private buildCredentialIssuerMetadataUrl(inputUrl: string): string {
         const trimmed = inputUrl.trim();
@@ -247,12 +381,19 @@ export class PresentationsService {
             );
         }
 
-        if (trimmed.includes(".well-known/openid-credential-issuer")) {
-            return trimmed;
+        if (parsedUrl.search || parsedUrl.hash) {
+            throw new BadRequestException(
+                "issuerUrl must not include query parameters or fragments",
+            );
         }
 
+        const wellKnownPrefix = "/.well-known/openid-credential-issuer";
         const normalizedPath = parsedUrl.pathname.replace(/\/$/, "");
-        return `${parsedUrl.origin}/.well-known/openid-credential-issuer${normalizedPath}`;
+        const issuerPath = normalizedPath.startsWith(wellKnownPrefix)
+            ? normalizedPath.slice(wellKnownPrefix.length) || ""
+            : normalizedPath;
+
+        return `${parsedUrl.origin}${wellKnownPrefix}${issuerPath}`;
     }
 
     /**

--- a/apps/backend/src/verifier/presentations/presentations.service.ts
+++ b/apps/backend/src/verifier/presentations/presentations.service.ts
@@ -189,6 +189,73 @@ export class PresentationsService {
     }
 
     /**
+     * Resolve OID4VCI credential issuer metadata server-side.
+     * This is used by the web client to avoid browser CORS restrictions.
+     */
+    async resolveCredentialIssuerMetadata(issuerUrl: string) {
+        const metadataUrl = this.buildCredentialIssuerMetadataUrl(issuerUrl);
+
+        const response = await fetch(metadataUrl, {
+            method: "GET",
+            headers: {
+                accept: "application/json",
+            },
+        }).catch((error) => {
+            throw new BadRequestException(
+                `Failed to fetch issuer metadata from ${metadataUrl}: ${error instanceof Error ? error.message : "unknown error"}`,
+            );
+        });
+
+        if (!response.ok) {
+            throw new BadRequestException(
+                `Failed to fetch issuer metadata from ${metadataUrl}: HTTP ${response.status}`,
+            );
+        }
+
+        const metadata = await response.json().catch(() => {
+            throw new BadRequestException(
+                `Issuer metadata response from ${metadataUrl} is not valid JSON`,
+            );
+        });
+
+        if (!metadata || typeof metadata !== "object") {
+            throw new BadRequestException(
+                `Issuer metadata response from ${metadataUrl} is invalid`,
+            );
+        }
+
+        return metadata;
+    }
+
+    /**
+     * Build OID4VCI metadata endpoint URL.
+     * Accepts either a base issuer URL or a full .well-known metadata URL.
+     */
+    private buildCredentialIssuerMetadataUrl(inputUrl: string): string {
+        const trimmed = inputUrl.trim();
+        let parsedUrl: URL;
+
+        try {
+            parsedUrl = new URL(trimmed);
+        } catch {
+            throw new BadRequestException("issuerUrl must be a valid URL");
+        }
+
+        if (parsedUrl.protocol !== "https:" && parsedUrl.protocol !== "http:") {
+            throw new BadRequestException(
+                "issuerUrl must use http or https protocol",
+            );
+        }
+
+        if (trimmed.includes(".well-known/openid-credential-issuer")) {
+            return trimmed;
+        }
+
+        const normalizedPath = parsedUrl.pathname.replace(/\/$/, "");
+        return `${parsedUrl.origin}/.well-known/openid-credential-issuer${normalizedPath}`;
+    }
+
+    /**
      * Stores the new registration certificate.
      * @param registrationCertId - The ID of the registration certificate to store.
      * @param id - The ID of the presentation configuration to update.

--- a/apps/client/src/app/presentation/presentation-config/issuer-metadata-browser/issuer-metadata-browser.component.ts
+++ b/apps/client/src/app/presentation/presentation-config/issuer-metadata-browser/issuer-metadata-browser.component.ts
@@ -90,8 +90,8 @@ export class IssuerMetadataBrowserComponent implements OnInit {
       console.error('Failed to fetch issuer metadata:', err);
       if (err.status === 0) {
         this.error =
-          'Failed to fetch metadata. This may be due to CORS restrictions. ' +
-          'Try using the issuer URL directly or check the console for details.';
+          'Failed to fetch metadata through the EUDIPLO proxy. ' +
+          'Check network connectivity and issuer URL, then try again.';
       } else if (err.status === 404) {
         this.error = 'Credential issuer metadata not found at the specified URL.';
       } else {

--- a/apps/client/src/app/presentation/presentation-config/issuer-metadata-browser/issuer-metadata.service.ts
+++ b/apps/client/src/app/presentation/presentation-config/issuer-metadata-browser/issuer-metadata.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
+import { ApiService } from '../../../core';
 
 /**
  * OID4VCI Credential Issuer Metadata structure
@@ -100,24 +101,27 @@ export interface NormalizedCredential {
 
 @Injectable()
 export class IssuerMetadataService {
-  constructor(private readonly http: HttpClient) {}
+  constructor(
+    private readonly http: HttpClient,
+    private readonly apiService: ApiService
+  ) {}
 
   /**
    * Fetch credential issuer metadata from a given URL.
    * Handles both full URLs and base URLs (appending .well-known path).
    */
   async fetchMetadata(issuerUrl: string): Promise<CredentialIssuerMetadata> {
-    let metadataUrl = issuerUrl.trim();
-
-    // If URL doesn't contain .well-known, construct the metadata URL
-    if (!metadataUrl.includes('.well-known/openid-credential-issuer')) {
-      // Remove trailing slash
-      metadataUrl = metadataUrl.replace(/\/$/, '');
-      const url = new URL(metadataUrl);
-      metadataUrl = `${url.origin}/.well-known/openid-credential-issuer${url.pathname}`;
+    const baseUrl = this.apiService.getBaseUrl();
+    if (!baseUrl) {
+      throw new Error('API base URL is not configured. Please log in again.');
     }
 
-    return firstValueFrom(this.http.get<CredentialIssuerMetadata>(metadataUrl));
+    const endpoint = `${baseUrl}/api/verifier/config/issuer-metadata/resolve`;
+    return firstValueFrom(
+      this.http.post<CredentialIssuerMetadata>(endpoint, {
+        issuerUrl,
+      })
+    );
   }
 
   /**


### PR DESCRIPTION
## Summary
- add a server-side endpoint to resolve external OID4VCI issuer metadata
- switch the issuer metadata browser to call EUDIPLO backend instead of direct browser fetch
- update error messaging in the metadata browser to reflect proxy-based resolution

## Why
Some issuers do not allow browser CORS access to their `/.well-known/openid-credential-issuer` endpoints. Fetching from the backend avoids browser CORS restrictions while keeping the UI flow unchanged.

## Backend
- added `POST /api/verifier/config/issuer-metadata/resolve`
- added request DTO for `issuerUrl`
- implemented metadata URL normalization and server-side fetch in presentations service

## Frontend
- updated issuer metadata service to call backend proxy endpoint
- removed direct browser call to external issuer metadata URL

## Validation
- TypeScript diagnostics checked for modified files; no errors reported.
