### PR TITLE
feat(client): restructure config pages into grouped tabs

### DIFF
--- a/apps/client/src/app/app.config.ts
+++ b/apps/client/src/app/app.config.ts
@@ -15,11 +15,24 @@ import { ArrayTypeComponent } from './types/array.type';
 import { provideMonacoEditor } from 'ngx-monaco-editor-v2';
 import schemas from './utils/schemas.json';
 import transactionDataSchemaObj from '../../../../schemas/TransactionData.schema.json';
+import claimsMetadataSchemaObj from '../../../../schemas/ClaimMetadata.schema.json';
 import { authInterceptor } from './core';
 
 declare let monaco: any;
 
 // Dynamic schemas not generated from OpenAPI
+const claimsMetadataArraySchema = {
+  uri: 'https://raw.githubusercontent.com/openwallet-foundation-labs/eudiplo/refs/heads/main/schemas/ClaimMetadataArray.schema.json',
+  fileMatch: ['a://b/ClaimMetadataArray*.schema.json'],
+  schema: {
+    $schema: 'https://json-schema.org/draft/2020-12/schema',
+    $id: 'https://raw.githubusercontent.com/openwallet-foundation-labs/eudiplo/refs/heads/main/schemas/ClaimMetadataArray.schema.json',
+    title: 'ClaimMetadataArray',
+    type: 'array',
+    items: claimsMetadataSchemaObj,
+  },
+};
+
 const transactionDataArraySchema = {
   uri: 'https://raw.githubusercontent.com/openwallet-foundation-labs/eudiplo/refs/heads/main/schemas/TransactionDataArray.schema.json',
   fileMatch: ['a://b/TransactionDataArray*.schema.json'],
@@ -36,7 +49,7 @@ export function onMonacoLoad() {
   monaco.languages.json.jsonDefaults.diagnosticsOptions.enableSchemaRequest = true;
   monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
     validate: true,
-    schemas: [...schemas, transactionDataArraySchema],
+    schemas: [...schemas, transactionDataArraySchema, claimsMetadataArraySchema],
   });
 }
 

--- a/apps/client/src/app/issuance/credential-config/credential-config-create/credential-config-create.component.html
+++ b/apps/client/src/app/issuance/credential-config/credential-config-create/credential-config-create.component.html
@@ -50,686 +50,807 @@
 
   <!-- Main Form -->
   <form [formGroup]="form" (ngSubmit)="onSubmit()">
-    <!-- Basic Information Card -->
-    <mat-card>
-      <mat-card-header>
-        <mat-card-title>
-          <mat-icon>settings</mat-icon>
-          Basic Information
-        </mat-card-title>
-      </mat-card-header>
-      <mat-card-content fxLayout="column" fxLayoutGap="16px">
-        <!-- Configuration ID -->
-        <div fxLayout="row" fxLayoutGap="8px" fxLayoutAlign="start center">
-          <mat-form-field fxFlex>
-            <mat-label>Configuration ID</mat-label>
-            <input matInput formControlName="id" placeholder="unique-credential-config-id" />
-            <mat-icon matSuffix>fingerprint</mat-icon>
-            @if (form.get('id')?.invalid && form.get('id')?.touched) {
-              <mat-error>Configuration ID is required</mat-error>
-            }
-          </mat-form-field>
-        </div>
+    <mat-tab-group animationDuration="200ms">
+      <!-- TAB 1: Metadata -->
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <mat-icon class="tab-icon">info</mat-icon>
+          Metadata
+        </ng-template>
 
-        <mat-form-field>
-          <mat-label>Description</mat-label>
-          <input matInput formControlName="description" placeholder="Description" />
-          <mat-icon matSuffix>description</mat-icon>
-          @if (form.get('description')?.invalid && form.get('description')?.touched) {
-            <mat-error>Description is required</mat-error>
-          }
-        </mat-form-field>
-
-        <!-- Credential Format -->
-        <mat-form-field>
-          <mat-label>Credential Format</mat-label>
-          <mat-select formControlName="format">
-            <mat-option value="dc+sd-jwt">SD-JWT VC (dc+sd-jwt)</mat-option>
-            <mat-option value="mso_mdoc">mDOC (mso_mdoc)</mat-option>
-          </mat-select>
-          <mat-icon matSuffix>format_shapes</mat-icon>
-          <mat-hint>Select the credential format to issue</mat-hint>
-        </mat-form-field>
-
-        <!-- Key Chain Selection -->
-        <mat-form-field>
-          <mat-label>Signing Key Chain</mat-label>
-          <mat-select formControlName="keyChainId">
-            <mat-option value="">
-              <em>No key chain selected (use default)</em>
-            </mat-option>
-            @for (keyChain of keyChains; track keyChain.id) {
-              <mat-option [value]="keyChain.id">
-                <div fxLayout="column">
-                  <span
-                    ><strong>{{ keyChain.id }}</strong></span
-                  >
-                  <span class="option-description">{{
-                    keyChain.description || keyChain.usageType
-                  }}</span>
-                </div>
-              </mat-option>
-            }
-          </mat-select>
-          <mat-icon matSuffix>key</mat-icon>
-          <mat-hint>Select the key chain for signing credentials</mat-hint>
-        </mat-form-field>
-
-        <!-- Lifetime -->
-        <div fxLayout="row" fxLayoutGap="16px" fxLayout.lt-md="column">
-          <mat-form-field fxFlex>
-            <mat-label>Credential Lifetime</mat-label>
-            <mat-select
-              [value]="selectedLifetimePreset"
-              (selectionChange)="onLifetimePresetChange($event.value)"
-            >
-              @for (preset of lifetimePresets; track preset.value) {
-                <mat-option [value]="preset.value">{{ preset.label }}</mat-option>
-              }
-            </mat-select>
-            <mat-icon matSuffix>schedule</mat-icon>
-            <mat-hint>
-              @if (!customLifetime && form.get('lifeTime')?.value) {
-                {{ formatLifetime(form.get('lifeTime')?.value) }}
-              } @else {
-                Select a preset or enter custom value
-              }
-            </mat-hint>
-          </mat-form-field>
-          @if (customLifetime) {
-            <mat-form-field fxFlex>
-              <mat-label>Custom Lifetime (seconds)</mat-label>
-              <input matInput type="number" formControlName="lifeTime" placeholder="3600" min="1" />
-              <mat-icon matSuffix>edit</mat-icon>
-              <mat-hint>= {{ formatLifetime(form.get('lifeTime')?.value || 0) }}</mat-hint>
-            </mat-form-field>
-          }
-        </div>
-
-        <!-- Scope -->
-        <mat-form-field>
-          <mat-label>Scope</mat-label>
-          <input matInput formControlName="scope" placeholder="scope" />
-          <mat-hint>Select the scope for the credential</mat-hint>
-        </mat-form-field>
-      </mat-card-content>
-    </mat-card>
-
-    <!-- Feature Configuration Card -->
-    <mat-card>
-      <mat-card-header>
-        <mat-card-title>
-          <mat-icon>tune</mat-icon>
-          Feature Configuration
-        </mat-card-title>
-      </mat-card-header>
-      <mat-card-content fxLayout="column" fxLayoutGap="16px">
-        <!-- Feature Toggles -->
-        <div fxLayout="row" fxLayoutGap="32px" fxLayout.lt-md="column">
-          <div fxFlex>
-            <mat-slide-toggle formControlName="keyBinding">
-              <div fxLayout="column">
-                <span><strong>Key Binding</strong></span>
-                <span class="toggle-description">Enable to issue key-bound credentials</span>
-              </div>
-            </mat-slide-toggle>
-          </div>
-          <div fxFlex>
-            <mat-slide-toggle formControlName="statusManagement">
-              <div fxLayout="column">
-                <span><strong>Status Management</strong></span>
-                <span class="toggle-description">Enable credential status tracking</span>
-              </div>
-            </mat-slide-toggle>
-          </div>
-        </div>
-
-        <!-- Key Attestation Requirements (HAIP compliance) -->
-        <div class="key-attestation-section">
-          <mat-slide-toggle formControlName="keyAttestationEnabled">
-            <div fxLayout="column">
-              <span><strong>Require Key Attestation</strong></span>
-              <span class="toggle-description"
-                >Require wallets to provide key attestation proofs (HAIP compliance)</span
-              >
-            </div>
-          </mat-slide-toggle>
-
-          @if (form.get('keyAttestationEnabled')?.value) {
-            <div
-              fxLayout="row"
-              fxLayoutGap="16px"
-              fxLayout.lt-md="column"
-              class="key-attestation-fields"
-            >
-              <mat-form-field fxFlex appearance="outline">
-                <mat-label>Key Storage Types</mat-label>
-                <mat-select formControlName="keyStorageTypes" multiple>
-                  @for (preset of keyAttestationPresets; track preset.value) {
-                    <mat-option [value]="preset.value">{{ preset.label }}</mat-option>
-                  }
-                </mat-select>
-                <mat-hint>Required key storage assurance levels</mat-hint>
+        <div fxLayout="column" fxLayoutGap="24px" class="tab-content">
+          <!-- Basic Information -->
+          <mat-card>
+            <mat-card-header>
+              <mat-card-title>
+                <mat-icon>settings</mat-icon>
+                Basic Information
+              </mat-card-title>
+            </mat-card-header>
+            <mat-card-content fxLayout="column" fxLayoutGap="16px">
+              <!-- Configuration ID -->
+              <mat-form-field>
+                <mat-label>Configuration ID</mat-label>
+                <input matInput formControlName="id" placeholder="unique-credential-config-id" />
+                <mat-icon matSuffix>fingerprint</mat-icon>
+                @if (form.get('id')?.invalid && form.get('id')?.touched) {
+                  <mat-error>Configuration ID is required</mat-error>
+                }
               </mat-form-field>
 
-              <mat-form-field fxFlex appearance="outline">
-                <mat-label>User Authentication Types</mat-label>
-                <mat-select formControlName="userAuthenticationTypes" multiple>
-                  @for (preset of keyAttestationPresets; track preset.value) {
-                    <mat-option [value]="preset.value">{{ preset.label }}</mat-option>
-                  }
-                </mat-select>
-                <mat-hint>Required user authentication assurance levels</mat-hint>
+              <mat-form-field>
+                <mat-label>Description</mat-label>
+                <input matInput formControlName="description" placeholder="Description" />
+                <mat-icon matSuffix>description</mat-icon>
+                @if (form.get('description')?.invalid && form.get('description')?.touched) {
+                  <mat-error>Description is required</mat-error>
+                }
               </mat-form-field>
-            </div>
-          }
-        </div>
 
-        <!-- Interactive Authorization (IAE) Actions -->
-        <div class="iae-actions-section">
-          <div fxLayout="row" fxLayoutAlign="space-between center" class="section-header">
-            <span><strong>Interactive Authorization Actions</strong></span>
-            <button mat-button color="primary" [matMenuTriggerFor]="addActionMenu" type="button">
-              <mat-icon>add</mat-icon> Add Action
-            </button>
-            <mat-menu #addActionMenu="matMenu">
-              <button mat-menu-item type="button" (click)="addIaeAction('openid4vp_presentation')">
-                <mat-icon>verified_user</mat-icon>
-                <span>OID4VP Presentation</span>
-              </button>
-              <button mat-menu-item type="button" (click)="addIaeAction('redirect_to_web')">
-                <mat-icon>open_in_new</mat-icon>
-                <span>Redirect to Web</span>
-              </button>
-            </mat-menu>
-          </div>
+              <!-- Credential Format -->
+              <mat-form-field>
+                <mat-label>Credential Format</mat-label>
+                <mat-select formControlName="format">
+                  <mat-option value="dc+sd-jwt">SD-JWT VC (dc+sd-jwt)</mat-option>
+                  <mat-option value="mso_mdoc">mDOC (mso_mdoc)</mat-option>
+                </mat-select>
+                <mat-icon matSuffix>format_shapes</mat-icon>
+                <mat-hint>Select the credential format to issue</mat-hint>
+              </mat-form-field>
 
-          @if (iaeActions.length === 0) {
-            <p class="no-actions-hint">
-              No interactive authorization required. Add actions to require user interaction before
-              credential issuance.
-            </p>
-          }
-
-          <div formArrayName="iaeActions" cdkDropList (cdkDropListDropped)="dropIaeAction($event)">
-            @for (action of iaeActions.controls; track $index; let i = $index) {
-              <mat-card class="iae-action-card" [formGroupName]="i" cdkDrag>
-                <mat-card-header>
-                  <mat-card-title fxLayout="row" fxLayoutAlign="space-between center">
-                    <span fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="8px">
-                      <mat-icon cdkDragHandle class="drag-handle">drag_indicator</mat-icon>
-                      <span
-                        >Step {{ i + 1 }}:
-                        {{
-                          action.get('type')?.value === 'openid4vp_presentation'
-                            ? 'OID4VP Presentation'
-                            : 'Redirect to Web'
-                        }}</span
-                      >
-                    </span>
-                    <span>
-                      <button
-                        mat-icon-button
-                        (click)="moveIaeAction(i, 'up')"
-                        [disabled]="i === 0"
-                        type="button"
-                        matTooltip="Move up"
-                      >
-                        <mat-icon>arrow_upward</mat-icon>
-                      </button>
-                      <button
-                        mat-icon-button
-                        (click)="moveIaeAction(i, 'down')"
-                        [disabled]="i === iaeActions.length - 1"
-                        type="button"
-                        matTooltip="Move down"
-                      >
-                        <mat-icon>arrow_downward</mat-icon>
-                      </button>
-                      <button
-                        mat-icon-button
-                        color="warn"
-                        (click)="removeIaeAction(i)"
-                        type="button"
-                        matTooltip="Remove action"
-                      >
-                        <mat-icon>delete</mat-icon>
-                      </button>
-                    </span>
-                  </mat-card-title>
-                </mat-card-header>
-                <mat-card-content>
-                  @if (action.get('type')?.value === 'openid4vp_presentation') {
-                    <mat-form-field appearance="outline" class="full-width">
-                      <mat-label>Presentation Config</mat-label>
-                      <mat-select formControlName="presentationConfigId">
-                        @for (pc of presentationConfigs; track pc.id) {
-                          <mat-option [value]="pc.id"
-                            >{{ pc.id
-                            }}{{ pc.description ? ' - ' + pc.description : '' }}</mat-option
-                          >
-                        }
-                      </mat-select>
-                      <mat-icon matSuffix>verified_user</mat-icon>
-                      <mat-hint>Select the presentation config to use for verification</mat-hint>
-                    </mat-form-field>
-                  }
-                  @if (action.get('type')?.value === 'redirect_to_web') {
-                    <div fxLayout="column" fxLayoutGap="16px">
-                      <mat-form-field appearance="outline" class="full-width">
-                        <mat-label>Redirect URL</mat-label>
-                        <input
-                          matInput
-                          formControlName="url"
-                          placeholder="https://example.com/form"
-                        />
-                        <mat-icon matSuffix>link</mat-icon>
-                        <mat-hint>URL to redirect the user to</mat-hint>
-                      </mat-form-field>
-                      <mat-form-field appearance="outline" class="full-width">
-                        <mat-label>Callback URL</mat-label>
-                        <input
-                          matInput
-                          formControlName="callbackUrl"
-                          placeholder="https://issuer.example.com/iae/callback"
-                        />
-                        <mat-icon matSuffix>keyboard_return</mat-icon>
-                        <mat-hint
-                          >URL where the external service should redirect back (optional)</mat-hint
+              <!-- Key Chain Selection -->
+              <mat-form-field>
+                <mat-label>Signing Key Chain</mat-label>
+                <mat-select formControlName="keyChainId">
+                  <mat-option value="">
+                    <em>No key chain selected (use default)</em>
+                  </mat-option>
+                  @for (keyChain of keyChains; track keyChain.id) {
+                    <mat-option [value]="keyChain.id">
+                      <div fxLayout="column">
+                        <span
+                          ><strong>{{ keyChain.id }}</strong></span
                         >
-                      </mat-form-field>
-                      <mat-form-field appearance="outline" class="full-width">
-                        <mat-label>Description</mat-label>
-                        <input
-                          matInput
-                          formControlName="description"
-                          placeholder="Complete additional verification"
-                        />
-                        <mat-icon matSuffix>description</mat-icon>
-                        <mat-hint>Description shown to the user (optional)</mat-hint>
-                      </mat-form-field>
-                    </div>
+                        <span class="option-description">{{
+                          keyChain.description || keyChain.usageType
+                        }}</span>
+                      </div>
+                    </mat-option>
                   }
-                </mat-card-content>
-              </mat-card>
-            }
-          </div>
-        </div>
-      </mat-card-content>
-    </mat-card>
+                </mat-select>
+                <mat-icon matSuffix>key</mat-icon>
+                <mat-hint>Select the key chain for signing credentials</mat-hint>
+              </mat-form-field>
 
-    <!-- Display Configuration Card -->
-    <mat-card>
-      <mat-card-header>
-        <mat-card-title>
-          <mat-icon>palette</mat-icon>
-          Display Configuration
-        </mat-card-title>
-        <mat-card-subtitle>
-          Configure how credentials appear in wallets and viewers
-        </mat-card-subtitle>
-      </mat-card-header>
-      <mat-card-content>
-        <div formArrayName="displayConfigs">
-          @for (displayConfig of displayConfigs.controls; track $index; let i = $index) {
-            <mat-card class="display-config-card" [formGroupName]="i">
+              <!-- Lifetime -->
+              <div fxLayout="row" fxLayoutGap="16px" fxLayout.lt-md="column">
+                <mat-form-field fxFlex>
+                  <mat-label>Credential Lifetime</mat-label>
+                  <mat-select
+                    [value]="selectedLifetimePreset"
+                    (selectionChange)="onLifetimePresetChange($event.value)"
+                  >
+                    @for (preset of lifetimePresets; track preset.value) {
+                      <mat-option [value]="preset.value">{{ preset.label }}</mat-option>
+                    }
+                  </mat-select>
+                  <mat-icon matSuffix>schedule</mat-icon>
+                  <mat-hint>
+                    @if (!customLifetime && form.get('lifeTime')?.value) {
+                      {{ formatLifetime(form.get('lifeTime')?.value) }}
+                    } @else {
+                      Select a preset or enter custom value
+                    }
+                  </mat-hint>
+                </mat-form-field>
+                @if (customLifetime) {
+                  <mat-form-field fxFlex>
+                    <mat-label>Custom Lifetime (seconds)</mat-label>
+                    <input
+                      matInput
+                      type="number"
+                      formControlName="lifeTime"
+                      placeholder="3600"
+                      min="1"
+                    />
+                    <mat-icon matSuffix>edit</mat-icon>
+                    <mat-hint>= {{ formatLifetime(form.get('lifeTime')?.value || 0) }}</mat-hint>
+                  </mat-form-field>
+                }
+              </div>
+
+              <!-- Scope -->
+              <mat-form-field>
+                <mat-label>Scope</mat-label>
+                <input matInput formControlName="scope" placeholder="scope" />
+                <mat-hint>Select the scope for the credential</mat-hint>
+              </mat-form-field>
+            </mat-card-content>
+          </mat-card>
+
+          <!-- VCT Information Card (SD-JWT only) -->
+          @if (!isMdocFormat) {
+            <mat-card>
               <mat-card-header>
                 <mat-card-title>
-                  <span>Display Configuration {{ i + 1 }}</span>
-                  @if (displayConfigs.length > 1) {
-                    <button
-                      matIconButton
-                      type="button"
-                      color="warn"
-                      (click)="removeDisplayConfig(i)"
-                      matTooltip="Remove this display configuration"
-                    >
-                      <mat-icon>delete</mat-icon>
-                    </button>
-                  }
+                  <mat-icon>description</mat-icon>
+                  Verifiable Credential Type (VCT)
                 </mat-card-title>
+                <mat-card-subtitle>SD-JWT VC specific configuration</mat-card-subtitle>
               </mat-card-header>
               <mat-card-content fxLayout="column" fxLayoutGap="16px">
-                <!-- Basic Display Information -->
-                <div fxLayout="row" fxLayoutGap="16px" fxLayout.lt-md="column">
-                  <mat-form-field fxFlex>
-                    <mat-label>Display Name</mat-label>
-                    <input matInput formControlName="name" placeholder="PID" required />
-                    <mat-icon matSuffix>title</mat-icon>
-                    <mat-hint>Short name shown in wallet</mat-hint>
-                  </mat-form-field>
-
-                  <mat-form-field fxFlex>
-                    <mat-label>Locale</mat-label>
-                    <mat-select formControlName="locale">
-                      <mat-option value="en-US">English (US)</mat-option>
-                      <mat-option value="en-GB">English (UK)</mat-option>
-                      <mat-option value="de-DE">German</mat-option>
-                      <mat-option value="fr-FR">French</mat-option>
-                      <mat-option value="es-ES">Spanish</mat-option>
-                      <mat-option value="it-IT">Italian</mat-option>
-                    </mat-select>
-                    <mat-icon matSuffix>language</mat-icon>
-                  </mat-form-field>
+                <!-- VCT Mode Selection -->
+                <div fxLayout="row" fxLayoutGap="16px" fxLayoutAlign="start center">
+                  <span>Host VCT Metadata:</span>
+                  <mat-button-toggle-group
+                    [value]="vctMode"
+                    (change)="onVctModeChange($event.value)"
+                    aria-label="VCT Type"
+                  >
+                    <mat-button-toggle value="string">
+                      <mat-icon>link</mat-icon>
+                      No (Custom URI)
+                    </mat-button-toggle>
+                    <mat-button-toggle value="object">
+                      <mat-icon>data_object</mat-icon>
+                      Yes (Host Metadata)
+                    </mat-button-toggle>
+                  </mat-button-toggle-group>
                 </div>
 
-                <!-- Description -->
+                @if (vctMode === 'string') {
+                  <mat-form-field>
+                    <mat-label>VCT URI</mat-label>
+                    <input
+                      matInput
+                      formControlName="vctString"
+                      placeholder="https://example.com/credential/my-credential-type"
+                    />
+                    <mat-icon matSuffix>link</mat-icon>
+                    @if (form.get('vctString')?.invalid && form.get('vctString')?.touched) {
+                      <mat-error>VCT URI is required</mat-error>
+                    }
+                    <mat-hint>
+                      Enter a custom VCT identifier URI. No metadata will be hosted by this system.
+                    </mat-hint>
+                  </mat-form-field>
+                }
+
+                @if (vctMode === 'object') {
+                  <div class="vct-auto-uri">
+                    <mat-icon>link</mat-icon>
+                    <span>
+                      VCT URI (auto-generated): <code>{{ getVctUri() }}</code>
+                    </span>
+                  </div>
+                  <div class="vct-hint">
+                    <mat-icon>info</mat-icon>
+                    <span>
+                      Define VCT metadata that will be hosted at the VCT URI. The
+                      <code>vct</code> field will be added automatically by EUDIPLO.
+                    </span>
+                  </div>
+                  <app-editor
+                    [schema]="vctSchema"
+                    formControlName="vct"
+                    [errors]="form.get('vct')?.errors"
+                  ></app-editor>
+                }
+              </mat-card-content>
+            </mat-card>
+          }
+
+          <!-- mDOC Configuration Card (mDOC only) -->
+          @if (isMdocFormat) {
+            <mat-card>
+              <mat-card-header>
+                <mat-card-title>
+                  <mat-icon>badge</mat-icon>
+                  mDOC Configuration
+                </mat-card-title>
+                <mat-card-subtitle>mDOC (ISO 18013-5) specific configuration</mat-card-subtitle>
+              </mat-card-header>
+              <mat-card-content fxLayout="column" fxLayoutGap="16px">
+                <!-- Document Type Preset -->
                 <mat-form-field>
-                  <mat-label>Description</mat-label>
-                  <input
-                    matInput
-                    formControlName="description"
-                    placeholder="PID Credential"
-                    required
-                  />
-                  <mat-icon matSuffix>description</mat-icon>
-                  <mat-hint>Detailed description of the credential</mat-hint>
+                  <mat-label>Document Type Preset</mat-label>
+                  <mat-select (selectionChange)="onDocTypePresetChange($event.value)">
+                    @for (preset of docTypePresets; track preset.value) {
+                      <mat-option [value]="preset">{{ preset.label }}</mat-option>
+                    }
+                  </mat-select>
+                  <mat-icon matSuffix>list_alt</mat-icon>
+                  <mat-hint>Select a common document type or choose Custom</mat-hint>
                 </mat-form-field>
 
-                <!-- Colors -->
-                <div fxLayout="row" fxLayoutGap="16px" fxLayout.lt-md="column">
-                  <div fxFlex fxLayout="row" fxLayoutGap="8px" fxLayoutAlign="start center">
-                    <span
-                      class="color-swatch"
-                      [style.background-color]="
-                        displayConfig.get('background_color')?.value || '#FFFFFF'
-                      "
-                    ></span>
-                    <mat-form-field fxFlex>
-                      <mat-label>Background Color</mat-label>
-                      <input
-                        matInput
-                        formControlName="background_color"
-                        placeholder="#FFFFFF"
-                        pattern="^#[0-9A-Fa-f]{6}$"
-                      />
-                      <mat-icon matSuffix>palette</mat-icon>
-                      <mat-hint>Hex color code (e.g., #FFFFFF)</mat-hint>
-                    </mat-form-field>
-                  </div>
+                <!-- Document Type -->
+                <mat-form-field>
+                  <mat-label>Document Type (docType)</mat-label>
+                  <input matInput formControlName="docType" placeholder="org.iso.18013.5.1.mDL" />
+                  <mat-icon matSuffix>badge</mat-icon>
+                  <mat-hint>The document type identifier (e.g., org.iso.18013.5.1.mDL)</mat-hint>
+                </mat-form-field>
 
-                  <div fxFlex fxLayout="row" fxLayoutGap="8px" fxLayoutAlign="start center">
-                    <span
-                      class="color-swatch"
-                      [style.background-color]="displayConfig.get('text_color')?.value || '#000000'"
-                    ></span>
-                    <mat-form-field fxFlex>
-                      <mat-label>Text Color</mat-label>
-                      <input
-                        matInput
-                        formControlName="text_color"
-                        placeholder="#000000"
-                        pattern="^#[0-9A-Fa-f]{6}$"
-                      />
-                      <mat-icon matSuffix>format_color_text</mat-icon>
-                      <mat-hint>Hex color code (e.g., #000000)</mat-hint>
-                    </mat-form-field>
-                  </div>
-                </div>
-
-                <!-- Background Image -->
-
-                <app-image-field
-                  [field]="getControl(displayConfig.get('background_image.uri'))"
-                  label="Background Image"
-                  [required]="false"
-                ></app-image-field>
-
-                <app-image-field
-                  [field]="getControl(displayConfig.get('logo.uri'))"
-                  label="Logo"
-                  [required]="false"
-                ></app-image-field>
+                <!-- Namespace -->
+                <mat-form-field>
+                  <mat-label>Default Namespace</mat-label>
+                  <input matInput formControlName="namespace" placeholder="org.iso.18013.5.1" />
+                  <mat-icon matSuffix>folder_open</mat-icon>
+                  <mat-hint>Default namespace for claims (e.g., org.iso.18013.5.1)</mat-hint>
+                </mat-form-field>
               </mat-card-content>
             </mat-card>
           }
         </div>
+      </mat-tab>
 
-        <!-- Add Display Configuration Button -->
-        <div fxLayout="row" fxLayoutAlign="center center" class="add-button-container">
-          <button mat-stroked-button type="button" (click)="addDisplayConfig()">
-            <mat-icon>add</mat-icon>
-            Add Display Configuration
-          </button>
+      <!-- TAB 2: Business Logic -->
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <mat-icon class="tab-icon">settings_applications</mat-icon>
+          Business Logic
+        </ng-template>
+
+        <div fxLayout="column" fxLayoutGap="24px" class="tab-content">
+          <!-- Feature Toggles -->
+          <mat-card>
+            <mat-card-header>
+              <mat-card-title>
+                <mat-icon>tune</mat-icon>
+                Credential Features
+              </mat-card-title>
+            </mat-card-header>
+            <mat-card-content fxLayout="column" fxLayoutGap="16px">
+              <div fxLayout="row" fxLayoutGap="32px" fxLayout.lt-md="column">
+                <div fxFlex>
+                  <mat-slide-toggle formControlName="keyBinding">
+                    <div fxLayout="column">
+                      <span><strong>Key Binding</strong></span>
+                      <span class="toggle-description">Enable to issue key-bound credentials</span>
+                    </div>
+                  </mat-slide-toggle>
+                </div>
+                <div fxFlex>
+                  <mat-slide-toggle formControlName="statusManagement">
+                    <div fxLayout="column">
+                      <span><strong>Status Management</strong></span>
+                      <span class="toggle-description">Enable credential status tracking</span>
+                    </div>
+                  </mat-slide-toggle>
+                </div>
+              </div>
+
+              <!-- Key Attestation Requirements -->
+              <div class="key-attestation-section">
+                <mat-slide-toggle formControlName="keyAttestationEnabled">
+                  <div fxLayout="column">
+                    <span><strong>Require Key Attestation</strong></span>
+                    <span class="toggle-description">
+                      Require wallets to provide key attestation proofs (HAIP compliance)
+                    </span>
+                  </div>
+                </mat-slide-toggle>
+
+                @if (form.get('keyAttestationEnabled')?.value) {
+                  <div
+                    fxLayout="row"
+                    fxLayoutGap="16px"
+                    fxLayout.lt-md="column"
+                    class="key-attestation-fields"
+                  >
+                    <mat-form-field fxFlex appearance="outline">
+                      <mat-label>Key Storage Types</mat-label>
+                      <mat-select formControlName="keyStorageTypes" multiple>
+                        @for (preset of keyAttestationPresets; track preset.value) {
+                          <mat-option [value]="preset.value">{{ preset.label }}</mat-option>
+                        }
+                      </mat-select>
+                      <mat-hint>Required key storage assurance levels</mat-hint>
+                    </mat-form-field>
+
+                    <mat-form-field fxFlex appearance="outline">
+                      <mat-label>User Authentication Types</mat-label>
+                      <mat-select formControlName="userAuthenticationTypes" multiple>
+                        @for (preset of keyAttestationPresets; track preset.value) {
+                          <mat-option [value]="preset.value">{{ preset.label }}</mat-option>
+                        }
+                      </mat-select>
+                      <mat-hint>Required user authentication assurance levels</mat-hint>
+                    </mat-form-field>
+                  </div>
+                }
+              </div>
+            </mat-card-content>
+          </mat-card>
+
+          <!-- Embedded Disclosure Policy -->
+          <mat-card>
+            <mat-card-header>
+              <mat-card-title>
+                <mat-icon>policy</mat-icon>
+                Embedded Disclosure Policy
+              </mat-card-title>
+            </mat-card-header>
+            <mat-card-content>
+              <app-editor
+                [schema]="embeddedDisclosurePolicySchema"
+                formControlName="embeddedDisclosurePolicy"
+                [errors]="form.get('embeddedDisclosurePolicy')?.errors"
+              ></app-editor>
+            </mat-card-content>
+          </mat-card>
+
+          <!-- IAE Actions -->
+          <mat-card>
+            <mat-card-header>
+              <mat-card-title>
+                <mat-icon>interactive_space</mat-icon>
+                Interactive Authorization Actions
+              </mat-card-title>
+              <mat-card-subtitle>
+                Steps the user must complete before credential issuance
+              </mat-card-subtitle>
+            </mat-card-header>
+            <mat-card-content>
+              <div class="iae-actions-section">
+                <div fxLayout="row" fxLayoutAlign="end center" class="section-header">
+                  <button
+                    mat-button
+                    color="primary"
+                    [matMenuTriggerFor]="addActionMenu"
+                    type="button"
+                  >
+                    <mat-icon>add</mat-icon> Add Action
+                  </button>
+                  <mat-menu #addActionMenu="matMenu">
+                    <button
+                      mat-menu-item
+                      type="button"
+                      (click)="addIaeAction('openid4vp_presentation')"
+                    >
+                      <mat-icon>verified_user</mat-icon>
+                      <span>OID4VP Presentation</span>
+                    </button>
+                    <button mat-menu-item type="button" (click)="addIaeAction('redirect_to_web')">
+                      <mat-icon>open_in_new</mat-icon>
+                      <span>Redirect to Web</span>
+                    </button>
+                  </mat-menu>
+                </div>
+
+                @if (iaeActions.length === 0) {
+                  <p class="no-actions-hint">
+                    No interactive authorization required. Add actions to require user interaction
+                    before credential issuance.
+                  </p>
+                }
+
+                <div
+                  formArrayName="iaeActions"
+                  cdkDropList
+                  (cdkDropListDropped)="dropIaeAction($event)"
+                >
+                  @for (action of iaeActions.controls; track $index; let i = $index) {
+                    <mat-card class="iae-action-card" [formGroupName]="i" cdkDrag>
+                      <mat-card-header>
+                        <mat-card-title fxLayout="row" fxLayoutAlign="space-between center">
+                          <span fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="8px">
+                            <mat-icon cdkDragHandle class="drag-handle">drag_indicator</mat-icon>
+                            <span
+                              >Step {{ i + 1 }}:
+                              {{
+                                action.get('type')?.value === 'openid4vp_presentation'
+                                  ? 'OID4VP Presentation'
+                                  : 'Redirect to Web'
+                              }}
+                            </span>
+                          </span>
+                          <span>
+                            <button
+                              mat-icon-button
+                              (click)="moveIaeAction(i, 'up')"
+                              [disabled]="i === 0"
+                              type="button"
+                              matTooltip="Move up"
+                            >
+                              <mat-icon>arrow_upward</mat-icon>
+                            </button>
+                            <button
+                              mat-icon-button
+                              (click)="moveIaeAction(i, 'down')"
+                              [disabled]="i === iaeActions.length - 1"
+                              type="button"
+                              matTooltip="Move down"
+                            >
+                              <mat-icon>arrow_downward</mat-icon>
+                            </button>
+                            <button
+                              mat-icon-button
+                              color="warn"
+                              (click)="removeIaeAction(i)"
+                              type="button"
+                              matTooltip="Remove action"
+                            >
+                              <mat-icon>delete</mat-icon>
+                            </button>
+                          </span>
+                        </mat-card-title>
+                      </mat-card-header>
+                      <mat-card-content>
+                        @if (action.get('type')?.value === 'openid4vp_presentation') {
+                          <mat-form-field appearance="outline" class="full-width">
+                            <mat-label>Presentation Config</mat-label>
+                            <mat-select formControlName="presentationConfigId">
+                              @for (pc of presentationConfigs; track pc.id) {
+                                <mat-option [value]="pc.id"
+                                  >{{ pc.id
+                                  }}{{ pc.description ? ' - ' + pc.description : '' }}</mat-option
+                                >
+                              }
+                            </mat-select>
+                            <mat-icon matSuffix>verified_user</mat-icon>
+                            <mat-hint
+                              >Select the presentation config to use for verification</mat-hint
+                            >
+                          </mat-form-field>
+                        }
+                        @if (action.get('type')?.value === 'redirect_to_web') {
+                          <div fxLayout="column" fxLayoutGap="16px">
+                            <mat-form-field appearance="outline" class="full-width">
+                              <mat-label>Redirect URL</mat-label>
+                              <input
+                                matInput
+                                formControlName="url"
+                                placeholder="https://example.com/form"
+                              />
+                              <mat-icon matSuffix>link</mat-icon>
+                              <mat-hint>URL to redirect the user to</mat-hint>
+                            </mat-form-field>
+                            <mat-form-field appearance="outline" class="full-width">
+                              <mat-label>Callback URL</mat-label>
+                              <input
+                                matInput
+                                formControlName="callbackUrl"
+                                placeholder="https://issuer.example.com/iae/callback"
+                              />
+                              <mat-icon matSuffix>keyboard_return</mat-icon>
+                              <mat-hint
+                                >URL where the external service should redirect back
+                                (optional)</mat-hint
+                              >
+                            </mat-form-field>
+                            <mat-form-field appearance="outline" class="full-width">
+                              <mat-label>Description</mat-label>
+                              <input
+                                matInput
+                                formControlName="description"
+                                placeholder="Complete additional verification"
+                              />
+                              <mat-icon matSuffix>description</mat-icon>
+                              <mat-hint>Description shown to the user (optional)</mat-hint>
+                            </mat-form-field>
+                          </div>
+                        }
+                      </mat-card-content>
+                    </mat-card>
+                  }
+                </div>
+              </div>
+            </mat-card-content>
+          </mat-card>
+
+          <!-- Attribute Provider -->
+          <mat-card>
+            <mat-card-header>
+              <mat-card-title>
+                <mat-icon>cloud_download</mat-icon>
+                Attribute Provider
+              </mat-card-title>
+              <mat-card-subtitle>
+                Select an attribute provider for dynamically fetching claims
+              </mat-card-subtitle>
+            </mat-card-header>
+            <mat-card-content fxLayout="column" fxLayoutGap="16px">
+              <mat-form-field>
+                <mat-label>Attribute Provider</mat-label>
+                <mat-select formControlName="attributeProviderId">
+                  <mat-option value="">None</mat-option>
+                  @for (provider of attributeProviders; track provider.id) {
+                    <mat-option [value]="provider.id"
+                      >{{ provider.name }} ({{ provider.id }})</mat-option
+                    >
+                  }
+                </mat-select>
+                <mat-hint>External endpoint that provides claim values during issuance</mat-hint>
+              </mat-form-field>
+            </mat-card-content>
+          </mat-card>
+
+          <!-- Webhook Endpoint -->
+          <mat-card>
+            <mat-card-header>
+              <mat-card-title>
+                <mat-icon>webhook</mat-icon>
+                Webhook Endpoint
+              </mat-card-title>
+              <mat-card-subtitle>
+                Select a webhook endpoint for lifecycle event notifications
+              </mat-card-subtitle>
+            </mat-card-header>
+            <mat-card-content fxLayout="column" fxLayoutGap="16px">
+              <mat-form-field>
+                <mat-label>Webhook Endpoint</mat-label>
+                <mat-select formControlName="webhookEndpointId">
+                  <mat-option value="">None</mat-option>
+                  @for (endpoint of webhookEndpoints; track endpoint.id) {
+                    <mat-option [value]="endpoint.id"
+                      >{{ endpoint.name }} ({{ endpoint.id }})</mat-option
+                    >
+                  }
+                </mat-select>
+                <mat-hint>Endpoint that receives credential lifecycle notifications</mat-hint>
+              </mat-form-field>
+            </mat-card-content>
+          </mat-card>
         </div>
-      </mat-card-content>
-    </mat-card>
+      </mat-tab>
 
-    <!-- Attribute Provider -->
-    <mat-card>
-      <mat-card-header>
-        <mat-card-title>
-          <mat-icon>cloud_download</mat-icon>
-          Attribute Provider
-        </mat-card-title>
-        <mat-card-subtitle
-          >Select an attribute provider for dynamically fetching claims</mat-card-subtitle
-        >
-      </mat-card-header>
-      <mat-card-content fxLayout="column" fxLayoutGap="16px">
-        <mat-form-field>
-          <mat-label>Attribute Provider</mat-label>
-          <mat-select formControlName="attributeProviderId">
-            <mat-option value="">None</mat-option>
-            @for (provider of attributeProviders; track provider.id) {
-              <mat-option [value]="provider.id">{{ provider.name }} ({{ provider.id }})</mat-option>
-            }
-          </mat-select>
-          <mat-hint>External endpoint that provides claim values during issuance</mat-hint>
-        </mat-form-field>
-      </mat-card-content>
-    </mat-card>
+      <!-- TAB 3: Visual & Display -->
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <mat-icon class="tab-icon">palette</mat-icon>
+          Visual &amp; Display
+        </ng-template>
 
-    <!-- Webhook Endpoint -->
-    <mat-card>
-      <mat-card-header>
-        <mat-card-title>
-          <mat-icon>webhook</mat-icon>
-          Webhook Endpoint
-        </mat-card-title>
-        <mat-card-subtitle
-          >Select a webhook endpoint for lifecycle event notifications</mat-card-subtitle
-        >
-      </mat-card-header>
-      <mat-card-content fxLayout="column" fxLayoutGap="16px">
-        <mat-form-field>
-          <mat-label>Webhook Endpoint</mat-label>
-          <mat-select formControlName="webhookEndpointId">
-            <mat-option value="">None</mat-option>
-            @for (endpoint of webhookEndpoints; track endpoint.id) {
-              <mat-option [value]="endpoint.id">{{ endpoint.name }} ({{ endpoint.id }})</mat-option>
-            }
-          </mat-select>
-          <mat-hint>Endpoint that receives credential lifecycle notifications</mat-hint>
-        </mat-form-field>
-      </mat-card-content>
-    </mat-card>
+        <div fxLayout="column" fxLayoutGap="24px" class="tab-content">
+          <mat-card>
+            <mat-card-header>
+              <mat-card-title>
+                <mat-icon>palette</mat-icon>
+                Display Configuration
+              </mat-card-title>
+              <mat-card-subtitle>
+                Configure how credentials appear in wallets and viewers
+              </mat-card-subtitle>
+            </mat-card-header>
+            <mat-card-content>
+              <div formArrayName="displayConfigs">
+                @for (displayConfig of displayConfigs.controls; track $index; let i = $index) {
+                  <mat-card class="display-config-card" [formGroupName]="i">
+                    <mat-card-header>
+                      <mat-card-title>
+                        <span>Display Configuration {{ i + 1 }}</span>
+                        @if (displayConfigs.length > 1) {
+                          <button
+                            matIconButton
+                            type="button"
+                            color="warn"
+                            (click)="removeDisplayConfig(i)"
+                            matTooltip="Remove this display configuration"
+                          >
+                            <mat-icon>delete</mat-icon>
+                          </button>
+                        }
+                      </mat-card-title>
+                    </mat-card-header>
+                    <mat-card-content fxLayout="column" fxLayoutGap="16px">
+                      <div fxLayout="row" fxLayoutGap="16px" fxLayout.lt-md="column">
+                        <mat-form-field fxFlex>
+                          <mat-label>Display Name</mat-label>
+                          <input matInput formControlName="name" placeholder="PID" required />
+                          <mat-icon matSuffix>title</mat-icon>
+                          <mat-hint>Short name shown in wallet</mat-hint>
+                        </mat-form-field>
 
-    <!-- VCT Information Card (SD-JWT only) -->
-    @if (!isMdocFormat) {
-      <mat-card>
-        <mat-card-header>
-          <mat-card-title>
-            <mat-icon>description</mat-icon>
-            Verifiable Credential Type (VCT)
-          </mat-card-title>
-          <mat-card-subtitle>SD-JWT VC specific configuration</mat-card-subtitle>
-        </mat-card-header>
-        <mat-card-content fxLayout="column" fxLayoutGap="16px">
-          <!-- VCT Mode Selection -->
-          <div fxLayout="row" fxLayoutGap="16px" fxLayoutAlign="start center">
-            <span>Host VCT Metadata:</span>
-            <mat-button-toggle-group
-              [value]="vctMode"
-              (change)="onVctModeChange($event.value)"
-              aria-label="VCT Type"
-            >
-              <mat-button-toggle value="string">
-                <mat-icon>link</mat-icon>
-                No (Custom URI)
-              </mat-button-toggle>
-              <mat-button-toggle value="object">
-                <mat-icon>data_object</mat-icon>
-                Yes (Host Metadata)
-              </mat-button-toggle>
-            </mat-button-toggle-group>
-          </div>
+                        <mat-form-field fxFlex>
+                          <mat-label>Locale</mat-label>
+                          <mat-select formControlName="locale">
+                            <mat-option value="en-US">English (US)</mat-option>
+                            <mat-option value="en-GB">English (UK)</mat-option>
+                            <mat-option value="de-DE">German</mat-option>
+                            <mat-option value="fr-FR">French</mat-option>
+                            <mat-option value="es-ES">Spanish</mat-option>
+                            <mat-option value="it-IT">Italian</mat-option>
+                          </mat-select>
+                          <mat-icon matSuffix>language</mat-icon>
+                        </mat-form-field>
+                      </div>
 
-          <!-- Custom VCT URI Input (when not hosting metadata) -->
-          @if (vctMode === 'string') {
-            <mat-form-field>
-              <mat-label>VCT URI</mat-label>
-              <input
-                matInput
-                formControlName="vctString"
-                placeholder="https://example.com/credential/my-credential-type"
-              />
-              <mat-icon matSuffix>link</mat-icon>
-              @if (form.get('vctString')?.invalid && form.get('vctString')?.touched) {
-                <mat-error>VCT URI is required</mat-error>
-              }
-              <mat-hint>
-                Enter a custom VCT identifier URI. No metadata will be hosted by this system.
-              </mat-hint>
-            </mat-form-field>
+                      <mat-form-field>
+                        <mat-label>Description</mat-label>
+                        <input
+                          matInput
+                          formControlName="description"
+                          placeholder="PID Credential"
+                          required
+                        />
+                        <mat-icon matSuffix>description</mat-icon>
+                        <mat-hint>Detailed description of the credential</mat-hint>
+                      </mat-form-field>
+
+                      <div fxLayout="row" fxLayoutGap="16px" fxLayout.lt-md="column">
+                        <div fxFlex fxLayout="row" fxLayoutGap="8px" fxLayoutAlign="start center">
+                          <span
+                            class="color-swatch"
+                            [style.background-color]="
+                              displayConfig.get('background_color')?.value || '#FFFFFF'
+                            "
+                          ></span>
+                          <mat-form-field fxFlex>
+                            <mat-label>Background Color</mat-label>
+                            <input
+                              matInput
+                              formControlName="background_color"
+                              placeholder="#FFFFFF"
+                              pattern="^#[0-9A-Fa-f]{6}$"
+                            />
+                            <mat-icon matSuffix>palette</mat-icon>
+                            <mat-hint>Hex color code (e.g., #FFFFFF)</mat-hint>
+                          </mat-form-field>
+                        </div>
+
+                        <div fxFlex fxLayout="row" fxLayoutGap="8px" fxLayoutAlign="start center">
+                          <span
+                            class="color-swatch"
+                            [style.background-color]="
+                              displayConfig.get('text_color')?.value || '#000000'
+                            "
+                          ></span>
+                          <mat-form-field fxFlex>
+                            <mat-label>Text Color</mat-label>
+                            <input
+                              matInput
+                              formControlName="text_color"
+                              placeholder="#000000"
+                              pattern="^#[0-9A-Fa-f]{6}$"
+                            />
+                            <mat-icon matSuffix>format_color_text</mat-icon>
+                            <mat-hint>Hex color code (e.g., #000000)</mat-hint>
+                          </mat-form-field>
+                        </div>
+                      </div>
+
+                      <app-image-field
+                        [field]="getControl(displayConfig.get('background_image.uri'))"
+                        label="Background Image"
+                        [required]="false"
+                      ></app-image-field>
+
+                      <app-image-field
+                        [field]="getControl(displayConfig.get('logo.uri'))"
+                        label="Logo"
+                        [required]="false"
+                      ></app-image-field>
+                    </mat-card-content>
+                  </mat-card>
+                }
+              </div>
+
+              <div fxLayout="row" fxLayoutAlign="center center" class="add-button-container">
+                <button mat-stroked-button type="button" (click)="addDisplayConfig()">
+                  <mat-icon>add</mat-icon>
+                  Add Display Configuration
+                </button>
+              </div>
+            </mat-card-content>
+          </mat-card>
+        </div>
+      </mat-tab>
+
+      <!-- TAB 4: Claims & Disclosure -->
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <mat-icon class="tab-icon">fact_check</mat-icon>
+          Claims &amp; Disclosure
+        </ng-template>
+
+        <div fxLayout="column" fxLayoutGap="24px" class="tab-content">
+          <!-- Default Claims -->
+          <mat-card>
+            <mat-card-header>
+              <mat-card-title>
+                <mat-icon>fact_check</mat-icon>
+                Default Claims
+              </mat-card-title>
+              <mat-card-subtitle>
+                Claims to include in every credential if no others are provided.
+              </mat-card-subtitle>
+            </mat-card-header>
+            <mat-card-content>
+              <app-editor
+                formControlName="claims"
+                [errors]="form.get('claims')?.errors"
+              ></app-editor>
+            </mat-card-content>
+          </mat-card>
+
+          <!-- Disclosure Frame (SD-JWT only) -->
+          @if (!isMdocFormat) {
+            <mat-card>
+              <mat-card-header>
+                <mat-card-title>
+                  <mat-icon>visibility</mat-icon>
+                  Disclosure Frame
+                </mat-card-title>
+                <mat-card-subtitle>
+                  Controls which SD-JWT claims are selectively disclosable
+                </mat-card-subtitle>
+              </mat-card-header>
+              <mat-card-content>
+                <app-editor
+                  formControlName="disclosureFrame"
+                  [errors]="form.get('disclosureFrame')?.errors"
+                ></app-editor>
+              </mat-card-content>
+            </mat-card>
           }
 
-          <!-- Auto-generated VCT URI (when hosting metadata) -->
-          @if (vctMode === 'object') {
-            <div class="vct-auto-uri">
-              <mat-icon>link</mat-icon>
-              <span>
-                VCT URI (auto-generated): <code>{{ getVctUri() }}</code>
-              </span>
-            </div>
-
-            <div class="vct-hint">
-              <mat-icon>info</mat-icon>
-              <span>
-                Define VCT metadata that will be hosted at the VCT URI. The <code>vct</code> field
-                will be added automatically by EUDIPLO.
-              </span>
-            </div>
-            <app-editor
-              [schema]="vctSchema"
-              formControlName="vct"
-              [errors]="form.get('vct')?.errors"
-            ></app-editor>
+          <!-- Claims by Namespace (mDOC only) -->
+          @if (isMdocFormat) {
+            <mat-card>
+              <mat-card-header>
+                <mat-card-title>
+                  <mat-icon>folder_open</mat-icon>
+                  Claims by Namespace
+                </mat-card-title>
+                <mat-card-subtitle>
+                  Define claims organized by namespace for multi-namespace mDOC documents
+                </mat-card-subtitle>
+              </mat-card-header>
+              <mat-card-content>
+                <app-editor
+                  formControlName="claimsByNamespace"
+                  [errors]="form.get('claimsByNamespace')?.errors"
+                ></app-editor>
+              </mat-card-content>
+            </mat-card>
           }
-        </mat-card-content>
-      </mat-card>
-    }
 
-    <!-- mDOC Configuration Card (mDOC only) -->
-    @if (isMdocFormat) {
-      <mat-card>
-        <mat-card-header>
-          <mat-card-title>
-            <mat-icon>description</mat-icon>
-            mDOC Configuration
-          </mat-card-title>
-          <mat-card-subtitle>mDOC (ISO 18013-5) specific configuration</mat-card-subtitle>
-        </mat-card-header>
-        <mat-card-content fxLayout="column" fxLayoutGap="16px">
-          <!-- Document Type Preset -->
-          <mat-form-field>
-            <mat-label>Document Type Preset</mat-label>
-            <mat-select (selectionChange)="onDocTypePresetChange($event.value)">
-              @for (preset of docTypePresets; track preset.value) {
-                <mat-option [value]="preset">{{ preset.label }}</mat-option>
-              }
-            </mat-select>
-            <mat-icon matSuffix>list_alt</mat-icon>
-            <mat-hint>Select a common document type or choose Custom</mat-hint>
-          </mat-form-field>
+          <!-- JSON Schema -->
+          <mat-card>
+            <mat-card-header>
+              <mat-card-title>
+                <mat-icon>schema</mat-icon>
+                JSON Schema
+              </mat-card-title>
+              <mat-card-subtitle
+                >Used to validate passed claims against a JSON schema</mat-card-subtitle
+              >
+            </mat-card-header>
+            <mat-card-content>
+              <app-editor
+                formControlName="schema"
+                [errors]="form.get('schema')?.errors"
+              ></app-editor>
+            </mat-card-content>
+          </mat-card>
 
-          <!-- Document Type -->
-          <mat-form-field>
-            <mat-label>Document Type (docType)</mat-label>
-            <input matInput formControlName="docType" placeholder="org.iso.18013.5.1.mDL" />
-            <mat-icon matSuffix>badge</mat-icon>
-            <mat-hint>The document type identifier (e.g., org.iso.18013.5.1.mDL)</mat-hint>
-          </mat-form-field>
-
-          <!-- Namespace -->
-          <mat-form-field>
-            <mat-label>Default Namespace</mat-label>
-            <input matInput formControlName="namespace" placeholder="org.iso.18013.5.1" />
-            <mat-icon matSuffix>folder_open</mat-icon>
-            <mat-hint>Default namespace for claims (e.g., org.iso.18013.5.1)</mat-hint>
-          </mat-form-field>
-
-          <!-- Claims by Namespace -->
-          <h4>Claims by Namespace (Optional)</h4>
-          <p class="field-description">
-            Define claims organized by namespace. Use this when you need claims from multiple
-            namespaces.
-          </p>
-          <app-editor
-            formControlName="claimsByNamespace"
-            [errors]="form.get('claimsByNamespace')?.errors"
-          ></app-editor>
-        </mat-card-content>
-      </mat-card>
-    }
-
-    <!-- Advanced Configuration -->
-    <mat-expansion-panel>
-      <mat-expansion-panel-header>
-        <mat-panel-title>
-          <mat-icon>settings_applications</mat-icon>
-          Advanced Configuration
-        </mat-panel-title>
-        <mat-panel-description> Optional advanced settings and schemas </mat-panel-description>
-      </mat-expansion-panel-header>
-
-      <div fxLayout="column" fxLayoutGap="16px" class="expansion-content">
-        <!-- Default Claims -->
-        <h4>
-          Default claims to include in every credential if no others are provided. Good for demo
-          purposes
-        </h4>
-        <app-editor formControlName="claims" [errors]="form.get('claims')?.errors"></app-editor>
-
-        <!-- Disclosure Frame (SD-JWT only) -->
-        @if (!isMdocFormat) {
-          <h4>Disclosure Frame (SD-JWT)</h4>
-          <app-editor
-            formControlName="disclosureFrame"
-            [errors]="form.get('disclosureFrame')?.errors"
-          ></app-editor>
-        }
-
-        <!-- JSON Schema -->
-        <h4>JSON Schema</h4>
-        <p>Used to validate passed claims against a JSON schema</p>
-        <app-editor formControlName="schema" [errors]="form.get('schema')?.errors"></app-editor>
-
-        <!-- Embedded Disclosure Policy -->
-        <h4>Embedded Disclosure Policy</h4>
-        <app-editor
-          [schema]="embeddedDisclosurePolicySchema"
-          formControlName="embeddedDisclosurePolicy"
-          [errors]="form.get('embeddedDisclosurePolicy')?.errors"
-        ></app-editor>
-
-        <!-- Claims Metadata -->
-        <h4>Claims Metadata</h4>
-        <p>
-          Define metadata for individual claims including display names in different languages, and
-          whether each claim is mandatory. This is exposed in the issuer metadata for wallets to
-          render claims appropriately.
-        </p>
-        <app-editor
-          [schema]="claimsMetadataSchema"
-          formControlName="claimsMetadata"
-          [errors]="form.get('claimsMetadata')?.errors"
-        ></app-editor>
-      </div>
-    </mat-expansion-panel>
+          <!-- Claims Metadata -->
+          <mat-card>
+            <mat-card-header>
+              <mat-card-title>
+                <mat-icon>label</mat-icon>
+                Claims Metadata
+              </mat-card-title>
+              <mat-card-subtitle>
+                Define metadata for individual claims including display names in different languages
+                and whether each claim is mandatory.
+              </mat-card-subtitle>
+            </mat-card-header>
+            <mat-card-content>
+              <app-editor
+                [schema]="claimsMetadataSchema"
+                formControlName="claimsMetadata"
+                [errors]="form.get('claimsMetadata')?.errors"
+              ></app-editor>
+            </mat-card-content>
+          </mat-card>
+        </div>
+      </mat-tab>
+    </mat-tab-group>
 
     <!-- Action Buttons -->
-    <div fxLayout="row" fxLayoutGap="16px" fxLayoutAlign="end center">
+    <div fxLayout="row" fxLayoutGap="16px" fxLayoutAlign="end center" class="form-actions">
       <button mat-button type="button" [routerLink]="['../']">Cancel</button>
       <button mat-flat-button type="submit" [disabled]="loading">
         @if (loading) {

--- a/apps/client/src/app/issuance/credential-config/credential-config-create/credential-config-create.component.scss
+++ b/apps/client/src/app/issuance/credential-config/credential-config-create/credential-config-create.component.scss
@@ -2,6 +2,14 @@
   width: 100%;
 }
 
+.tab-content {
+  padding-top: 24px;
+}
+
+.tab-icon {
+  margin-right: 8px;
+}
+
 .json-textarea {
   font-family: 'Roboto Mono', monospace;
   font-size: 13px;

--- a/apps/client/src/app/issuance/credential-config/credential-config-create/credential-config-create.component.ts
+++ b/apps/client/src/app/issuance/credential-config/credential-config-create/credential-config-create.component.ts
@@ -15,6 +15,7 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSelectModule } from '@angular/material/select';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatTabsModule } from '@angular/material/tabs';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { FlexLayoutModule } from 'ngx-flexible-layout';
@@ -59,6 +60,7 @@ import { ImageFieldComponent } from '../../../utils/image-field/image-field.comp
     MatDialogModule,
     MatDividerModule,
     MatMenuModule,
+    MatTabsModule,
     MatTooltipModule,
     FlexLayoutModule,
     MatSlideToggleModule,
@@ -653,7 +655,6 @@ export class CredentialConfigCreateComponent implements OnInit {
       format: formValue.format,
       display: formValue.displayConfigs,
       scope: formValue.scope || undefined,
-      claimsMetadata: this.parseJsonField(formValue.claimsMetadata, 'parse', true),
       // Key attestation requirements (if enabled)
       ...(formValue.keyAttestationEnabled && {
         keyAttestationsRequired: {

--- a/apps/client/src/app/issuance/credential-config/credential-config-show/credential-config-show.component.html
+++ b/apps/client/src/app/issuance/credential-config/credential-config-show/credential-config-show.component.html
@@ -28,7 +28,6 @@
 
     <!-- Tab Group -->
     <mat-tab-group animationDuration="200ms">
-
       <!-- ── TAB 1: Metadata ──────────────────────────────────────────── -->
       <mat-tab>
         <ng-template mat-tab-label>
@@ -37,7 +36,6 @@
         </ng-template>
 
         <div fxLayout="column" fxLayoutGap="24px" class="tab-content">
-
           <!-- General Information -->
           <mat-card>
             <mat-card-header>
@@ -163,7 +161,6 @@
               </mat-card-content>
             </mat-card>
           }
-
         </div>
       </mat-tab>
 
@@ -175,7 +172,6 @@
         </ng-template>
 
         <div fxLayout="column" fxLayoutGap="24px" class="tab-content">
-
           <!-- Credential Features -->
           <mat-card>
             <mat-card-header>
@@ -201,7 +197,9 @@
                     {{ config.statusManagement ? 'verified' : 'block' }}
                   </mat-icon>
                   <span matListItemTitle>Status Management</span>
-                  <span matListItemLine>{{ config.statusManagement ? 'Enabled' : 'Disabled' }}</span>
+                  <span matListItemLine>{{
+                    config.statusManagement ? 'Enabled' : 'Disabled'
+                  }}</span>
                 </mat-list-item>
                 @if (config.statusManagement && statusListId) {
                   <mat-list-item>
@@ -249,11 +247,12 @@
             </mat-card-header>
             <mat-card-content>
               <div class="config-item">
-                <pre class="config-value">{{ formatJsonValue(config.embeddedDisclosurePolicy) }}</pre>
+                <pre class="config-value">{{
+                  formatJsonValue(config.embeddedDisclosurePolicy)
+                }}</pre>
               </div>
             </mat-card-content>
           </mat-card>
-
         </div>
       </mat-tab>
 
@@ -265,7 +264,6 @@
         </ng-template>
 
         <div fxLayout="column" fxLayoutGap="24px" class="tab-content">
-
           <!-- Credential Preview -->
           @if (primaryDisplay) {
             <mat-card class="preview-card">
@@ -351,7 +349,6 @@
               </mat-card-content>
             </mat-card>
           }
-
         </div>
       </mat-tab>
 
@@ -363,7 +360,6 @@
         </ng-template>
 
         <div fxLayout="column" fxLayoutGap="24px" class="tab-content">
-
           <!-- Default Claims -->
           <mat-card>
             <mat-card-header>
@@ -435,7 +431,9 @@
                 <mat-card-subtitle>Claims organized by mDOC namespace</mat-card-subtitle>
               </mat-card-header>
               <mat-card-content>
-                <pre class="config-value">{{ formatJsonValue(config.config.claimsByNamespace) }}</pre>
+                <pre class="config-value">{{
+                  formatJsonValue(config.config.claimsByNamespace)
+                }}</pre>
               </mat-card-content>
             </mat-card>
           }
@@ -502,10 +500,8 @@
               </div>
             }
           </mat-expansion-panel>
-
         </div>
       </mat-tab>
-
     </mat-tab-group>
   </div>
 }

--- a/apps/client/src/app/issuance/credential-config/credential-config-show/credential-config-show.component.html
+++ b/apps/client/src/app/issuance/credential-config/credential-config-show/credential-config-show.component.html
@@ -26,419 +26,486 @@
       </div>
     </div>
 
-    <!-- General Information Card -->
-    <mat-card>
-      <mat-card-header>
-        <mat-card-title>
-          <mat-icon>settings</mat-icon>
-          General Information
-        </mat-card-title>
-      </mat-card-header>
-      <mat-card-content>
-        <mat-list class="config-list">
-          <mat-list-item>
-            <mat-icon matListItemIcon>fingerprint</mat-icon>
-            <span matListItemTitle>Configuration ID</span>
-            <span matListItemLine>{{ config.id }}</span>
-          </mat-list-item>
-          @if (config.description) {
-            <mat-list-item>
-              <mat-icon matListItemIcon>description</mat-icon>
-              <span matListItemTitle>Description</span>
-              <span matListItemLine>{{ config.description }}</span>
-            </mat-list-item>
-          }
-          <mat-list-item>
-            <mat-icon matListItemIcon>category</mat-icon>
-            <span matListItemTitle>Format</span>
-            <span matListItemLine>{{ formatLabel }}</span>
-          </mat-list-item>
-          <mat-list-item>
-            <mat-icon matListItemIcon>timer</mat-icon>
-            <span matListItemTitle>Lifetime</span>
-            <span matListItemLine>{{ formatLifetime(config.lifeTime) }}</span>
-          </mat-list-item>
-          @if (config.keyChain) {
-            <mat-list-item>
-              <mat-icon matListItemIcon>key</mat-icon>
-              <span matListItemTitle>Key Chain</span>
-              <span matListItemLine
-                >{{ config.keyChain.id }} ({{
-                  config.keyChain.description || config.keyChain.usageType
-                }})</span
-              >
-            </mat-list-item>
-          }
-          @if (config.config.scope) {
-            <mat-list-item>
-              <mat-icon matListItemIcon>shield</mat-icon>
-              <span matListItemTitle>Scope</span>
-              <span matListItemLine>{{ config.config.scope }}</span>
-            </mat-list-item>
-          }
-          <mat-list-item>
-            <mat-icon matListItemIcon>
-              {{ config.keyBinding ? 'lock' : 'lock_open' }}
-            </mat-icon>
-            <span matListItemTitle>Key Binding</span>
-            <span matListItemLine>{{ config.keyBinding ? 'Enabled' : 'Disabled' }}</span>
-          </mat-list-item>
-          <mat-list-item>
-            <mat-icon
-              matListItemIcon
-              [class]="config.statusManagement ? 'icon-enabled' : 'icon-disabled'"
-            >
-              {{ config.statusManagement ? 'verified' : 'block' }}
-            </mat-icon>
-            <span matListItemTitle>Status Management</span>
-            <span matListItemLine>{{ config.statusManagement ? 'Enabled' : 'Disabled' }}</span>
-          </mat-list-item>
-          @if (config.statusManagement && statusListId) {
-            <mat-list-item>
-              <mat-icon matListItemIcon>checklist</mat-icon>
-              <span matListItemTitle>Status List</span>
-              <span matListItemLine>
-                <a [routerLink]="['/status-lists', statusListId]">{{ statusListId }}</a>
-              </span>
-            </mat-list-item>
-          }
-          @if (config.attributeProviderId) {
-            <mat-list-item>
-              <mat-icon matListItemIcon>webhook</mat-icon>
-              <span matListItemTitle>Attribute Provider</span>
-              <span matListItemLine>
-                <a [routerLink]="['/attribute-providers', config.attributeProviderId]">{{
-                  config.attributeProviderId
-                }}</a>
-              </span>
-            </mat-list-item>
-          }
-          @if (config.webhookEndpointId) {
-            <mat-list-item>
-              <mat-icon matListItemIcon>notifications</mat-icon>
-              <span matListItemTitle>Webhook Endpoint</span>
-              <span matListItemLine>
-                <a [routerLink]="['/webhook-endpoints', config.webhookEndpointId]">{{
-                  config.webhookEndpointId
-                }}</a>
-              </span>
-            </mat-list-item>
-          }
-        </mat-list>
-      </mat-card-content>
-    </mat-card>
+    <!-- Tab Group -->
+    <mat-tab-group animationDuration="200ms">
 
-    <!-- Credential Preview Card -->
-    @if (primaryDisplay) {
-      <mat-card class="preview-card">
-        <mat-card-header>
-          <mat-card-title>
-            <mat-icon>preview</mat-icon>
-            Credential Preview
-          </mat-card-title>
-          <mat-card-subtitle>How the credential appears in wallets</mat-card-subtitle>
-        </mat-card-header>
-        <mat-card-content>
-          <div
-            class="credential-preview"
-            [style.background-color]="primaryDisplay.background_color || '#FFFFFF'"
-            [style.color]="primaryDisplay.text_color || '#000000'"
-            [style.background-image]="
-              primaryDisplay.background_image?.uri
-                ? 'url(' + primaryDisplay.background_image.uri + ')'
-                : 'none'
-            "
-          >
-            @if (primaryDisplay.logo?.uri) {
-              <img [src]="primaryDisplay.logo.uri" alt="Logo" class="preview-logo" />
-            }
-            <div class="preview-content">
-              <div class="preview-name">{{ primaryDisplay.name }}</div>
-              <div class="preview-description">{{ primaryDisplay.description }}</div>
-              <div class="preview-locale">{{ primaryDisplay.locale }}</div>
-            </div>
-          </div>
-          @if (config.config.display && config.config.display.length > 1) {
-            <div class="locale-chips">
-              <strong>Available locales:</strong>
-              <mat-chip-set>
-                @for (display of config.config.display; track display.locale) {
-                  <mat-chip>{{ display.locale }} - {{ display.name }}</mat-chip>
+      <!-- ── TAB 1: Metadata ──────────────────────────────────────────── -->
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <mat-icon class="tab-icon">info</mat-icon>
+          Metadata
+        </ng-template>
+
+        <div fxLayout="column" fxLayoutGap="24px" class="tab-content">
+
+          <!-- General Information -->
+          <mat-card>
+            <mat-card-header>
+              <mat-card-title>
+                <mat-icon>settings</mat-icon>
+                General Information
+              </mat-card-title>
+            </mat-card-header>
+            <mat-card-content>
+              <mat-list class="config-list">
+                <mat-list-item>
+                  <mat-icon matListItemIcon>fingerprint</mat-icon>
+                  <span matListItemTitle>Configuration ID</span>
+                  <span matListItemLine>{{ config.id }}</span>
+                </mat-list-item>
+                @if (config.description) {
+                  <mat-list-item>
+                    <mat-icon matListItemIcon>description</mat-icon>
+                    <span matListItemTitle>Description</span>
+                    <span matListItemLine>{{ config.description }}</span>
+                  </mat-list-item>
                 }
-              </mat-chip-set>
-            </div>
+                <mat-list-item>
+                  <mat-icon matListItemIcon>category</mat-icon>
+                  <span matListItemTitle>Format</span>
+                  <span matListItemLine>{{ formatLabel }}</span>
+                </mat-list-item>
+                <mat-list-item>
+                  <mat-icon matListItemIcon>timer</mat-icon>
+                  <span matListItemTitle>Lifetime</span>
+                  <span matListItemLine>{{ formatLifetime(config.lifeTime) }}</span>
+                </mat-list-item>
+                @if (config.keyChain) {
+                  <mat-list-item>
+                    <mat-icon matListItemIcon>key</mat-icon>
+                    <span matListItemTitle>Key Chain</span>
+                    <span matListItemLine>
+                      {{ config.keyChain.id }} ({{
+                        config.keyChain.description || config.keyChain.usageType
+                      }})
+                    </span>
+                  </mat-list-item>
+                }
+                @if (config.config.scope) {
+                  <mat-list-item>
+                    <mat-icon matListItemIcon>shield</mat-icon>
+                    <span matListItemTitle>Scope</span>
+                    <span matListItemLine>{{ config.config.scope }}</span>
+                  </mat-list-item>
+                }
+              </mat-list>
+            </mat-card-content>
+          </mat-card>
+
+          <!-- VCT Information Card (SD-JWT only) -->
+          @if (config.vct && !isMdocFormat) {
+            <mat-card>
+              <mat-card-header>
+                <mat-card-title>
+                  <mat-icon>description</mat-icon>
+                  Verifiable Credential Type (VCT)
+                </mat-card-title>
+              </mat-card-header>
+              <mat-card-content fxLayout="column" fxLayoutGap="16px">
+                @if (isVctString) {
+                  <div>
+                    <div><strong>VCT URI:</strong></div>
+                    <div class="value-text">{{ vctAsString }}</div>
+                  </div>
+                } @else {
+                  <div>
+                    <div><strong>Name:</strong></div>
+                    <div class="value-text">{{ vctAsObject?.name || 'Not specified' }}</div>
+                  </div>
+                  @if (vctAsObject?.description) {
+                    <div>
+                      <div><strong>Description:</strong></div>
+                      <div class="value-text">{{ vctAsObject.description }}</div>
+                    </div>
+                  }
+                  @if (vctAsObject?.extends) {
+                    <div>
+                      <div><strong>Extends:</strong></div>
+                      <div class="value-text">{{ vctAsObject.extends }}</div>
+                    </div>
+                  }
+                  @if (vctAsObject?.schema_uri) {
+                    <div>
+                      <div><strong>Schema URI:</strong></div>
+                      <div class="value-text">{{ vctAsObject.schema_uri }}</div>
+                    </div>
+                  }
+                }
+              </mat-card-content>
+            </mat-card>
           }
-        </mat-card-content>
-      </mat-card>
-    }
 
-    <!-- VCT Information Card (SD-JWT only) -->
-    @if (config.vct && !isMdocFormat) {
-      <mat-card>
-        <mat-card-header>
-          <mat-card-title>
-            <mat-icon>description</mat-icon>
-            Verifiable Credential Type (VCT)
-          </mat-card-title>
-        </mat-card-header>
-        <mat-card-content fxLayout="column" fxLayoutGap="16px">
-          @if (isVctString) {
-            <!-- VCT as string URI -->
-            <div>
-              <div><strong>VCT URI:</strong></div>
-              <div class="value-text">{{ vctAsString }}</div>
-            </div>
-          } @else {
-            <!-- VCT as object -->
-            <div>
-              <div><strong>Name:</strong></div>
-              <div class="value-text">{{ vctAsObject?.name || 'Not specified' }}</div>
-            </div>
-
-            @if (vctAsObject?.description) {
-              <div>
-                <div><strong>Description:</strong></div>
-                <div class="value-text">{{ vctAsObject.description }}</div>
-              </div>
-            }
-            @if (vctAsObject?.extends) {
-              <div>
-                <div><strong>Extends:</strong></div>
-                <div class="value-text">{{ vctAsObject.extends }}</div>
-              </div>
-            }
-            @if (vctAsObject?.schema_uri) {
-              <div>
-                <div><strong>Schema URI:</strong></div>
-                <div class="value-text">{{ vctAsObject.schema_uri }}</div>
-              </div>
-            }
+          <!-- mDOC Configuration Card (mDOC only) -->
+          @if (isMdocFormat) {
+            <mat-card>
+              <mat-card-header>
+                <mat-card-title>
+                  <mat-icon>badge</mat-icon>
+                  mDOC Configuration
+                </mat-card-title>
+                <mat-card-subtitle>ISO 18013-5 specific configuration</mat-card-subtitle>
+              </mat-card-header>
+              <mat-card-content fxLayout="column" fxLayoutGap="16px">
+                <div fxLayout="row" fxLayoutGap="32px" fxLayout.lt-md="column">
+                  @if (config.config.docType) {
+                    <div fxFlex>
+                      <div><strong>Document Type (docType):</strong></div>
+                      <div class="value-text">{{ config.config.docType }}</div>
+                    </div>
+                  }
+                  @if (config.config.namespace) {
+                    <div fxFlex>
+                      <div><strong>Default Namespace:</strong></div>
+                      <div class="value-text">{{ config.config.namespace }}</div>
+                    </div>
+                  }
+                </div>
+              </mat-card-content>
+            </mat-card>
           }
-        </mat-card-content>
-      </mat-card>
-    }
 
-    <!-- mDOC Configuration Card (mDOC only) -->
-    @if (isMdocFormat) {
-      <mat-card>
-        <mat-card-header>
-          <mat-card-title>
-            <mat-icon>badge</mat-icon>
-            mDOC Configuration
-          </mat-card-title>
-          <mat-card-subtitle>ISO 18013-5 specific configuration</mat-card-subtitle>
-        </mat-card-header>
-        <mat-card-content fxLayout="column" fxLayoutGap="16px">
-          <div fxLayout="row" fxLayoutGap="32px" fxLayout.lt-md="column">
-            @if (config.config.docType) {
-              <div fxFlex>
-                <div><strong>Document Type (docType):</strong></div>
-                <div class="value-text">{{ config.config.docType }}</div>
-              </div>
-            }
-            @if (config.config.namespace) {
-              <div fxFlex>
-                <div><strong>Default Namespace:</strong></div>
-                <div class="value-text">{{ config.config.namespace }}</div>
-              </div>
-            }
-          </div>
-          @if (config.config.claimsByNamespace) {
-            <div>
-              <div><strong>Claims by Namespace:</strong></div>
-              <pre class="config-value">{{ formatJsonValue(config.config.claimsByNamespace) }}</pre>
-            </div>
-          }
-        </mat-card-content>
-      </mat-card>
-    }
+        </div>
+      </mat-tab>
 
-    <!-- Expandable Sections -->
-    <mat-accordion>
-      <!-- Configuration Details -->
-      <mat-expansion-panel>
-        <mat-expansion-panel-header>
-          <mat-panel-title>
-            <mat-icon>tune</mat-icon>
-            Configuration Details
-          </mat-panel-title>
-          <mat-panel-description> Technical configuration parameters </mat-panel-description>
-        </mat-expansion-panel-header>
+      <!-- ── TAB 2: Business Logic ────────────────────────────────────── -->
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <mat-icon class="tab-icon">settings_applications</mat-icon>
+          Business Logic
+        </ng-template>
 
-        @if (getObjectKeys(config.config).length > 0) {
-          <div fxLayout="column" fxLayoutGap="12px">
-            @for (key of getObjectKeys(config.config); track key) {
+        <div fxLayout="column" fxLayoutGap="24px" class="tab-content">
+
+          <!-- Credential Features -->
+          <mat-card>
+            <mat-card-header>
+              <mat-card-title>
+                <mat-icon>tune</mat-icon>
+                Credential Features
+              </mat-card-title>
+            </mat-card-header>
+            <mat-card-content>
+              <mat-list class="config-list">
+                <mat-list-item>
+                  <mat-icon matListItemIcon>
+                    {{ config.keyBinding ? 'lock' : 'lock_open' }}
+                  </mat-icon>
+                  <span matListItemTitle>Key Binding</span>
+                  <span matListItemLine>{{ config.keyBinding ? 'Enabled' : 'Disabled' }}</span>
+                </mat-list-item>
+                <mat-list-item>
+                  <mat-icon
+                    matListItemIcon
+                    [class]="config.statusManagement ? 'icon-enabled' : 'icon-disabled'"
+                  >
+                    {{ config.statusManagement ? 'verified' : 'block' }}
+                  </mat-icon>
+                  <span matListItemTitle>Status Management</span>
+                  <span matListItemLine>{{ config.statusManagement ? 'Enabled' : 'Disabled' }}</span>
+                </mat-list-item>
+                @if (config.statusManagement && statusListId) {
+                  <mat-list-item>
+                    <mat-icon matListItemIcon>checklist</mat-icon>
+                    <span matListItemTitle>Status List</span>
+                    <span matListItemLine>
+                      <a [routerLink]="['/status-lists', statusListId]">{{ statusListId }}</a>
+                    </span>
+                  </mat-list-item>
+                }
+                @if (config.attributeProviderId) {
+                  <mat-list-item>
+                    <mat-icon matListItemIcon>cloud_download</mat-icon>
+                    <span matListItemTitle>Attribute Provider</span>
+                    <span matListItemLine>
+                      <a [routerLink]="['/attribute-providers', config.attributeProviderId]">{{
+                        config.attributeProviderId
+                      }}</a>
+                    </span>
+                  </mat-list-item>
+                }
+                @if (config.webhookEndpointId) {
+                  <mat-list-item>
+                    <mat-icon matListItemIcon>notifications</mat-icon>
+                    <span matListItemTitle>Webhook Endpoint</span>
+                    <span matListItemLine>
+                      <a [routerLink]="['/webhook-endpoints', config.webhookEndpointId]">{{
+                        config.webhookEndpointId
+                      }}</a>
+                    </span>
+                  </mat-list-item>
+                }
+              </mat-list>
+            </mat-card-content>
+          </mat-card>
+
+          <!-- Embedded Disclosure Policy -->
+          <mat-card>
+            <mat-card-header>
+              <mat-card-title>
+                <mat-icon>policy</mat-icon>
+                Embedded Disclosure Policy
+              </mat-card-title>
+              <mat-card-subtitle>Policy configuration for the credential</mat-card-subtitle>
+            </mat-card-header>
+            <mat-card-content>
               <div class="config-item">
-                <div class="config-key">{{ key }}:</div>
-                <pre class="config-value">{{ formatJsonValue(asAny(config.config)[key]) }}</pre>
+                <pre class="config-value">{{ formatJsonValue(config.embeddedDisclosurePolicy) }}</pre>
               </div>
-            }
-          </div>
-        } @else {
-          <div class="empty-state">
-            <mat-icon>info</mat-icon>
-            <span>No configuration parameters defined</span>
-          </div>
-        }
-      </mat-expansion-panel>
+            </mat-card-content>
+          </mat-card>
 
-      <!-- Default Claims -->
-      <mat-expansion-panel>
-        <mat-expansion-panel-header>
-          <mat-panel-title>
-            <mat-icon>fact_check</mat-icon>
-            Default Claims
-          </mat-panel-title>
-          <mat-panel-description> Claims that will be included by default </mat-panel-description>
-        </mat-expansion-panel-header>
+        </div>
+      </mat-tab>
 
-        @if (getObjectKeys(config.claims).length > 0) {
-          <div fxLayout="column" fxLayoutGap="12px">
-            @for (key of getObjectKeys(config.claims); track key) {
-              <div class="config-item">
-                <div class="config-key">{{ key }}:</div>
-                <pre class="config-value">{{ formatJsonValue(config.claims![key]) }}</pre>
-              </div>
-            }
-          </div>
-        } @else {
-          <div class="empty-state">
-            <mat-icon>info</mat-icon>
-            <span>No default claims defined</span>
-          </div>
-        }
-      </mat-expansion-panel>
+      <!-- ── TAB 3: Visual & Display ──────────────────────────────────── -->
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <mat-icon class="tab-icon">palette</mat-icon>
+          Visual &amp; Display
+        </ng-template>
 
-      <!-- Disclosure Frame (SD-JWT only) -->
-      @if (!isMdocFormat) {
-        <mat-expansion-panel>
-          <mat-expansion-panel-header>
-            <mat-panel-title>
-              <mat-icon>visibility</mat-icon>
-              Disclosure Frame
-            </mat-panel-title>
-            <mat-panel-description> SD-JWT VC disclosure configuration </mat-panel-description>
-          </mat-expansion-panel-header>
+        <div fxLayout="column" fxLayoutGap="24px" class="tab-content">
 
-          @if (getObjectKeys(config.disclosureFrame).length > 0) {
-            <div fxLayout="column" fxLayoutGap="12px">
-              @for (key of getObjectKeys(config.disclosureFrame); track key) {
-                <div class="config-item">
-                  <div class="config-key">{{ key }}:</div>
-                  <pre class="config-value">{{
-                    formatJsonValue(config.disclosureFrame![key])
-                  }}</pre>
+          <!-- Credential Preview -->
+          @if (primaryDisplay) {
+            <mat-card class="preview-card">
+              <mat-card-header>
+                <mat-card-title>
+                  <mat-icon>preview</mat-icon>
+                  Credential Preview
+                </mat-card-title>
+                <mat-card-subtitle>How the credential appears in wallets</mat-card-subtitle>
+              </mat-card-header>
+              <mat-card-content>
+                <div
+                  class="credential-preview"
+                  [style.background-color]="primaryDisplay.background_color || '#FFFFFF'"
+                  [style.color]="primaryDisplay.text_color || '#000000'"
+                  [style.background-image]="
+                    primaryDisplay.background_image?.uri
+                      ? 'url(' + primaryDisplay.background_image.uri + ')'
+                      : 'none'
+                  "
+                >
+                  @if (primaryDisplay.logo?.uri) {
+                    <img [src]="primaryDisplay.logo.uri" alt="Logo" class="preview-logo" />
+                  }
+                  <div class="preview-content">
+                    <div class="preview-name">{{ primaryDisplay.name }}</div>
+                    <div class="preview-description">{{ primaryDisplay.description }}</div>
+                    <div class="preview-locale">{{ primaryDisplay.locale }}</div>
+                  </div>
+                </div>
+                @if (config.config.display && config.config.display.length > 1) {
+                  <div class="locale-chips">
+                    <strong>Available locales:</strong>
+                    <mat-chip-set>
+                      @for (display of config.config.display; track display.locale) {
+                        <mat-chip>{{ display.locale }} - {{ display.name }}</mat-chip>
+                      }
+                    </mat-chip-set>
+                  </div>
+                }
+              </mat-card-content>
+            </mat-card>
+          }
+
+          <!-- Claims Metadata -->
+          @if (config.config.claimsMetadata && config.config.claimsMetadata.length > 0) {
+            <mat-card>
+              <mat-card-header>
+                <mat-card-title>
+                  <mat-icon>label</mat-icon>
+                  Claims Metadata
+                </mat-card-title>
+                <mat-card-subtitle>
+                  Display names and localization for credential claims
+                </mat-card-subtitle>
+              </mat-card-header>
+              <mat-card-content>
+                <div fxLayout="column" fxLayoutGap="16px">
+                  @for (claim of config.config.claimsMetadata; track claim.path.join('.')) {
+                    <div class="claim-metadata-item">
+                      <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="8px">
+                        <mat-icon>{{
+                          claim.mandatory ? 'check_circle' : 'radio_button_unchecked'
+                        }}</mat-icon>
+                        <strong>{{ claim.path.join(' > ') }}</strong>
+                        @if (claim.mandatory) {
+                          <mat-chip>Mandatory</mat-chip>
+                        }
+                      </div>
+                      @if (claim.display && claim.display.length > 0) {
+                        <div class="claim-display-list">
+                          @for (display of claim.display; track display.locale) {
+                            <div class="claim-display-item">
+                              <span class="locale-badge">{{ display.locale || 'default' }}</span>
+                              <span>{{ display.name }}</span>
+                            </div>
+                          }
+                        </div>
+                      }
+                    </div>
+                  }
+                </div>
+              </mat-card-content>
+            </mat-card>
+          }
+
+        </div>
+      </mat-tab>
+
+      <!-- ── TAB 4: Claims & Disclosure ───────────────────────────────── -->
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <mat-icon class="tab-icon">fact_check</mat-icon>
+          Claims &amp; Disclosure
+        </ng-template>
+
+        <div fxLayout="column" fxLayoutGap="24px" class="tab-content">
+
+          <!-- Default Claims -->
+          <mat-card>
+            <mat-card-header>
+              <mat-card-title>
+                <mat-icon>fact_check</mat-icon>
+                Default Claims
+              </mat-card-title>
+              <mat-card-subtitle>Claims that will be included by default</mat-card-subtitle>
+            </mat-card-header>
+            <mat-card-content>
+              @if (getObjectKeys(config.claims).length > 0) {
+                <div fxLayout="column" fxLayoutGap="12px">
+                  @for (key of getObjectKeys(config.claims); track key) {
+                    <div class="config-item">
+                      <div class="config-key">{{ key }}:</div>
+                      <pre class="config-value">{{ formatJsonValue(config.claims![key]) }}</pre>
+                    </div>
+                  }
+                </div>
+              } @else {
+                <div class="empty-state">
+                  <mat-icon>info</mat-icon>
+                  <span>No default claims defined</span>
                 </div>
               }
-            </div>
-          } @else {
-            <div class="empty-state">
-              <mat-icon>info</mat-icon>
-              <span>No disclosure frame defined</span>
-            </div>
-          }
-        </mat-expansion-panel>
-      }
+            </mat-card-content>
+          </mat-card>
 
-      <!-- JSON Schema -->
-      @if (config.schema) {
-        <mat-expansion-panel>
-          <mat-expansion-panel-header>
-            <mat-panel-title>
-              <mat-icon>schema</mat-icon>
-              JSON Schema
-            </mat-panel-title>
-            <mat-panel-description> Schema validation for claims </mat-panel-description>
-          </mat-expansion-panel-header>
-
-          <div fxLayout="column" fxLayoutGap="16px">
-            <div class="config-item">
-              <div class="config-key">Schema:</div>
-              <pre class="config-value">{{ formatJsonValue(config.schema.$schema) }}</pre>
-            </div>
-
-            <div class="config-item">
-              <div class="config-key">Type:</div>
-              <pre class="config-value">{{ formatJsonValue(config.schema.type) }}</pre>
-            </div>
-
-            @if (config.schema.required && config.schema.required.length > 0) {
-              <div class="config-item">
-                <div class="config-key">Required Fields:</div>
-                <div fxLayout="row wrap" fxLayoutGap="8px" class="required-fields">
-                  @for (field of config.schema.required; track field) {
-                    <mat-chip>{{ field }}</mat-chip>
-                  }
-                </div>
-              </div>
-            }
-
-            <div class="config-item">
-              <div class="config-key">Properties:</div>
-              <pre class="config-value">{{ formatJsonValue(config.schema.properties) }}</pre>
-            </div>
-          </div>
-        </mat-expansion-panel>
-      }
-
-      <!-- Embedded Disclosure Policy -->
-      <mat-expansion-panel>
-        <mat-expansion-panel-header>
-          <mat-panel-title>
-            <mat-icon>policy</mat-icon>
-            Embedded Disclosure Policy
-          </mat-panel-title>
-          <mat-panel-description> Policy configuration for the credential </mat-panel-description>
-        </mat-expansion-panel-header>
-
-        <div fxLayout="column" fxLayoutGap="16px">
-          <div class="config-item">
-            <div class="config-key">Policy:</div>
-            <pre class="config-value">{{ formatJsonValue(config.embeddedDisclosurePolicy) }}</pre>
-          </div>
-        </div>
-      </mat-expansion-panel>
-
-      <!-- Claims Metadata -->
-      @if (config.config.claimsMetadata && config.config.claimsMetadata.length > 0) {
-        <mat-expansion-panel>
-          <mat-expansion-panel-header>
-            <mat-panel-title>
-              <mat-icon>label</mat-icon>
-              Claims Metadata
-            </mat-panel-title>
-            <mat-panel-description>
-              Display names and localization for credential claims
-            </mat-panel-description>
-          </mat-expansion-panel-header>
-
-          <div fxLayout="column" fxLayoutGap="16px">
-            @for (claim of config.config.claimsMetadata; track claim.path.join('.')) {
-              <div class="claim-metadata-item">
-                <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="8px">
-                  <mat-icon>{{
-                    claim.mandatory ? 'check_circle' : 'radio_button_unchecked'
-                  }}</mat-icon>
-                  <strong>{{ claim.path.join(' > ') }}</strong>
-                  @if (claim.mandatory) {
-                    <mat-chip>Mandatory</mat-chip>
-                  }
-                </div>
-                @if (claim.display && claim.display.length > 0) {
-                  <div class="claim-display-list">
-                    @for (display of claim.display; track display.locale) {
-                      <div class="claim-display-item">
-                        <span class="locale-badge">{{ display.locale || 'default' }}</span>
-                        <span>{{ display.name }}</span>
+          <!-- Disclosure Frame (SD-JWT only) -->
+          @if (!isMdocFormat) {
+            <mat-card>
+              <mat-card-header>
+                <mat-card-title>
+                  <mat-icon>visibility</mat-icon>
+                  Disclosure Frame
+                </mat-card-title>
+                <mat-card-subtitle>SD-JWT VC disclosure configuration</mat-card-subtitle>
+              </mat-card-header>
+              <mat-card-content>
+                @if (getObjectKeys(config.disclosureFrame).length > 0) {
+                  <div fxLayout="column" fxLayoutGap="12px">
+                    @for (key of getObjectKeys(config.disclosureFrame); track key) {
+                      <div class="config-item">
+                        <div class="config-key">{{ key }}:</div>
+                        <pre class="config-value">{{
+                          formatJsonValue(config.disclosureFrame![key])
+                        }}</pre>
                       </div>
                     }
                   </div>
+                } @else {
+                  <div class="empty-state">
+                    <mat-icon>info</mat-icon>
+                    <span>No disclosure frame defined</span>
+                  </div>
+                }
+              </mat-card-content>
+            </mat-card>
+          }
+
+          <!-- Claims by Namespace (mDOC only) -->
+          @if (isMdocFormat && config.config.claimsByNamespace) {
+            <mat-card>
+              <mat-card-header>
+                <mat-card-title>
+                  <mat-icon>folder_open</mat-icon>
+                  Claims by Namespace
+                </mat-card-title>
+                <mat-card-subtitle>Claims organized by mDOC namespace</mat-card-subtitle>
+              </mat-card-header>
+              <mat-card-content>
+                <pre class="config-value">{{ formatJsonValue(config.config.claimsByNamespace) }}</pre>
+              </mat-card-content>
+            </mat-card>
+          }
+
+          <!-- JSON Schema -->
+          @if (config.schema) {
+            <mat-card>
+              <mat-card-header>
+                <mat-card-title>
+                  <mat-icon>schema</mat-icon>
+                  JSON Schema
+                </mat-card-title>
+                <mat-card-subtitle>Schema validation for claims</mat-card-subtitle>
+              </mat-card-header>
+              <mat-card-content fxLayout="column" fxLayoutGap="16px">
+                <div class="config-item">
+                  <div class="config-key">Schema:</div>
+                  <pre class="config-value">{{ formatJsonValue(config.schema.$schema) }}</pre>
+                </div>
+                <div class="config-item">
+                  <div class="config-key">Type:</div>
+                  <pre class="config-value">{{ formatJsonValue(config.schema.type) }}</pre>
+                </div>
+                @if (config.schema.required && config.schema.required.length > 0) {
+                  <div class="config-item">
+                    <div class="config-key">Required Fields:</div>
+                    <div fxLayout="row wrap" fxLayoutGap="8px" class="required-fields">
+                      @for (field of config.schema.required; track field) {
+                        <mat-chip>{{ field }}</mat-chip>
+                      }
+                    </div>
+                  </div>
+                }
+                <div class="config-item">
+                  <div class="config-key">Properties:</div>
+                  <pre class="config-value">{{ formatJsonValue(config.schema.properties) }}</pre>
+                </div>
+              </mat-card-content>
+            </mat-card>
+          }
+
+          <!-- Raw Configuration Details -->
+          <mat-expansion-panel>
+            <mat-expansion-panel-header>
+              <mat-panel-title>
+                <mat-icon>tune</mat-icon>
+                Raw Configuration
+              </mat-panel-title>
+              <mat-panel-description>All technical configuration parameters</mat-panel-description>
+            </mat-expansion-panel-header>
+            @if (getObjectKeys(config.config).length > 0) {
+              <div fxLayout="column" fxLayoutGap="12px">
+                @for (key of getObjectKeys(config.config); track key) {
+                  <div class="config-item">
+                    <div class="config-key">{{ key }}:</div>
+                    <pre class="config-value">{{ formatJsonValue(asAny(config.config)[key]) }}</pre>
+                  </div>
                 }
               </div>
+            } @else {
+              <div class="empty-state">
+                <mat-icon>info</mat-icon>
+                <span>No configuration parameters defined</span>
+              </div>
             }
-          </div>
-        </mat-expansion-panel>
-      }
-    </mat-accordion>
+          </mat-expansion-panel>
+
+        </div>
+      </mat-tab>
+
+    </mat-tab-group>
   </div>
 }

--- a/apps/client/src/app/issuance/credential-config/credential-config-show/credential-config-show.component.scss
+++ b/apps/client/src/app/issuance/credential-config/credential-config-show/credential-config-show.component.scss
@@ -1,3 +1,11 @@
+.tab-content {
+  padding-top: 24px;
+}
+
+.tab-icon {
+  margin-right: 8px;
+}
+
 .value-text {
   color: #666;
   margin-top: 4px;

--- a/apps/client/src/app/issuance/credential-config/credential-config-show/credential-config-show.component.ts
+++ b/apps/client/src/app/issuance/credential-config/credential-config-show/credential-config-show.component.ts
@@ -10,6 +10,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatListModule } from '@angular/material/list';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { MatTabsModule } from '@angular/material/tabs';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { FlexLayoutModule } from 'ngx-flexible-layout';
@@ -30,6 +31,7 @@ import { StatusListManagementService } from '../../../status-list-management/sta
     MatDividerModule,
     MatListModule,
     MatProgressBarModule,
+    MatTabsModule,
     FlexLayoutModule,
     RouterModule,
     ClipboardModule,

--- a/apps/client/src/app/issuance/issuance-config/issuance-config-create/issuance-config-create.component.html
+++ b/apps/client/src/app/issuance/issuance-config/issuance-config-create/issuance-config-create.component.html
@@ -16,410 +16,459 @@
 
   <!-- Main Form -->
   <form [formGroup]="form" (ngSubmit)="onSubmit()">
-    <!-- Basic Information Card -->
-    <mat-card>
-      <mat-card-header>
-        <mat-card-title>
-          <mat-icon>settings</mat-icon>
-          Basic Information
-        </mat-card-title>
-      </mat-card-header>
-      <mat-card-content fxLayout="column" fxLayoutGap="16px">
-        <!-- Batch Size -->
-        <mat-form-field>
-          <mat-label>Batch Size</mat-label>
-          <input matInput type="number" formControlName="batchSize" placeholder="1" min="1" />
-          <mat-icon matSuffix>batch_prediction</mat-icon>
-          <mat-hint>Number of credentials issued in a single batch (default: 1)</mat-hint>
-          @if (form.get('batchSize')?.invalid && form.get('batchSize')?.touched) {
-            <mat-error>Batch size must be at least 1</mat-error>
-          }
-        </mat-form-field>
-        <mat-slide-toggle formControlName="dPopRequired">
-          <div fxLayout="column">
-            <span><strong>DPoP Required</strong></span>
-            <span class="toggle-description"
-              >Enable DPoP (Demonstrated Proof of Possession) for sender-constrained tokens. Disable
-              if your wallet doesn't support DPoP.</span
-            >
-          </div>
-        </mat-slide-toggle>
+    <mat-tab-group animationDuration="200ms">
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <mat-icon class="tab-icon">info</mat-icon>
+          Metadata
+        </ng-template>
 
-        <mat-slide-toggle formControlName="refreshTokenEnabled">
-          <div fxLayout="column">
-            <span><strong>Issue Refresh Tokens</strong></span>
-            <span class="toggle-description"
-              >Allow wallets to exchange a refresh token for a new access token without restarting
-              the issuance authorization flow.</span
-            >
-          </div>
-        </mat-slide-toggle>
-
-        @if (refreshTokenEnabled) {
-          <mat-form-field>
-            <mat-label>Refresh Token Lifetime (seconds)</mat-label>
-            <input
-              matInput
-              type="number"
-              formControlName="refreshTokenExpiresInSeconds"
-              placeholder="2592000"
-              min="1"
-            />
-            <mat-icon matSuffix>timelapse</mat-icon>
-            <mat-hint>
-              How long issued refresh tokens remain valid. Default: 2592000 seconds (30 days).
-            </mat-hint>
-            @if (
-              form.get('refreshTokenExpiresInSeconds')?.invalid &&
-              form.get('refreshTokenExpiresInSeconds')?.touched
-            ) {
-              <mat-error>Refresh token lifetime must be at least 1 second</mat-error>
-            }
-          </mat-form-field>
-        }
-
-        <mat-slide-toggle formControlName="credentialResponseEncryption">
-          <div fxLayout="column">
-            <span><strong>Advertise Credential Response Encryption</strong></span>
-            <span class="toggle-description"
-              >Advertise `credential_response_encryption` (ECDH-ES, A128GCM/A256GCM) in the
-              credential issuer metadata so wallets MAY request encrypted credential responses. Some
-              wallets reject metadata advertising encryption they do not support — leave disabled
-              unless you need it.</span
-            >
-          </div>
-        </mat-slide-toggle>
-      </mat-card-content>
-    </mat-card>
-
-    <!-- Authorization Servers Card -->
-    <mat-card>
-      <mat-card-header>
-        <mat-card-title>
-          <mat-icon>dns</mat-icon>
-          Authorization Servers
-        </mat-card-title>
-        <mat-card-subtitle
-          >Configure external authorization server URLs. Leave empty to use the built-in
-          server.</mat-card-subtitle
-        >
-      </mat-card-header>
-      <mat-card-content fxLayout="column" fxLayoutGap="16px">
-        <div formArrayName="authServers">
-          @for (server of authServers.controls; track $index; let i = $index) {
-            <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="8px">
-              <mat-form-field fxFlex>
-                <mat-label>Authorization Server {{ i + 1 }}</mat-label>
-                <input
-                  matInput
-                  [formControlName]="i"
-                  placeholder="https://auth.example.com"
-                  type="url"
-                />
-                <mat-icon matSuffix>link</mat-icon>
-                @if (server.invalid && server.touched) {
-                  <mat-error>Please enter a valid URL</mat-error>
+        <div fxLayout="column" fxLayoutGap="24px" class="tab-content">
+          <!-- Basic Information Card -->
+          <mat-card>
+            <mat-card-header>
+              <mat-card-title>
+                <mat-icon>settings</mat-icon>
+                Basic Information
+              </mat-card-title>
+            </mat-card-header>
+            <mat-card-content fxLayout="column" fxLayoutGap="16px">
+              <!-- Batch Size -->
+              <mat-form-field>
+                <mat-label>Batch Size</mat-label>
+                <input matInput type="number" formControlName="batchSize" placeholder="1" min="1" />
+                <mat-icon matSuffix>batch_prediction</mat-icon>
+                <mat-hint>Number of credentials issued in a single batch (default: 1)</mat-hint>
+                @if (form.get('batchSize')?.invalid && form.get('batchSize')?.touched) {
+                  <mat-error>Batch size must be at least 1</mat-error>
                 }
               </mat-form-field>
-              <button
-                matIconButton
-                type="button"
-                color="warn"
-                (click)="removeAuthServer(i)"
-                matTooltip="Remove this authorization server"
-              >
-                <mat-icon>delete</mat-icon>
-              </button>
-            </div>
-          }
-        </div>
-        <div fxLayout="row" fxLayoutAlign="center center">
-          <button mat-raised-button type="button" (click)="addAuthServer()">
-            <mat-icon>add</mat-icon> Add Authorization Server
-          </button>
-        </div>
-
-        <!-- Preferred Authorization Server -->
-        <mat-form-field>
-          <mat-label>Preferred Authorization Server</mat-label>
-          <mat-select formControlName="preferredAuthServer">
-            <mat-option value="">None (use default order)</mat-option>
-            @for (option of availableAuthServerOptions; track option.value) {
-              <mat-option [value]="option.value">{{ option.label }}</mat-option>
-            }
-          </mat-select>
-          <mat-icon matSuffix>star</mat-icon>
-          <mat-hint
-            >The preferred AS is placed first in the issuer metadata. Wallets typically use the
-            first AS for wallet-initiated flows.</mat-hint
-          >
-        </mat-form-field>
-      </mat-card-content>
-    </mat-card>
-
-    <!-- Display Configurations Card -->
-    <mat-card>
-      <mat-card-header>
-        <mat-card-title>
-          <mat-icon>view_carousel</mat-icon>
-          Display Configurations
-        </mat-card-title>
-        <mat-card-subtitle>Configure how credentials are displayed to users</mat-card-subtitle>
-      </mat-card-header>
-      <mat-card-content fxLayout="column" fxLayoutGap="16px">
-        <div formArrayName="display">
-          @for (display of displays.controls; track $index; let i = $index) {
-            <div [formGroupName]="i" class="mat-elevation-z2 display-entry">
-              <div fxLayout="row" fxLayoutAlign="space-between center" class="display-entry-header">
-                <h3>Display Entry {{ i + 1 }}</h3>
-                @if (displays.length > 1) {
-                  <button
-                    matIconButton
-                    type="button"
-                    color="warn"
-                    (click)="removeDisplay(i)"
-                    matTooltip="Remove this display configuration"
+              <mat-slide-toggle formControlName="dPopRequired">
+                <div fxLayout="column">
+                  <span><strong>DPoP Required</strong></span>
+                  <span class="toggle-description"
+                    >Enable DPoP (Demonstrated Proof of Possession) for sender-constrained tokens.
+                    Disable if your wallet doesn't support DPoP.</span
                   >
-                    <mat-icon>delete</mat-icon>
-                  </button>
+                </div>
+              </mat-slide-toggle>
+
+              <mat-slide-toggle formControlName="refreshTokenEnabled">
+                <div fxLayout="column">
+                  <span><strong>Issue Refresh Tokens</strong></span>
+                  <span class="toggle-description"
+                    >Allow wallets to exchange a refresh token for a new access token without
+                    restarting the issuance authorization flow.</span
+                  >
+                </div>
+              </mat-slide-toggle>
+
+              @if (refreshTokenEnabled) {
+                <mat-form-field>
+                  <mat-label>Refresh Token Lifetime (seconds)</mat-label>
+                  <input
+                    matInput
+                    type="number"
+                    formControlName="refreshTokenExpiresInSeconds"
+                    placeholder="2592000"
+                    min="1"
+                  />
+                  <mat-icon matSuffix>timelapse</mat-icon>
+                  <mat-hint>
+                    How long issued refresh tokens remain valid. Default: 2592000 seconds (30 days).
+                  </mat-hint>
+                  @if (
+                    form.get('refreshTokenExpiresInSeconds')?.invalid &&
+                    form.get('refreshTokenExpiresInSeconds')?.touched
+                  ) {
+                    <mat-error>Refresh token lifetime must be at least 1 second</mat-error>
+                  }
+                </mat-form-field>
+              }
+
+              <mat-slide-toggle formControlName="credentialResponseEncryption">
+                <div fxLayout="column">
+                  <span><strong>Advertise Credential Response Encryption</strong></span>
+                  <span class="toggle-description"
+                    >Advertise `credential_response_encryption` (ECDH-ES, A128GCM/A256GCM) in the
+                    credential issuer metadata so wallets MAY request encrypted credential
+                    responses. Some wallets reject metadata advertising encryption they do not
+                    support — leave disabled unless you need it.</span
+                  >
+                </div>
+              </mat-slide-toggle>
+            </mat-card-content>
+          </mat-card>
+
+          <!-- Display Configurations Card -->
+          <mat-card>
+            <mat-card-header>
+              <mat-card-title>
+                <mat-icon>view_carousel</mat-icon>
+                Display Configurations
+              </mat-card-title>
+              <mat-card-subtitle
+                >Configure how credentials are displayed to users</mat-card-subtitle
+              >
+            </mat-card-header>
+            <mat-card-content fxLayout="column" fxLayoutGap="16px">
+              <div formArrayName="display">
+                @for (display of displays.controls; track $index; let i = $index) {
+                  <div [formGroupName]="i" class="mat-elevation-z2 display-entry">
+                    <div
+                      fxLayout="row"
+                      fxLayoutAlign="space-between center"
+                      class="display-entry-header"
+                    >
+                      <h3>Display Entry {{ i + 1 }}</h3>
+                      @if (displays.length > 1) {
+                        <button
+                          matIconButton
+                          type="button"
+                          color="warn"
+                          (click)="removeDisplay(i)"
+                          matTooltip="Remove this display configuration"
+                        >
+                          <mat-icon>delete</mat-icon>
+                        </button>
+                      }
+                    </div>
+                    <div fxLayout="column" fxLayoutGap="16px">
+                      <div fxLayout="row" fxLayoutGap="16px">
+                        <mat-form-field fxFlex>
+                          <mat-label>Name</mat-label>
+                          <input
+                            matInput
+                            formControlName="name"
+                            placeholder="Enter display name"
+                            required
+                          />
+                          <mat-icon matSuffix>badge</mat-icon>
+                        </mat-form-field>
+                        <mat-form-field fxFlex>
+                          <mat-label>Locale</mat-label>
+                          <mat-select formControlName="locale" required>
+                            <mat-option value="en-US">English (US)</mat-option>
+                            <mat-option value="en-GB">English (UK)</mat-option>
+                            <mat-option value="de-DE">German</mat-option>
+                            <mat-option value="fr-FR">French</mat-option>
+                            <mat-option value="es-ES">Spanish</mat-option>
+                            <mat-option value="it-IT">Italian</mat-option>
+                          </mat-select>
+                          <mat-icon matSuffix>language</mat-icon>
+                        </mat-form-field>
+                      </div>
+                      <app-image-field
+                        [field]="getControl(display.get('logo.uri'))"
+                        label="Logo URL"
+                      ></app-image-field>
+                    </div>
+                  </div>
                 }
               </div>
-              <div fxLayout="column" fxLayoutGap="16px">
-                <div fxLayout="row" fxLayoutGap="16px">
-                  <mat-form-field fxFlex>
-                    <mat-label>Name</mat-label>
-                    <input
-                      matInput
-                      formControlName="name"
-                      placeholder="Enter display name"
-                      required
-                    />
-                    <mat-icon matSuffix>badge</mat-icon>
-                  </mat-form-field>
-                  <mat-form-field fxFlex>
-                    <mat-label>Locale</mat-label>
-                    <mat-select formControlName="locale" required>
-                      <mat-option value="en-US">English (US)</mat-option>
-                      <mat-option value="en-GB">English (UK)</mat-option>
-                      <mat-option value="de-DE">German</mat-option>
-                      <mat-option value="fr-FR">French</mat-option>
-                      <mat-option value="es-ES">Spanish</mat-option>
-                      <mat-option value="it-IT">Italian</mat-option>
-                    </mat-select>
-                    <mat-icon matSuffix>language</mat-icon>
-                  </mat-form-field>
-                </div>
-                <app-image-field
-                  [field]="getControl(display.get('logo.uri'))"
-                  label="Logo URL"
-                ></app-image-field>
+              <div fxLayout="row" fxLayoutAlign="center center">
+                <button mat-raised-button type="button" (click)="addDisplay()">
+                  <mat-icon>add</mat-icon> Add Display
+                </button>
               </div>
-            </div>
-          }
+            </mat-card-content>
+          </mat-card>
         </div>
-        <div fxLayout="row" fxLayoutAlign="center center">
-          <button mat-raised-button type="button" (click)="addDisplay()">
-            <mat-icon>add</mat-icon> Add Display
-          </button>
+      </mat-tab>
+
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <mat-icon class="tab-icon">settings_applications</mat-icon>
+          Business Logic
+        </ng-template>
+
+        <div fxLayout="column" fxLayoutGap="24px" class="tab-content">
+          <!-- Authorization Servers Card -->
+          <mat-card>
+            <mat-card-header>
+              <mat-card-title>
+                <mat-icon>dns</mat-icon>
+                Authorization Servers
+              </mat-card-title>
+              <mat-card-subtitle
+                >Configure external authorization server URLs. Leave empty to use the built-in
+                server.</mat-card-subtitle
+              >
+            </mat-card-header>
+            <mat-card-content fxLayout="column" fxLayoutGap="16px">
+              <div formArrayName="authServers">
+                @for (server of authServers.controls; track $index; let i = $index) {
+                  <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="8px">
+                    <mat-form-field fxFlex>
+                      <mat-label>Authorization Server {{ i + 1 }}</mat-label>
+                      <input
+                        matInput
+                        [formControlName]="i"
+                        placeholder="https://auth.example.com"
+                        type="url"
+                      />
+                      <mat-icon matSuffix>link</mat-icon>
+                      @if (server.invalid && server.touched) {
+                        <mat-error>Please enter a valid URL</mat-error>
+                      }
+                    </mat-form-field>
+                    <button
+                      matIconButton
+                      type="button"
+                      color="warn"
+                      (click)="removeAuthServer(i)"
+                      matTooltip="Remove this authorization server"
+                    >
+                      <mat-icon>delete</mat-icon>
+                    </button>
+                  </div>
+                }
+              </div>
+              <div fxLayout="row" fxLayoutAlign="center center">
+                <button mat-raised-button type="button" (click)="addAuthServer()">
+                  <mat-icon>add</mat-icon> Add Authorization Server
+                </button>
+              </div>
+
+              <!-- Preferred Authorization Server -->
+              <mat-form-field>
+                <mat-label>Preferred Authorization Server</mat-label>
+                <mat-select formControlName="preferredAuthServer">
+                  <mat-option value="">None (use default order)</mat-option>
+                  @for (option of availableAuthServerOptions; track option.value) {
+                    <mat-option [value]="option.value">{{ option.label }}</mat-option>
+                  }
+                </mat-select>
+                <mat-icon matSuffix>star</mat-icon>
+                <mat-hint
+                  >The preferred AS is placed first in the issuer metadata. Wallets typically use
+                  the first AS for wallet-initiated flows.</mat-hint
+                >
+              </mat-form-field>
+            </mat-card-content>
+          </mat-card>
         </div>
-      </mat-card-content>
-    </mat-card>
+      </mat-tab>
 
-    <!-- Wallet Attestation Card -->
-    <mat-card>
-      <mat-card-header>
-        <mat-card-title>
-          <mat-icon>verified_user</mat-icon>
-          Wallet Attestation
-        </mat-card-title>
-        <mat-card-subtitle
-          >Configure wallet attestation requirements for client authentication</mat-card-subtitle
-        >
-      </mat-card-header>
-      <mat-card-content fxLayout="column" fxLayoutGap="16px">
-        <mat-slide-toggle formControlName="walletAttestationRequired">
-          <div fxLayout="column">
-            <span><strong>Require Wallet Attestation</strong></span>
-            <span class="toggle-description"
-              >When enabled, wallets must provide OAuth-Client-Attestation headers at the token
-              endpoint</span
-            >
-          </div>
-        </mat-slide-toggle>
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <mat-icon class="tab-icon">security</mat-icon>
+          Security
+        </ng-template>
 
-        @if (form.get('walletAttestationRequired')?.value) {
-          <div fxLayout="column" fxLayoutGap="16px" class="trust-lists-section">
-            <p class="section-hint">
-              <mat-icon>info</mat-icon>
-              Add trust list URLs containing trusted wallet providers. The wallet's X.509
-              certificate will be validated against these lists.
-            </p>
-            <div formArrayName="walletProviderTrustLists">
-              @for (trustList of walletProviderTrustLists.controls; track $index; let i = $index) {
-                <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="8px">
-                  <mat-form-field fxFlex>
-                    <mat-label>Trust List URL {{ i + 1 }}</mat-label>
-                    <input
-                      matInput
-                      [formControlName]="i"
-                      placeholder="https://trust-list.example.com/wallet-providers"
-                      type="url"
-                    />
-                    <mat-icon matSuffix>security</mat-icon>
-                    @if (trustList.invalid && trustList.touched) {
-                      <mat-error>Please enter a valid URL</mat-error>
-                    }
-                  </mat-form-field>
-                  <button
-                    matIconButton
-                    type="button"
-                    color="warn"
-                    (click)="removeWalletProviderTrustList(i)"
-                    matTooltip="Remove this trust list"
+        <div fxLayout="column" fxLayoutGap="24px" class="tab-content">
+          <!-- Wallet Attestation Card -->
+          <mat-card>
+            <mat-card-header>
+              <mat-card-title>
+                <mat-icon>verified_user</mat-icon>
+                Wallet Attestation
+              </mat-card-title>
+              <mat-card-subtitle
+                >Configure wallet attestation requirements for client
+                authentication</mat-card-subtitle
+              >
+            </mat-card-header>
+            <mat-card-content fxLayout="column" fxLayoutGap="16px">
+              <mat-slide-toggle formControlName="walletAttestationRequired">
+                <div fxLayout="column">
+                  <span><strong>Require Wallet Attestation</strong></span>
+                  <span class="toggle-description"
+                    >When enabled, wallets must provide OAuth-Client-Attestation headers at the
+                    token endpoint</span
                   >
-                    <mat-icon>delete</mat-icon>
-                  </button>
+                </div>
+              </mat-slide-toggle>
+
+              @if (form.get('walletAttestationRequired')?.value) {
+                <div fxLayout="column" fxLayoutGap="16px" class="trust-lists-section">
+                  <p class="section-hint">
+                    <mat-icon>info</mat-icon>
+                    Add trust list URLs containing trusted wallet providers. The wallet's X.509
+                    certificate will be validated against these lists.
+                  </p>
+                  <div formArrayName="walletProviderTrustLists">
+                    @for (
+                      trustList of walletProviderTrustLists.controls;
+                      track $index;
+                      let i = $index
+                    ) {
+                      <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="8px">
+                        <mat-form-field fxFlex>
+                          <mat-label>Trust List URL {{ i + 1 }}</mat-label>
+                          <input
+                            matInput
+                            [formControlName]="i"
+                            placeholder="https://trust-list.example.com/wallet-providers"
+                            type="url"
+                          />
+                          <mat-icon matSuffix>security</mat-icon>
+                          @if (trustList.invalid && trustList.touched) {
+                            <mat-error>Please enter a valid URL</mat-error>
+                          }
+                        </mat-form-field>
+                        <button
+                          matIconButton
+                          type="button"
+                          color="warn"
+                          (click)="removeWalletProviderTrustList(i)"
+                          matTooltip="Remove this trust list"
+                        >
+                          <mat-icon>delete</mat-icon>
+                        </button>
+                      </div>
+                    }
+                  </div>
+                  <div fxLayout="row" fxLayoutAlign="center center">
+                    <button mat-raised-button type="button" (click)="addWalletProviderTrustList()">
+                      <mat-icon>add</mat-icon> Add Trust List URL
+                    </button>
+                  </div>
+                  @if (walletProviderTrustLists.length === 0) {
+                    <p class="warning-hint">
+                      <mat-icon>warning</mat-icon>
+                      No trust lists configured. All wallet providers will be rejected when wallet
+                      attestation is required.
+                    </p>
+                  }
                 </div>
               }
-            </div>
-            <div fxLayout="row" fxLayoutAlign="center center">
-              <button mat-raised-button type="button" (click)="addWalletProviderTrustList()">
-                <mat-icon>add</mat-icon> Add Trust List URL
-              </button>
-            </div>
-            @if (walletProviderTrustLists.length === 0) {
-              <p class="warning-hint">
-                <mat-icon>warning</mat-icon>
-                No trust lists configured. All wallet providers will be rejected when wallet
-                attestation is required.
-              </p>
-            }
-          </div>
-        }
-      </mat-card-content>
-    </mat-card>
+            </mat-card-content>
+          </mat-card>
+        </div>
+      </mat-tab>
 
-    <!-- Chained Authorization Server Card -->
-    <mat-card formGroupName="chainedAs">
-      <mat-card-header>
-        <mat-card-title>
-          <mat-icon>account_tree</mat-icon>
-          Chained Authorization Server
-        </mat-card-title>
-        <mat-card-subtitle
-          >Delegate user authentication to an upstream OIDC provider while issuing EUDIPLO
-          tokens</mat-card-subtitle
-        >
-      </mat-card-header>
-      <mat-card-content fxLayout="column" fxLayoutGap="16px">
-        <mat-slide-toggle formControlName="enabled">
-          <div fxLayout="column">
-            <span><strong>Enable Chained AS</strong></span>
-            <span class="toggle-description"
-              >When enabled, EUDIPLO acts as an OAuth AS facade, delegating authentication to an
-              upstream OIDC provider (e.g., Keycloak)</span
-            >
-          </div>
-        </mat-slide-toggle>
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <mat-icon class="tab-icon">account_tree</mat-icon>
+          Advanced Federation
+        </ng-template>
 
-        @if (chainedAsEnabled) {
-          <!-- Upstream OIDC Provider Section -->
-          <div
-            formGroupName="upstream"
-            fxLayout="column"
-            fxLayoutGap="16px"
-            class="chained-as-section"
-          >
-            <h4>
-              <mat-icon>cloud</mat-icon>
-              Upstream OIDC Provider
-            </h4>
-            <mat-form-field>
-              <mat-label>Issuer URL</mat-label>
-              <input
-                matInput
-                formControlName="issuer"
-                placeholder="https://keycloak.example.com/realms/my-realm"
-                type="url"
-              />
-              <mat-icon matSuffix>link</mat-icon>
-              <mat-hint>The upstream OIDC provider URL (must support discovery)</mat-hint>
-            </mat-form-field>
-
-            <div fxLayout="row" fxLayoutGap="16px">
-              <mat-form-field fxFlex>
-                <mat-label>Client ID</mat-label>
-                <input matInput formControlName="clientId" placeholder="eudiplo-client" />
-                <mat-icon matSuffix>fingerprint</mat-icon>
-              </mat-form-field>
-              <mat-form-field fxFlex>
-                <mat-label>Client Secret</mat-label>
-                <input
-                  matInput
-                  formControlName="clientSecret"
-                  type="password"
-                  placeholder="••••••••"
-                />
-                <mat-icon matSuffix>lock</mat-icon>
-              </mat-form-field>
-            </div>
-
-            <p class="section-hint">
-              <mat-icon>info</mat-icon>
-              Configure your upstream OIDC provider with redirect URI:
-              <code>https://your-eudiplo-url/&#123;tenant&#125;/chained-as/callback</code>
-            </p>
-          </div>
-
-          <!-- Token Configuration Section -->
-          <div
-            formGroupName="token"
-            fxLayout="column"
-            fxLayoutGap="16px"
-            class="chained-as-section"
-          >
-            <h4>
-              <mat-icon>token</mat-icon>
-              Token Configuration
-            </h4>
-            <div fxLayout="row" fxLayoutGap="16px">
-              <mat-form-field fxFlex>
-                <mat-label>Token Lifetime (seconds)</mat-label>
-                <input
-                  matInput
-                  type="number"
-                  formControlName="lifetimeSeconds"
-                  placeholder="3600"
-                  min="60"
-                />
-                <mat-icon matSuffix>schedule</mat-icon>
-                <mat-hint>Access token lifetime in seconds (default: 3600)</mat-hint>
-              </mat-form-field>
-              <mat-form-field fxFlex>
-                <mat-label>Signing Key ID (optional)</mat-label>
-                <input
-                  matInput
-                  formControlName="signingKeyId"
-                  placeholder="Leave empty for default"
-                />
-                <mat-icon matSuffix>key</mat-icon>
-                <mat-hint>Key ID for token signing (uses default if empty)</mat-hint>
-              </mat-form-field>
-            </div>
-          </div>
-
-          <!-- DPoP Requirement -->
-          <mat-slide-toggle formControlName="requireDPoP">
-            <div fxLayout="column">
-              <span><strong>Require DPoP</strong></span>
-              <span class="toggle-description"
-                >Require wallets to provide DPoP proof when requesting tokens</span
+        <div fxLayout="column" fxLayoutGap="24px" class="tab-content">
+          <!-- Chained Authorization Server Card -->
+          <mat-card formGroupName="chainedAs">
+            <mat-card-header>
+              <mat-card-title>
+                <mat-icon>account_tree</mat-icon>
+                Chained Authorization Server
+              </mat-card-title>
+              <mat-card-subtitle
+                >Delegate user authentication to an upstream OIDC provider while issuing EUDIPLO
+                tokens</mat-card-subtitle
               >
-            </div>
-          </mat-slide-toggle>
-        }
-      </mat-card-content>
-    </mat-card>
+            </mat-card-header>
+            <mat-card-content fxLayout="column" fxLayoutGap="16px">
+              <mat-slide-toggle formControlName="enabled">
+                <div fxLayout="column">
+                  <span><strong>Enable Chained AS</strong></span>
+                  <span class="toggle-description"
+                    >When enabled, EUDIPLO acts as an OAuth AS facade, delegating authentication to
+                    an upstream OIDC provider (e.g., Keycloak)</span
+                  >
+                </div>
+              </mat-slide-toggle>
+
+              @if (chainedAsEnabled) {
+                <!-- Upstream OIDC Provider Section -->
+                <div
+                  formGroupName="upstream"
+                  fxLayout="column"
+                  fxLayoutGap="16px"
+                  class="chained-as-section"
+                >
+                  <h4>
+                    <mat-icon>cloud</mat-icon>
+                    Upstream OIDC Provider
+                  </h4>
+                  <mat-form-field>
+                    <mat-label>Issuer URL</mat-label>
+                    <input
+                      matInput
+                      formControlName="issuer"
+                      placeholder="https://keycloak.example.com/realms/my-realm"
+                      type="url"
+                    />
+                    <mat-icon matSuffix>link</mat-icon>
+                    <mat-hint>The upstream OIDC provider URL (must support discovery)</mat-hint>
+                  </mat-form-field>
+
+                  <div fxLayout="row" fxLayoutGap="16px">
+                    <mat-form-field fxFlex>
+                      <mat-label>Client ID</mat-label>
+                      <input matInput formControlName="clientId" placeholder="eudiplo-client" />
+                      <mat-icon matSuffix>fingerprint</mat-icon>
+                    </mat-form-field>
+                    <mat-form-field fxFlex>
+                      <mat-label>Client Secret</mat-label>
+                      <input
+                        matInput
+                        formControlName="clientSecret"
+                        type="password"
+                        placeholder="••••••••"
+                      />
+                      <mat-icon matSuffix>lock</mat-icon>
+                    </mat-form-field>
+                  </div>
+
+                  <p class="section-hint">
+                    <mat-icon>info</mat-icon>
+                    Configure your upstream OIDC provider with redirect URI:
+                    <code>https://your-eudiplo-url/&#123;tenant&#125;/chained-as/callback</code>
+                  </p>
+                </div>
+
+                <!-- Token Configuration Section -->
+                <div
+                  formGroupName="token"
+                  fxLayout="column"
+                  fxLayoutGap="16px"
+                  class="chained-as-section"
+                >
+                  <h4>
+                    <mat-icon>token</mat-icon>
+                    Token Configuration
+                  </h4>
+                  <div fxLayout="row" fxLayoutGap="16px">
+                    <mat-form-field fxFlex>
+                      <mat-label>Token Lifetime (seconds)</mat-label>
+                      <input
+                        matInput
+                        type="number"
+                        formControlName="lifetimeSeconds"
+                        placeholder="3600"
+                        min="60"
+                      />
+                      <mat-icon matSuffix>schedule</mat-icon>
+                      <mat-hint>Access token lifetime in seconds (default: 3600)</mat-hint>
+                    </mat-form-field>
+                    <mat-form-field fxFlex>
+                      <mat-label>Signing Key ID (optional)</mat-label>
+                      <input
+                        matInput
+                        formControlName="signingKeyId"
+                        placeholder="Leave empty for default"
+                      />
+                      <mat-icon matSuffix>key</mat-icon>
+                      <mat-hint>Key ID for token signing (uses default if empty)</mat-hint>
+                    </mat-form-field>
+                  </div>
+                </div>
+
+                <!-- DPoP Requirement -->
+                <mat-slide-toggle formControlName="requireDPoP">
+                  <div fxLayout="column">
+                    <span><strong>Require DPoP</strong></span>
+                    <span class="toggle-description"
+                      >Require wallets to provide DPoP proof when requesting tokens</span
+                    >
+                  </div>
+                </mat-slide-toggle>
+              }
+            </mat-card-content>
+          </mat-card>
+        </div>
+      </mat-tab>
+    </mat-tab-group>
 
     <!-- Action Buttons -->
     <div fxLayout="row" fxLayoutGap="16px" fxLayoutAlign="end center">

--- a/apps/client/src/app/issuance/issuance-config/issuance-config-create/issuance-config-create.component.ts
+++ b/apps/client/src/app/issuance/issuance-config/issuance-config-create/issuance-config-create.component.ts
@@ -18,6 +18,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSelectModule } from '@angular/material/select';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatTabsModule } from '@angular/material/tabs';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { FlexLayoutModule } from 'ngx-flexible-layout';
@@ -41,6 +42,7 @@ import { MatCardModule } from '@angular/material/card';
     MatSelectModule,
     MatProgressSpinnerModule,
     MatSnackBarModule,
+    MatTabsModule,
     MatCheckboxModule,
     MatChipsModule,
     MatExpansionModule,

--- a/apps/client/src/app/issuance/issuance-config/issuance-config-show/issuance-config-show.component.html
+++ b/apps/client/src/app/issuance/issuance-config/issuance-config-show/issuance-config-show.component.html
@@ -16,192 +16,278 @@
       </div>
     </div>
 
-    <!-- Basic Information Card -->
-    <mat-card>
-      <mat-card-header>
-        <mat-card-title>
-          <mat-icon>settings</mat-icon>
-          Configuration Details
-        </mat-card-title>
-      </mat-card-header>
-      <mat-card-content>
-        <mat-list class="config-list">
-          <mat-list-item>
-            <mat-icon matListItemIcon>schedule</mat-icon>
-            <span matListItemTitle>Created At</span>
-            <span matListItemLine>{{ formatDate(config.createdAt) }}</span>
-          </mat-list-item>
-          <mat-list-item>
-            <mat-icon matListItemIcon>
-              {{ config.dPopRequired ? 'verified_user' : 'no_encryption' }}
-            </mat-icon>
-            <span matListItemTitle>DPoP</span>
-            <span matListItemLine>{{ config.dPopRequired ? 'Required' : 'Not required' }}</span>
-          </mat-list-item>
-          <mat-list-item>
-            <mat-icon matListItemIcon>layers</mat-icon>
-            <span matListItemTitle>Batch Size</span>
-            <span matListItemLine>{{ config.batchSize || 1 }} credential(s) per request</span>
-          </mat-list-item>
-          <mat-list-item>
-            <mat-icon matListItemIcon [class]="config.refreshTokenEnabled ? '' : 'icon-disabled'">
-              {{ config.refreshTokenEnabled ? 'refresh' : 'sync_disabled' }}
-            </mat-icon>
-            <span matListItemTitle>Refresh Tokens</span>
-            <span matListItemLine>
-              {{ config.refreshTokenEnabled ? 'Enabled' : 'Disabled' }}
-            </span>
-          </mat-list-item>
-          @if (config.refreshTokenEnabled) {
-            <mat-list-item>
-              <mat-icon matListItemIcon>timelapse</mat-icon>
-              <span matListItemTitle>Refresh Token Lifetime</span>
-              <span matListItemLine>
-                {{ config.refreshTokenExpiresInSeconds || 2592000 }} seconds
-              </span>
-            </mat-list-item>
-          }
-          <mat-list-item>
-            <mat-icon matListItemIcon>dns</mat-icon>
-            <span matListItemTitle>Authorization Servers</span>
-            <span matListItemLine>
-              @if (config.authServers && config.authServers.length > 0) {
-                {{ config.authServers.join(', ') }}
-              } @else {
-                Using built-in authorization server
-              }
-            </span>
-          </mat-list-item>
-          <mat-list-item>
-            <mat-icon
-              matListItemIcon
-              [class]="config.walletAttestationRequired ? '' : 'icon-disabled'"
-            >
-              {{ config.walletAttestationRequired ? 'verified_user' : 'no_encryption' }}
-            </mat-icon>
-            <span matListItemTitle>Wallet Attestation</span>
-            <span matListItemLine>{{
-              config.walletAttestationRequired ? 'Required' : 'Not required'
-            }}</span>
-          </mat-list-item>
-          @if (config.walletAttestationRequired) {
-            <mat-list-item>
-              <mat-icon matListItemIcon>security</mat-icon>
-              <span matListItemTitle>Wallet Provider Trust Lists</span>
-              <span matListItemLine>
-                @if (
-                  config.walletProviderTrustLists && config.walletProviderTrustLists.length > 0
-                ) {
-                  {{ config.walletProviderTrustLists.length }} trust list(s) configured
-                } @else {
-                  <span class="warning-text">No trust lists configured - all wallets rejected</span>
-                }
-              </span>
-            </mat-list-item>
-          }
-          <mat-list-item>
-            <mat-icon
-              matListItemIcon
-              [class]="config.chainedAs?.enabled ? 'icon-chained-as' : 'icon-disabled'"
-            >
-              {{ config.chainedAs?.enabled ? 'account_tree' : 'link_off' }}
-            </mat-icon>
-            <span matListItemTitle>Chained Authorization Server</span>
-            <span matListItemLine>{{ config.chainedAs?.enabled ? 'Enabled' : 'Disabled' }}</span>
-          </mat-list-item>
-        </mat-list>
-      </mat-card-content>
-    </mat-card>
+    <mat-tab-group animationDuration="200ms">
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <mat-icon class="tab-icon">info</mat-icon>
+          Metadata
+        </ng-template>
 
-    <!-- Chained AS Details Card -->
-    @if (config.chainedAs?.enabled) {
-      <mat-card class="chained-as-card">
-        <mat-card-header>
-          <mat-card-title>
-            <mat-icon>account_tree</mat-icon>
-            Chained Authorization Server Details
-          </mat-card-title>
-          <mat-card-subtitle>Upstream OIDC provider configuration</mat-card-subtitle>
-        </mat-card-header>
-        <mat-card-content>
-          <mat-list class="config-list">
-            <mat-list-item>
-              <mat-icon matListItemIcon>cloud</mat-icon>
-              <span matListItemTitle>Upstream Issuer</span>
-              <span matListItemLine>{{
-                config.chainedAs?.upstream?.issuer || 'Not configured'
-              }}</span>
-            </mat-list-item>
-            <mat-list-item>
-              <mat-icon matListItemIcon>fingerprint</mat-icon>
-              <span matListItemTitle>Client ID</span>
-              <span matListItemLine>{{
-                config.chainedAs?.upstream?.clientId || 'Not configured'
-              }}</span>
-            </mat-list-item>
-            <mat-list-item>
-              <mat-icon matListItemIcon>schedule</mat-icon>
-              <span matListItemTitle>Token Lifetime</span>
-              <span matListItemLine
-                >{{ config.chainedAs?.token?.lifetimeSeconds || 3600 }} seconds</span
-              >
-            </mat-list-item>
-            <mat-list-item>
-              <mat-icon
-                matListItemIcon
-                [class]="config.chainedAs?.requireDPoP ? '' : 'icon-disabled'"
-              >
-                {{ config.chainedAs?.requireDPoP ? 'verified_user' : 'no_encryption' }}
-              </mat-icon>
-              <span matListItemTitle>DPoP Requirement</span>
-              <span matListItemLine>{{
-                config.chainedAs?.requireDPoP ? 'Required' : 'Not required'
-              }}</span>
-            </mat-list-item>
-            @if ((config.chainedAs?.upstream?.scopes?.length ?? 0) > 0) {
-              <mat-list-item>
-                <mat-icon matListItemIcon>list</mat-icon>
-                <span matListItemTitle>Requested Scopes</span>
-                <span matListItemLine>{{ config.chainedAs!.upstream!.scopes!.join(', ') }}</span>
-              </mat-list-item>
-            }
-          </mat-list>
-        </mat-card-content>
-      </mat-card>
-    }
+        <div fxLayout="column" fxLayoutGap="24px" class="tab-content">
+          <mat-card>
+            <mat-card-header>
+              <mat-card-title>
+                <mat-icon>settings</mat-icon>
+                Configuration Details
+              </mat-card-title>
+            </mat-card-header>
+            <mat-card-content>
+              <mat-list class="config-list">
+                <mat-list-item>
+                  <mat-icon matListItemIcon>schedule</mat-icon>
+                  <span matListItemTitle>Created At</span>
+                  <span matListItemLine>{{ formatDate(config.createdAt) }}</span>
+                </mat-list-item>
+                <mat-list-item>
+                  <mat-icon matListItemIcon>layers</mat-icon>
+                  <span matListItemTitle>Batch Size</span>
+                  <span matListItemLine>{{ config.batchSize || 1 }} credential(s) per request</span>
+                </mat-list-item>
+              </mat-list>
+            </mat-card-content>
+          </mat-card>
 
-    <!-- Issuer Preview Card -->
-    @if (primaryDisplay) {
-      <mat-card class="preview-card">
-        <mat-card-header>
-          <mat-card-title>
-            <mat-icon>preview</mat-icon>
-            Issuer Preview
-          </mat-card-title>
-          <mat-card-subtitle>How the issuer appears to wallets</mat-card-subtitle>
-        </mat-card-header>
-        <mat-card-content>
-          <div class="issuer-preview">
-            @if (primaryDisplay.logo?.uri) {
-              <img [src]="primaryDisplay.logo.uri" alt="Issuer Logo" class="preview-logo" />
-            }
-            <div class="preview-content">
-              <div class="preview-name">{{ primaryDisplay.name }}</div>
-              <div class="preview-locale">{{ primaryDisplay.locale }}</div>
-            </div>
-          </div>
-          @if (config.display && config.display.length > 1) {
-            <div class="locale-chips">
-              <strong>Available locales:</strong>
-              <mat-chip-set>
-                @for (display of config.display; track display['locale']) {
-                  <mat-chip>{{ display['locale'] }} - {{ display['name'] }}</mat-chip>
+          @if (primaryDisplay) {
+            <mat-card class="preview-card">
+              <mat-card-header>
+                <mat-card-title>
+                  <mat-icon>preview</mat-icon>
+                  Issuer Preview
+                </mat-card-title>
+                <mat-card-subtitle>How the issuer appears to wallets</mat-card-subtitle>
+              </mat-card-header>
+              <mat-card-content>
+                <div class="issuer-preview">
+                  @if (primaryDisplay.logo?.uri) {
+                    <img [src]="primaryDisplay.logo.uri" alt="Issuer Logo" class="preview-logo" />
+                  }
+                  <div class="preview-content">
+                    <div class="preview-name">{{ primaryDisplay.name }}</div>
+                    <div class="preview-locale">{{ primaryDisplay.locale }}</div>
+                  </div>
+                </div>
+                @if (config.display && config.display.length > 1) {
+                  <div class="locale-chips">
+                    <strong>Available locales:</strong>
+                    <mat-chip-set>
+                      @for (display of config.display; track display['locale']) {
+                        <mat-chip>{{ display['locale'] }} - {{ display['name'] }}</mat-chip>
+                      }
+                    </mat-chip-set>
+                  </div>
                 }
-              </mat-chip-set>
-            </div>
+              </mat-card-content>
+            </mat-card>
           }
-        </mat-card-content>
-      </mat-card>
-    }
+        </div>
+      </mat-tab>
+
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <mat-icon class="tab-icon">settings_applications</mat-icon>
+          Business Logic
+        </ng-template>
+
+        <div fxLayout="column" fxLayoutGap="24px" class="tab-content">
+          <mat-card>
+            <mat-card-header>
+              <mat-card-title>
+                <mat-icon>sync_alt</mat-icon>
+                Issuance Behavior
+              </mat-card-title>
+            </mat-card-header>
+            <mat-card-content>
+              <mat-list class="config-list">
+                <mat-list-item>
+                  <mat-icon
+                    matListItemIcon
+                    [class]="config.refreshTokenEnabled ? '' : 'icon-disabled'"
+                  >
+                    {{ config.refreshTokenEnabled ? 'refresh' : 'sync_disabled' }}
+                  </mat-icon>
+                  <span matListItemTitle>Refresh Tokens</span>
+                  <span matListItemLine>
+                    {{ config.refreshTokenEnabled ? 'Enabled' : 'Disabled' }}
+                  </span>
+                </mat-list-item>
+                @if (config.refreshTokenEnabled) {
+                  <mat-list-item>
+                    <mat-icon matListItemIcon>timelapse</mat-icon>
+                    <span matListItemTitle>Refresh Token Lifetime</span>
+                    <span matListItemLine>
+                      {{ config.refreshTokenExpiresInSeconds || 2592000 }} seconds
+                    </span>
+                  </mat-list-item>
+                }
+                <mat-list-item>
+                  <mat-icon matListItemIcon>dns</mat-icon>
+                  <span matListItemTitle>Authorization Servers</span>
+                  <span matListItemLine>
+                    @if (config.authServers && config.authServers.length > 0) {
+                      {{ config.authServers.join(', ') }}
+                    } @else {
+                      Using built-in authorization server
+                    }
+                  </span>
+                </mat-list-item>
+              </mat-list>
+            </mat-card-content>
+          </mat-card>
+        </div>
+      </mat-tab>
+
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <mat-icon class="tab-icon">security</mat-icon>
+          Security
+        </ng-template>
+
+        <div fxLayout="column" fxLayoutGap="24px" class="tab-content">
+          <mat-card>
+            <mat-card-header>
+              <mat-card-title>
+                <mat-icon>verified_user</mat-icon>
+                Security Policies
+              </mat-card-title>
+            </mat-card-header>
+            <mat-card-content>
+              <mat-list class="config-list">
+                <mat-list-item>
+                  <mat-icon matListItemIcon>
+                    {{ config.dPopRequired ? 'verified_user' : 'no_encryption' }}
+                  </mat-icon>
+                  <span matListItemTitle>DPoP</span>
+                  <span matListItemLine>{{
+                    config.dPopRequired ? 'Required' : 'Not required'
+                  }}</span>
+                </mat-list-item>
+                <mat-list-item>
+                  <mat-icon
+                    matListItemIcon
+                    [class]="config.walletAttestationRequired ? '' : 'icon-disabled'"
+                  >
+                    {{ config.walletAttestationRequired ? 'verified_user' : 'no_encryption' }}
+                  </mat-icon>
+                  <span matListItemTitle>Wallet Attestation</span>
+                  <span matListItemLine>{{
+                    config.walletAttestationRequired ? 'Required' : 'Not required'
+                  }}</span>
+                </mat-list-item>
+                @if (config.walletAttestationRequired) {
+                  <mat-list-item>
+                    <mat-icon matListItemIcon>security</mat-icon>
+                    <span matListItemTitle>Wallet Provider Trust Lists</span>
+                    <span matListItemLine>
+                      @if (
+                        config.walletProviderTrustLists &&
+                        config.walletProviderTrustLists.length > 0
+                      ) {
+                        {{ config.walletProviderTrustLists.length }} trust list(s) configured
+                      } @else {
+                        <span class="warning-text"
+                          >No trust lists configured - all wallets rejected</span
+                        >
+                      }
+                    </span>
+                  </mat-list-item>
+                }
+              </mat-list>
+            </mat-card-content>
+          </mat-card>
+        </div>
+      </mat-tab>
+
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <mat-icon class="tab-icon">account_tree</mat-icon>
+          Advanced Federation
+        </ng-template>
+
+        <div fxLayout="column" fxLayoutGap="24px" class="tab-content">
+          <mat-card>
+            <mat-card-header>
+              <mat-card-title>
+                <mat-icon>account_tree</mat-icon>
+                Chained Authorization Server
+              </mat-card-title>
+            </mat-card-header>
+            <mat-card-content>
+              <mat-list class="config-list">
+                <mat-list-item>
+                  <mat-icon
+                    matListItemIcon
+                    [class]="config.chainedAs?.enabled ? 'icon-chained-as' : 'icon-disabled'"
+                  >
+                    {{ config.chainedAs?.enabled ? 'account_tree' : 'link_off' }}
+                  </mat-icon>
+                  <span matListItemTitle>Status</span>
+                  <span matListItemLine>{{
+                    config.chainedAs?.enabled ? 'Enabled' : 'Disabled'
+                  }}</span>
+                </mat-list-item>
+              </mat-list>
+            </mat-card-content>
+          </mat-card>
+
+          @if (config.chainedAs?.enabled) {
+            <mat-card class="chained-as-card">
+              <mat-card-header>
+                <mat-card-title>
+                  <mat-icon>account_tree</mat-icon>
+                  Chained Authorization Server Details
+                </mat-card-title>
+                <mat-card-subtitle>Upstream OIDC provider configuration</mat-card-subtitle>
+              </mat-card-header>
+              <mat-card-content>
+                <mat-list class="config-list">
+                  <mat-list-item>
+                    <mat-icon matListItemIcon>cloud</mat-icon>
+                    <span matListItemTitle>Upstream Issuer</span>
+                    <span matListItemLine>{{
+                      config.chainedAs?.upstream?.issuer || 'Not configured'
+                    }}</span>
+                  </mat-list-item>
+                  <mat-list-item>
+                    <mat-icon matListItemIcon>fingerprint</mat-icon>
+                    <span matListItemTitle>Client ID</span>
+                    <span matListItemLine>{{
+                      config.chainedAs?.upstream?.clientId || 'Not configured'
+                    }}</span>
+                  </mat-list-item>
+                  <mat-list-item>
+                    <mat-icon matListItemIcon>schedule</mat-icon>
+                    <span matListItemTitle>Token Lifetime</span>
+                    <span matListItemLine
+                      >{{ config.chainedAs?.token?.lifetimeSeconds || 3600 }} seconds</span
+                    >
+                  </mat-list-item>
+                  <mat-list-item>
+                    <mat-icon
+                      matListItemIcon
+                      [class]="config.chainedAs?.requireDPoP ? '' : 'icon-disabled'"
+                    >
+                      {{ config.chainedAs?.requireDPoP ? 'verified_user' : 'no_encryption' }}
+                    </mat-icon>
+                    <span matListItemTitle>DPoP Requirement</span>
+                    <span matListItemLine>{{
+                      config.chainedAs?.requireDPoP ? 'Required' : 'Not required'
+                    }}</span>
+                  </mat-list-item>
+                  @if ((config.chainedAs?.upstream?.scopes?.length ?? 0) > 0) {
+                    <mat-list-item>
+                      <mat-icon matListItemIcon>list</mat-icon>
+                      <span matListItemTitle>Requested Scopes</span>
+                      <span matListItemLine>{{
+                        config.chainedAs!.upstream!.scopes!.join(', ')
+                      }}</span>
+                    </mat-list-item>
+                  }
+                </mat-list>
+              </mat-card-content>
+            </mat-card>
+          }
+        </div>
+      </mat-tab>
+    </mat-tab-group>
   </div>
 }

--- a/apps/client/src/app/issuance/issuance-config/issuance-config-show/issuance-config-show.component.ts
+++ b/apps/client/src/app/issuance/issuance-config/issuance-config-show/issuance-config-show.component.ts
@@ -7,6 +7,7 @@ import { MatDividerModule } from '@angular/material/divider';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatIconModule } from '@angular/material/icon';
 import { MatListModule } from '@angular/material/list';
+import { MatTabsModule } from '@angular/material/tabs';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { RouterModule } from '@angular/router';
@@ -25,6 +26,7 @@ import { IssuanceConfigService } from '../issuance-config.service';
     MatChipsModule,
     MatDividerModule,
     MatListModule,
+    MatTabsModule,
     FlexLayoutModule,
     RouterModule,
     ClipboardModule,

--- a/apps/client/src/app/presentation/presentation-config/presentation-create/presentation-create.component.html
+++ b/apps/client/src/app/presentation/presentation-config/presentation-create/presentation-create.component.html
@@ -63,184 +63,235 @@
     fxLayout="column"
     fxLayoutGap="24px"
   >
-    <mat-card>
-      <mat-card-header>
-        <mat-card-title>
-          <mat-icon>settings</mat-icon>
-          Basic Information
-        </mat-card-title>
-      </mat-card-header>
+    <mat-tab-group animationDuration="200ms">
+      <!-- TAB 1: Basic -->
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <mat-icon class="tab-icon">settings</mat-icon>
+          Basic
+        </ng-template>
+        <div fxLayout="column" fxLayoutGap="24px" class="tab-content">
+          <mat-card>
+            <mat-card-header>
+              <mat-card-title>
+                <mat-icon>settings</mat-icon>
+                Basic Information
+              </mat-card-title>
+            </mat-card-header>
+            <mat-card-content fxLayout="column" fxLayoutGap="16px">
+              <!-- ID Field -->
+              <mat-form-field>
+                <mat-label>ID</mat-label>
+                <input matInput formControlName="id" placeholder="Enter unique identifier" />
+                @if (form.controls['id'].hasError('required')) {
+                  <mat-error> ID is required </mat-error>
+                }
+              </mat-form-field>
 
-      <mat-card-content fxLayout="column" fxLayoutGap="16px">
-        <!-- ID Field -->
-        <mat-form-field>
-          <mat-label>ID</mat-label>
-          <input matInput formControlName="id" placeholder="Enter unique identifier" />
-          @if (form.controls['id'].hasError('required')) {
-            <mat-error> ID is required </mat-error>
-          }
-        </mat-form-field>
+              <!-- Description Field -->
+              <mat-form-field>
+                <mat-label>Description</mat-label>
+                <input matInput formControlName="description" placeholder="Enter description" />
+                @if (form.controls['description'].hasError('required')) {
+                  <mat-error> Description is required </mat-error>
+                }
+              </mat-form-field>
 
-        <!-- Description Field -->
-        <mat-form-field>
-          <mat-label>Description</mat-label>
-          <input matInput formControlName="description" placeholder="Enter description" />
-          @if (form.controls['description'].hasError('required')) {
-            <mat-error> Description is required </mat-error>
-          }
-        </mat-form-field>
+              <mat-form-field>
+                <mat-label>Lifetime of the request</mat-label>
+                <input matInput formControlName="lifeTime" type="number" />
+                @if (form.controls['lifeTime'].hasError('required')) {
+                  <mat-error> Lifetime is required </mat-error>
+                }
+                @if (form.controls['lifeTime'].hasError('min')) {
+                  <mat-error> Lifetime must be at least 1 </mat-error>
+                }
+                <mat-hint> Lifetime is in seconds </mat-hint>
+              </mat-form-field>
 
-        <!-- DCQL Query Field -->
-        <h4>DCQL Query</h4>
-        <app-editor
-          formControlName="dcql_query"
-          [schema]="DCQLSchema"
-          [errors]="form.get('dcql_query')?.errors"
-        ></app-editor>
+              <mat-form-field>
+                <mat-label>Redirect URI (optional)</mat-label>
+                <input
+                  matInput
+                  formControlName="redirectUri"
+                  placeholder="https://example.com/callback?session={sessionId}"
+                />
+                <mat-hint>
+                  User will be redirected here after completing the presentation. Use
+                  <code>{{ '{' }}sessionId{{ '}' }}</code> as placeholder for the session ID.
+                </mat-hint>
+              </mat-form-field>
 
-        <mat-form-field>
-          <mat-label>Lifetime of the request</mat-label>
-          <input matInput formControlName="lifeTime" type="number" />
-          @if (form.controls['lifeTime'].hasError('required')) {
-            <mat-error> Lifetime is required </mat-error>
-          }
-          @if (form.controls['lifeTime'].hasError('min')) {
-            <mat-error> Lifetime must be at least 1 </mat-error>
-          }
-          <mat-hint> Lifetime is in seconds </mat-hint>
-        </mat-form-field>
-
-        <mat-form-field>
-          <mat-label>Redirect URI (optional)</mat-label>
-          <input
-            matInput
-            formControlName="redirectUri"
-            placeholder="https://example.com/callback?session={sessionId}"
-          />
-          <mat-hint>
-            User will be redirected here after completing the presentation. Use
-            <code>{{ '{' }}sessionId{{ '}' }}</code> as placeholder for the session ID.
-          </mat-hint>
-        </mat-form-field>
-
-        <mat-form-field>
-          <mat-label>Access Key Chain (optional)</mat-label>
-          <mat-select formControlName="accessKeyChainId">
-            <mat-select-trigger>
-              @if (form.controls['accessKeyChainId'].value; as keyChainId) {
-                {{ keyChainId }}
-              } @else {
-                <em>Use default access key chain</em>
-              }
-            </mat-select-trigger>
-            <mat-option [value]="null">
-              <em>Use default access key chain</em>
-            </mat-option>
-            @for (keyChain of keyChains; track keyChain.id) {
-              <mat-option [value]="keyChain.id">
-                <div fxLayout="column">
-                  <span
-                    ><strong>{{ keyChain.id }}</strong></span
-                  >
-                  <span class="option-description">{{
-                    keyChain.description || keyChain.usageType
-                  }}</span>
-                </div>
-              </mat-option>
-            }
-          </mat-select>
-          <mat-icon matSuffix>key</mat-icon>
-          <mat-hint>Select the access key chain for signing the presentation request</mat-hint>
-        </mat-form-field>
-      </mat-card-content>
-    </mat-card>
-
-    <mat-card>
-      <mat-card-header>
-        <mat-card-title>
-          <mat-icon>security</mat-icon>
-          Registrar
-        </mat-card-title>
-      </mat-card-header>
-      <mat-card-content fxLayout="column" fxLayoutGap="16px">
-        <!-- Registration Certificate Field -->
-        <h4>Registrar Certificate (optional)</h4>
-        <app-editor
-          formControlName="registrationCert"
-          [schema]="registrationCertificateRequestSchema"
-          [errors]="form.controls['registrationCert'].errors"
-        ></app-editor>
-      </mat-card-content>
-    </mat-card>
-
-    <!-- Transaction Data Card -->
-    <mat-card>
-      <mat-card-header>
-        <mat-card-title>
-          <mat-icon>receipt_long</mat-icon>
-          Transaction Data
-        </mat-card-title>
-        <mat-card-subtitle>
-          Optional transaction data to include in the OID4VP request
-        </mat-card-subtitle>
-      </mat-card-header>
-      <mat-card-content fxLayout="column" fxLayoutGap="16px">
-        <app-editor
-          formControlName="transaction_data"
-          [schema]="transactionDataArraySchema"
-          [errors]="form.controls['transaction_data']?.errors"
-        ></app-editor>
-        <mat-hint>
-          Transaction data is an array of objects with at least <code>type</code> and
-          <code>credential_ids</code> properties. Example:
-          <code
-            >[{{ '{' }}"type": "payment", "credential_ids": ["pid"], "amount": 100{{ '}' }}]</code
-          >
-        </mat-hint>
-      </mat-card-content>
-    </mat-card>
-
-    <!-- Attachment Configuration Card -->
-    <mat-card>
-      <mat-card-header>
-        <mat-card-title>
-          <mat-icon>attach_file</mat-icon>
-          Attachments
-        </mat-card-title>
-      </mat-card-header>
-      <mat-card-content fxLayout="column" fxLayoutGap="16px">
-        <button mat-button (click)="addAttachment()" type="button">Add Attachment</button>
-        <div formArrayName="attached">
-          @for (attachmentCtrl of getFormArray('attached').controls; let i = $index; track $index) {
-            <app-credential-ids
-              [formGroup]="asFormGroup(attachmentCtrl)"
-              (removeAttachment)="removeAttachment(i)"
-            ></app-credential-ids>
-          }
+              <mat-form-field>
+                <mat-label>Access Key Chain (optional)</mat-label>
+                <mat-select formControlName="accessKeyChainId">
+                  <mat-select-trigger>
+                    @if (form.controls['accessKeyChainId'].value; as keyChainId) {
+                      {{ keyChainId }}
+                    } @else {
+                      <em>Use default access key chain</em>
+                    }
+                  </mat-select-trigger>
+                  <mat-option [value]="null">
+                    <em>Use default access key chain</em>
+                  </mat-option>
+                  @for (keyChain of keyChains; track keyChain.id) {
+                    <mat-option [value]="keyChain.id">
+                      <div fxLayout="column">
+                        <span
+                          ><strong>{{ keyChain.id }}</strong></span
+                        >
+                        <span class="option-description">{{
+                          keyChain.description || keyChain.usageType
+                        }}</span>
+                      </div>
+                    </mat-option>
+                  }
+                </mat-select>
+                <mat-icon matSuffix>key</mat-icon>
+                <mat-hint
+                  >Select the access key chain for signing the presentation request</mat-hint
+                >
+              </mat-form-field>
+            </mat-card-content>
+          </mat-card>
         </div>
-      </mat-card-content>
-    </mat-card>
+      </mat-tab>
 
-    <!-- Webhook Configuration Card -->
-    <mat-card>
-      <mat-card-header>
-        <mat-card-title>
-          <mat-icon>webhook</mat-icon>
-          Webhook Configuration
-        </mat-card-title>
-      </mat-card-header>
+      <!-- TAB 2: Query -->
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <mat-icon class="tab-icon">search</mat-icon>
+          Query
+        </ng-template>
+        <div fxLayout="column" fxLayoutGap="24px" class="tab-content">
+          <mat-card>
+            <mat-card-header>
+              <mat-card-title>
+                <mat-icon>search</mat-icon>
+                DCQL Query
+              </mat-card-title>
+              <mat-card-subtitle>Credential query for the presentation request</mat-card-subtitle>
+            </mat-card-header>
+            <mat-card-content fxLayout="column" fxLayoutGap="16px">
+              <app-editor
+                formControlName="dcql_query"
+                [schema]="DCQLSchema"
+                [errors]="form.get('dcql_query')?.errors"
+              ></app-editor>
+            </mat-card-content>
+          </mat-card>
 
-      <mat-card-content fxLayout="column" fxLayoutGap="16px" formGroupName="webhook">
-        <app-webhook-config-edit [group]="getFormGroup('webhook')"></app-webhook-config-edit>
-      </mat-card-content>
-    </mat-card>
+          <!-- Transaction Data Card -->
+          <mat-card>
+            <mat-card-header>
+              <mat-card-title>
+                <mat-icon>receipt_long</mat-icon>
+                Transaction Data
+              </mat-card-title>
+              <mat-card-subtitle>
+                Optional transaction data to include in the OID4VP request
+              </mat-card-subtitle>
+            </mat-card-header>
+            <mat-card-content fxLayout="column" fxLayoutGap="16px">
+              <app-editor
+                formControlName="transaction_data"
+                [schema]="transactionDataArraySchema"
+                [errors]="form.controls['transaction_data']?.errors"
+              ></app-editor>
+              <mat-hint>
+                Transaction data is an array of objects with at least <code>type</code> and
+                <code>credential_ids</code> properties. Example:
+                <code
+                  >[{{ '{' }}"type": "payment", "credential_ids": ["pid"], "amount": 100{{
+                    '}'
+                  }}]</code
+                >
+              </mat-hint>
+            </mat-card-content>
+          </mat-card>
+        </div>
+      </mat-tab>
+
+      <!-- TAB 3: Security -->
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <mat-icon class="tab-icon">security</mat-icon>
+          Security
+        </ng-template>
+        <div fxLayout="column" fxLayoutGap="24px" class="tab-content">
+          <mat-card>
+            <mat-card-header>
+              <mat-card-title>
+                <mat-icon>security</mat-icon>
+                Registrar
+              </mat-card-title>
+            </mat-card-header>
+            <mat-card-content fxLayout="column" fxLayoutGap="16px">
+              <h4>Registrar Certificate (optional)</h4>
+              <app-editor
+                formControlName="registrationCert"
+                [schema]="registrationCertificateRequestSchema"
+                [errors]="form.controls['registrationCert'].errors"
+              ></app-editor>
+            </mat-card-content>
+          </mat-card>
+        </div>
+      </mat-tab>
+
+      <!-- TAB 4: Integration -->
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <mat-icon class="tab-icon">hub</mat-icon>
+          Integration
+        </ng-template>
+        <div fxLayout="column" fxLayoutGap="24px" class="tab-content">
+          <!-- Attachment Configuration Card -->
+          <mat-card>
+            <mat-card-header>
+              <mat-card-title>
+                <mat-icon>attach_file</mat-icon>
+                Attachments
+              </mat-card-title>
+            </mat-card-header>
+            <mat-card-content fxLayout="column" fxLayoutGap="16px">
+              <button mat-button (click)="addAttachment()" type="button">Add Attachment</button>
+              <div formArrayName="attached">
+                @for (
+                  attachmentCtrl of getFormArray('attached').controls;
+                  let i = $index;
+                  track $index
+                ) {
+                  <app-credential-ids
+                    [formGroup]="asFormGroup(attachmentCtrl)"
+                    (removeAttachment)="removeAttachment(i)"
+                  ></app-credential-ids>
+                }
+              </div>
+            </mat-card-content>
+          </mat-card>
+
+          <!-- Webhook Configuration Card -->
+          <mat-card>
+            <mat-card-header>
+              <mat-card-title>
+                <mat-icon>webhook</mat-icon>
+                Webhook Configuration
+              </mat-card-title>
+            </mat-card-header>
+            <mat-card-content fxLayout="column" fxLayoutGap="16px" formGroupName="webhook">
+              <app-webhook-config-edit [group]="getFormGroup('webhook')"></app-webhook-config-edit>
+            </mat-card-content>
+          </mat-card>
+        </div>
+      </mat-tab>
+    </mat-tab-group>
 
     <!-- Action Buttons -->
     <div fxLayout="row" fxLayoutGap="16px" fxLayoutAlign="end center">
       <button mat-button type="button" [routerLink]="['../']">Cancel</button>
       <button mat-flat-button type="submit" [disabled]="form.invalid">
         <mat-icon>{{ create ? 'add' : 'save' }}</mat-icon>
-
         {{ create ? 'Create' : 'Save' }} Configuration
       </button>
     </div>

--- a/apps/client/src/app/presentation/presentation-config/presentation-create/presentation-create.component.ts
+++ b/apps/client/src/app/presentation/presentation-config/presentation-create/presentation-create.component.ts
@@ -20,6 +20,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { JsonViewDialogComponent } from '../../../issuance/credential-config/credential-config-create/json-view-dialog/json-view-dialog.component';
 import { IssuerMetadataBrowserComponent } from '../issuer-metadata-browser/issuer-metadata-browser.component';
 import { MatMenuModule } from '@angular/material/menu';
+import { MatTabsModule } from '@angular/material/tabs';
 import { MatDividerModule } from '@angular/material/divider';
 import { configs } from './pre-config';
 import { MonacoEditorModule } from 'ngx-monaco-editor-v2';
@@ -49,6 +50,7 @@ import { CredentialIdsComponent } from '../../credential-ids/credential-ids.comp
     RouterModule,
     MatMenuModule,
     MatDividerModule,
+    MatTabsModule,
     MonacoEditorModule,
     EditorComponent,
     WebhookConfigEditComponent,

--- a/apps/client/src/app/presentation/presentation-config/presentation-show/presentation-show.component.html
+++ b/apps/client/src/app/presentation/presentation-config/presentation-show/presentation-show.component.html
@@ -35,260 +35,312 @@
     </div>
 
     <!-- Configuration Details Card -->
-    <mat-card>
-      <mat-card-header>
-        <mat-card-title>
-          <mat-icon>settings</mat-icon>
-          Configuration Details
-        </mat-card-title>
-      </mat-card-header>
-      <mat-card-content>
-        <mat-list class="config-list">
-          <mat-list-item>
-            <mat-icon matListItemIcon>fingerprint</mat-icon>
-            <span matListItemTitle>Configuration ID</span>
-            <span matListItemLine>{{ config.id }}</span>
-          </mat-list-item>
-          @if (config.description) {
-            <mat-list-item>
-              <mat-icon matListItemIcon>description</mat-icon>
-              <span matListItemTitle>Description</span>
-              <span matListItemLine>{{ config.description }}</span>
-            </mat-list-item>
-          }
-          <mat-list-item>
-            <mat-icon matListItemIcon>schedule</mat-icon>
-            <span matListItemTitle>Created At</span>
-            <span matListItemLine>{{ config.createdAt | date: 'medium' }}</span>
-          </mat-list-item>
-          <mat-list-item>
-            <mat-icon matListItemIcon>timer</mat-icon>
-            <span matListItemTitle>Request Lifetime</span>
-            <span matListItemLine>{{
-              config.lifeTime ? formatLifetime(config.lifeTime) : 'Not set'
-            }}</span>
-          </mat-list-item>
-          @if (config.redirectUri) {
-            <mat-list-item>
-              <mat-icon matListItemIcon>open_in_new</mat-icon>
-              <span matListItemTitle>Redirect URI</span>
-              <span matListItemLine>{{ config.redirectUri }}</span>
-            </mat-list-item>
-          }
-          <mat-list-item>
-            <mat-icon matListItemIcon>badge</mat-icon>
-            <span matListItemTitle>Access Certificate</span>
-            @if (config.accessKeyChainId) {
-              <span matListItemLine>{{ config.accessKeyChainId }}</span>
-            } @else {
-              <span matListItemLine>Default</span>
-            }
-          </mat-list-item>
-        </mat-list>
-      </mat-card-content>
-    </mat-card>
+    <mat-tab-group animationDuration="200ms">
+      <!-- TAB 1: Overview -->
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <mat-icon class="tab-icon">info</mat-icon>
+          Overview
+        </ng-template>
+        <div fxLayout="column" fxLayoutGap="24px" class="tab-content">
+          <mat-card>
+            <mat-card-header>
+              <mat-card-title>
+                <mat-icon>settings</mat-icon>
+                Configuration Details
+              </mat-card-title>
+            </mat-card-header>
+            <mat-card-content>
+              <mat-list class="config-list">
+                <mat-list-item>
+                  <mat-icon matListItemIcon>fingerprint</mat-icon>
+                  <span matListItemTitle>Configuration ID</span>
+                  <span matListItemLine>{{ config.id }}</span>
+                </mat-list-item>
+                @if (config.description) {
+                  <mat-list-item>
+                    <mat-icon matListItemIcon>description</mat-icon>
+                    <span matListItemTitle>Description</span>
+                    <span matListItemLine>{{ config.description }}</span>
+                  </mat-list-item>
+                }
+                <mat-list-item>
+                  <mat-icon matListItemIcon>schedule</mat-icon>
+                  <span matListItemTitle>Created At</span>
+                  <span matListItemLine>{{ config.createdAt | date: 'medium' }}</span>
+                </mat-list-item>
+                <mat-list-item>
+                  <mat-icon matListItemIcon>timer</mat-icon>
+                  <span matListItemTitle>Request Lifetime</span>
+                  <span matListItemLine>{{
+                    config.lifeTime ? formatLifetime(config.lifeTime) : 'Not set'
+                  }}</span>
+                </mat-list-item>
+                @if (config.redirectUri) {
+                  <mat-list-item>
+                    <mat-icon matListItemIcon>open_in_new</mat-icon>
+                    <span matListItemTitle>Redirect URI</span>
+                    <span matListItemLine>{{ config.redirectUri }}</span>
+                  </mat-list-item>
+                }
+                <mat-list-item>
+                  <mat-icon matListItemIcon>badge</mat-icon>
+                  <span matListItemTitle>Access Certificate</span>
+                  @if (config.accessKeyChainId) {
+                    <span matListItemLine>{{ config.accessKeyChainId }}</span>
+                  } @else {
+                    <span matListItemLine>Default</span>
+                  }
+                </mat-list-item>
+              </mat-list>
+            </mat-card-content>
+          </mat-card>
+        </div>
+      </mat-tab>
 
-    <!-- DCQL Query Card -->
-    <mat-card>
-      <mat-card-header>
-        <mat-card-title>
-          <mat-icon>search</mat-icon>
-          Credential Query (DCQL)
-        </mat-card-title>
-        <mat-card-subtitle>Credentials requested from the wallet</mat-card-subtitle>
-      </mat-card-header>
-      <mat-card-content>
-        <!-- Credential Set (combinations) -->
-        @if (config.dcql_query.credential_sets && config.dcql_query.credential_sets.length > 0) {
-          <div class="credential-sets-section">
-            <h4>
-              <mat-icon>account_tree</mat-icon>
-              Accepted Combinations
-            </h4>
-            <p class="section-description">
-              The wallet must provide one of the following credential combinations:
-            </p>
-            <div fxLayout="column" fxLayoutGap="12px">
-              @for (credSet of config.dcql_query.credential_sets; track $index; let i = $index) {
-                <div class="credential-set-card">
-                  <div class="set-header">
-                    <span class="set-label">Option {{ i + 1 }}</span>
-                    @if (credSet.required) {
-                      <mat-chip class="required-chip">Required</mat-chip>
-                    }
-                  </div>
-                  <div class="set-options">
-                    @for (option of credSet.options; track $index; let j = $index) {
-                      @if (j > 0) {
-                        <span class="or-separator">OR</span>
-                      }
-                      <div class="option-group">
-                        @for (credId of option; track credId; let k = $index) {
-                          @if (k > 0) {
-                            <span class="and-separator">+</span>
+      <!-- TAB 2: Query -->
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <mat-icon class="tab-icon">search</mat-icon>
+          Query
+        </ng-template>
+        <div fxLayout="column" fxLayoutGap="24px" class="tab-content">
+          <mat-card>
+            <mat-card-header>
+              <mat-card-title>
+                <mat-icon>search</mat-icon>
+                Credential Query (DCQL)
+              </mat-card-title>
+              <mat-card-subtitle>Credentials requested from the wallet</mat-card-subtitle>
+            </mat-card-header>
+            <mat-card-content>
+              <!-- Credential Set (combinations) -->
+              @if (
+                config.dcql_query.credential_sets && config.dcql_query.credential_sets.length > 0
+              ) {
+                <div class="credential-sets-section">
+                  <h4>
+                    <mat-icon>account_tree</mat-icon>
+                    Accepted Combinations
+                  </h4>
+                  <p class="section-description">
+                    The wallet must provide one of the following credential combinations:
+                  </p>
+                  <div fxLayout="column" fxLayoutGap="12px">
+                    @for (
+                      credSet of config.dcql_query.credential_sets;
+                      track $index;
+                      let i = $index
+                    ) {
+                      <div class="credential-set-card">
+                        <div class="set-header">
+                          <span class="set-label">Option {{ i + 1 }}</span>
+                          @if (credSet.required) {
+                            <mat-chip class="required-chip">Required</mat-chip>
                           }
-                          <mat-chip class="credential-id-chip">{{ credId }}</mat-chip>
-                        }
+                        </div>
+                        <div class="set-options">
+                          @for (option of credSet.options; track $index; let j = $index) {
+                            @if (j > 0) {
+                              <span class="or-separator">OR</span>
+                            }
+                            <div class="option-group">
+                              @for (credId of option; track credId; let k = $index) {
+                                @if (k > 0) {
+                                  <span class="and-separator">+</span>
+                                }
+                                <mat-chip class="credential-id-chip">{{ credId }}</mat-chip>
+                              }
+                            </div>
+                          }
+                        </div>
                       </div>
                     }
                   </div>
                 </div>
+                <mat-divider></mat-divider>
               }
-            </div>
-          </div>
-          <mat-divider></mat-divider>
-        }
 
-        <!-- Individual Credential Definitions -->
-        @if (credentialQueries.length > 0) {
-          <div class="credentials-section">
-            <h4>
-              <mat-icon>badge</mat-icon>
-              Credential Definitions
-            </h4>
-            <div fxLayout="column" fxLayoutGap="16px">
-              @for (cred of credentialQueries; track cred.id) {
-                <mat-card class="credential-query-card">
-                  <mat-card-header>
-                    <mat-card-title>{{ cred.id }}</mat-card-title>
-                    <mat-card-subtitle>
-                      <mat-chip-set>
-                        @if (cred.format) {
-                          <mat-chip
-                            [class]="cred.format === 'mso_mdoc' ? 'format-mdoc' : 'format-sdjwt'"
-                          >
-                            {{ cred.format === 'mso_mdoc' ? 'mDOC' : 'SD-JWT' }}
-                          </mat-chip>
-                        }
-                      </mat-chip-set>
-                    </mat-card-subtitle>
-                  </mat-card-header>
-                  <mat-card-content>
-                    @if (cred.meta?.doctype_value || cred.meta?.vct_values) {
-                      <div class="query-meta">
-                        @if (cred.meta?.doctype_value) {
-                          <div><strong>DocType:</strong> {{ cred.meta.doctype_value }}</div>
-                        }
-                        @if (cred.meta?.vct_values) {
-                          <div><strong>VCT:</strong> {{ cred.meta.vct_values.join(', ') }}</div>
-                        }
-                      </div>
-                    }
-                    @if (cred.claims) {
-                      <mat-expansion-panel class="claims-panel">
-                        <mat-expansion-panel-header>
-                          <mat-panel-title>
-                            <mat-icon>list</mat-icon>
-                            Requested Claims
-                          </mat-panel-title>
-                        </mat-expansion-panel-header>
-                        <pre class="config-value">{{ formatJsonValue(cred.claims) }}</pre>
-                      </mat-expansion-panel>
-                    }
-                    @if (cred.trusted_authorities && cred.trusted_authorities.length > 0) {
-                      <div class="trusted-authorities">
-                        <h5>
-                          <mat-icon>verified_user</mat-icon>
-                          Trusted Authorities
-                        </h5>
-                        @for (auth of cred.trusted_authorities; track $index) {
-                          <div class="authority-item">
+              <!-- Individual Credential Definitions -->
+              @if (credentialQueries.length > 0) {
+                <div class="credentials-section">
+                  <h4>
+                    <mat-icon>badge</mat-icon>
+                    Credential Definitions
+                  </h4>
+                  <div fxLayout="column" fxLayoutGap="16px">
+                    @for (cred of credentialQueries; track cred.id) {
+                      <mat-card class="credential-query-card">
+                        <mat-card-header>
+                          <mat-card-title>{{ cred.id }}</mat-card-title>
+                          <mat-card-subtitle>
                             <mat-chip-set>
-                              <mat-chip class="authority-type">{{ auth.type }}</mat-chip>
+                              @if (cred.format) {
+                                <mat-chip
+                                  [class]="
+                                    cred.format === 'mso_mdoc' ? 'format-mdoc' : 'format-sdjwt'
+                                  "
+                                >
+                                  {{ cred.format === 'mso_mdoc' ? 'mDOC' : 'SD-JWT' }}
+                                </mat-chip>
+                              }
                             </mat-chip-set>
-                            <div class="authority-values">
-                              @for (value of auth.values; track value) {
-                                <code class="authority-value">{{ value }}</code>
+                          </mat-card-subtitle>
+                        </mat-card-header>
+                        <mat-card-content>
+                          @if (cred.meta?.doctype_value || cred.meta?.vct_values) {
+                            <div class="query-meta">
+                              @if (cred.meta?.doctype_value) {
+                                <div><strong>DocType:</strong> {{ cred.meta.doctype_value }}</div>
+                              }
+                              @if (cred.meta?.vct_values) {
+                                <div>
+                                  <strong>VCT:</strong> {{ cred.meta.vct_values.join(', ') }}
+                                </div>
                               }
                             </div>
-                          </div>
-                        }
-                      </div>
+                          }
+                          @if (cred.claims) {
+                            <mat-expansion-panel class="claims-panel">
+                              <mat-expansion-panel-header>
+                                <mat-panel-title>
+                                  <mat-icon>list</mat-icon>
+                                  Requested Claims
+                                </mat-panel-title>
+                              </mat-expansion-panel-header>
+                              <pre class="config-value">{{ formatJsonValue(cred.claims) }}</pre>
+                            </mat-expansion-panel>
+                          }
+                          @if (cred.trusted_authorities && cred.trusted_authorities.length > 0) {
+                            <div class="trusted-authorities">
+                              <h5>
+                                <mat-icon>verified_user</mat-icon>
+                                Trusted Authorities
+                              </h5>
+                              @for (auth of cred.trusted_authorities; track $index) {
+                                <div class="authority-item">
+                                  <mat-chip-set>
+                                    <mat-chip class="authority-type">{{ auth.type }}</mat-chip>
+                                  </mat-chip-set>
+                                  <div class="authority-values">
+                                    @for (value of auth.values; track value) {
+                                      <code class="authority-value">{{ value }}</code>
+                                    }
+                                  </div>
+                                </div>
+                              }
+                            </div>
+                          }
+                        </mat-card-content>
+                      </mat-card>
                     }
-                  </mat-card-content>
-                </mat-card>
+                  </div>
+                </div>
+              } @else {
+                <mat-expansion-panel>
+                  <mat-expansion-panel-header>
+                    <mat-panel-title>
+                      <mat-icon>code</mat-icon>
+                      Raw DCQL Query
+                    </mat-panel-title>
+                  </mat-expansion-panel-header>
+                  <pre class="config-value">{{ formatJsonValue(config.dcql_query) }}</pre>
+                </mat-expansion-panel>
               }
-            </div>
-          </div>
-        } @else {
-          <mat-expansion-panel>
-            <mat-expansion-panel-header>
-              <mat-panel-title>
-                <mat-icon>code</mat-icon>
-                Raw DCQL Query
-              </mat-panel-title>
-            </mat-expansion-panel-header>
-            <pre class="config-value">{{ formatJsonValue(config.dcql_query) }}</pre>
-          </mat-expansion-panel>
-        }
-      </mat-card-content>
-    </mat-card>
+            </mat-card-content>
+          </mat-card>
+        </div>
+      </mat-tab>
 
-    <!-- Registration Certificate Card -->
-    @if (config.registrationCert) {
-      <mat-card>
-        <mat-card-header>
-          <mat-card-title>
-            <mat-icon>verified_user</mat-icon>
-            Registration Certificate
-          </mat-card-title>
-          <mat-card-subtitle>Certificate used for the presentation</mat-card-subtitle>
-        </mat-card-header>
-        <mat-card-content>
-          <mat-list class="config-list">
-            <mat-list-item>
-              <mat-icon matListItemIcon>key</mat-icon>
-              <span matListItemTitle>JWT</span>
-              <span matListItemLine class="jwt-preview"
-                >{{ config.registrationCert.jwt | slice: 0 : 50 }}...</span
-              >
-            </mat-list-item>
-          </mat-list>
-          <mat-expansion-panel>
-            <mat-expansion-panel-header>
-              <mat-panel-title>
-                <mat-icon>code</mat-icon>
-                Full JWT
-              </mat-panel-title>
-            </mat-expansion-panel-header>
-            <pre class="config-value">{{ config.registrationCert.jwt }}</pre>
-          </mat-expansion-panel>
-        </mat-card-content>
-      </mat-card>
-    }
+      <!-- TAB 3: Security -->
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <mat-icon class="tab-icon">security</mat-icon>
+          Security
+        </ng-template>
+        <div fxLayout="column" fxLayoutGap="24px" class="tab-content">
+          @if (config.registrationCert) {
+            <mat-card>
+              <mat-card-header>
+                <mat-card-title>
+                  <mat-icon>verified_user</mat-icon>
+                  Registration Certificate
+                </mat-card-title>
+                <mat-card-subtitle>Certificate used for the presentation</mat-card-subtitle>
+              </mat-card-header>
+              <mat-card-content>
+                <mat-list class="config-list">
+                  <mat-list-item>
+                    <mat-icon matListItemIcon>key</mat-icon>
+                    <span matListItemTitle>JWT</span>
+                    <span matListItemLine class="jwt-preview"
+                      >{{ config.registrationCert.jwt | slice: 0 : 50 }}...</span
+                    >
+                  </mat-list-item>
+                </mat-list>
+                <mat-expansion-panel>
+                  <mat-expansion-panel-header>
+                    <mat-panel-title>
+                      <mat-icon>code</mat-icon>
+                      Full JWT
+                    </mat-panel-title>
+                  </mat-expansion-panel-header>
+                  <pre class="config-value">{{ config.registrationCert.jwt }}</pre>
+                </mat-expansion-panel>
+              </mat-card-content>
+            </mat-card>
+          } @else {
+            <mat-card>
+              <mat-card-content>
+                <p>No registration certificate configured.</p>
+              </mat-card-content>
+            </mat-card>
+          }
+        </div>
+      </mat-tab>
 
-    <!-- Webhook -->
-    <app-webhook-config-show
-      [config]="config.webhook"
-      title="Verification Result"
-      descriptions="Where verification results are sent"
-    ></app-webhook-config-show>
+      <!-- TAB 4: Integration -->
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <mat-icon class="tab-icon">hub</mat-icon>
+          Integration
+        </ng-template>
+        <div fxLayout="column" fxLayoutGap="24px" class="tab-content">
+          <!-- Webhook -->
+          <app-webhook-config-show
+            [config]="config.webhook"
+            title="Verification Result"
+            descriptions="Where verification results are sent"
+          ></app-webhook-config-show>
 
-    <!-- Attached Data -->
-    @if (config.attached) {
-      <mat-card>
-        <mat-card-header>
-          <mat-card-title>
-            <mat-icon>attach_file</mat-icon>
-            Attached Data
-          </mat-card-title>
-          <mat-card-subtitle
-            >Additional data attached to the presentation request</mat-card-subtitle
-          >
-        </mat-card-header>
-        <mat-card-content>
-          <mat-expansion-panel>
-            <mat-expansion-panel-header>
-              <mat-panel-title>
-                <mat-icon>code</mat-icon>
-                View Attached Data
-              </mat-panel-title>
-            </mat-expansion-panel-header>
-            <pre class="config-value">{{ formatJsonValue(config.attached) }}</pre>
-          </mat-expansion-panel>
-        </mat-card-content>
-      </mat-card>
-    }
+          <!-- Attached Data -->
+          @if (config.attached) {
+            <mat-card>
+              <mat-card-header>
+                <mat-card-title>
+                  <mat-icon>attach_file</mat-icon>
+                  Attached Data
+                </mat-card-title>
+                <mat-card-subtitle
+                  >Additional data attached to the presentation request</mat-card-subtitle
+                >
+              </mat-card-header>
+              <mat-card-content>
+                <mat-expansion-panel>
+                  <mat-expansion-panel-header>
+                    <mat-panel-title>
+                      <mat-icon>code</mat-icon>
+                      View Attached Data
+                    </mat-panel-title>
+                  </mat-expansion-panel-header>
+                  <pre class="config-value">{{ formatJsonValue(config.attached) }}</pre>
+                </mat-expansion-panel>
+              </mat-card-content>
+            </mat-card>
+          }
+        </div>
+      </mat-tab>
+    </mat-tab-group>
   </div>
 } @else {
   <div class="empty-state" fxLayout="column" fxLayoutAlign="center center" fxFlex>

--- a/apps/client/src/app/presentation/presentation-config/presentation-show/presentation-show.component.ts
+++ b/apps/client/src/app/presentation/presentation-config/presentation-show/presentation-show.component.ts
@@ -6,6 +6,7 @@ import { MatCardModule } from '@angular/material/card';
 import { MatChipsModule } from '@angular/material/chips';
 import { MatDividerModule } from '@angular/material/divider';
 import { MatExpansionModule } from '@angular/material/expansion';
+import { MatTabsModule } from '@angular/material/tabs';
 import { MatIconModule } from '@angular/material/icon';
 import { MatListModule } from '@angular/material/list';
 import { MatSnackBar } from '@angular/material/snack-bar';
@@ -28,6 +29,7 @@ import { WebhookConfigShowComponent } from '../../../utils/webhook-config-show/w
     MatChipsModule,
     MatDividerModule,
     MatExpansionModule,
+    MatTabsModule,
     FlexLayoutModule,
     RouterModule,
     ClipboardModule,

--- a/apps/client/src/app/utils/schemas.ts
+++ b/apps/client/src/app/utils/schemas.ts
@@ -9,6 +9,15 @@ import presnetationConfigCreateSchemaObj from '../../../../../schemas/Presentati
 import transactionDataSchemaObj from '../../../../../schemas/TransactionData.schema.json';
 import claimsMetadataSchemaObj from '../../../../../schemas/ClaimMetadata.schema.json';
 
+// Create an array schema for ClaimMetadata (the field holds a list of claim description objects per OID4VCI spec Appendix B.2)
+const claimsMetadataArraySchemaObj = {
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
+  $id: 'https://raw.githubusercontent.com/openwallet-foundation-labs/eudiplo/refs/heads/main/schemas/ClaimMetadataArray.schema.json',
+  title: 'ClaimMetadataArray',
+  type: 'array',
+  items: claimsMetadataSchemaObj,
+};
+
 // Create an array schema for TransactionData (URI-based matching allows arrays as root)
 const transactionDataArraySchemaObj = {
   $schema: 'https://json-schema.org/draft/2020-12/schema',
@@ -60,4 +69,4 @@ export const DCQLSchema = new SchemaValidation(DCQLObj);
 
 export const transactionDataArraySchema = new SchemaValidation(transactionDataArraySchemaObj);
 
-export const claimsMetadataSchema = new SchemaValidation(claimsMetadataSchemaObj);
+export const claimsMetadataSchema = new SchemaValidation(claimsMetadataArraySchemaObj);


### PR DESCRIPTION
## Summary

Replaces the flat card-list layout on all configuration pages with a grouped `mat-tab-group` structure, improving navigability and reducing cognitive load when editing complex configs.

### Pages updated

| Page | Tabs |
|---|---|
| **Credential Config** create & show | Metadata · Business Logic · Visual & Display · Claims & Disclosure |
| **Issuance Config** create & show | Metadata · Business Logic · Security · Advanced Federation |
| **Presentation Config** create & show | Basic/Overview · Query · Security · Integration |

### Additional changes

- Replaced the Monaco JSON editor for `claimsMetadata` in credential-config-create with a structured `FormArray` UI (path, mandatory toggle, display name/locale per claim)
- Moved `embeddedDisclosurePolicy` from the Claims & Disclosure tab to the Business Logic tab (to match the show page layout)
- Added `MatTabsModule` to all affected components