### PR TITLE
fix(oid4vp): use accessKeyChainId when building client_id in Offer URI

### DIFF
--- a/apps/backend/src/verifier/oid4vp/oid4vp.service.ts
+++ b/apps/backend/src/verifier/oid4vp/oid4vp.service.ts
@@ -318,6 +318,7 @@ export class Oid4vpService {
         const cert = await this.certService.find({
             tenantId: tenantId,
             type: KeyUsageType.Access,
+            certId: presentationConfig.accessKeyChainId ?? undefined,
         });
 
         const certHash = this.certService.getCertHash(cert);

--- a/apps/backend/test/presentation/presentation-offer.e2e-spec.ts
+++ b/apps/backend/test/presentation/presentation-offer.e2e-spec.ts
@@ -1,9 +1,31 @@
+import { createHash } from "node:crypto";
 import { INestApplication } from "@nestjs/common";
 import request from "supertest";
 import { App } from "supertest/types";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { KeyChainImportDto } from "../../src/crypto/key/dto/key-chain-import.dto";
+import { KeyUsageType } from "../../src/crypto/key/entities/key-chain.entity";
 import { ResponseType } from "../../src/verifier/oid4vp/dto/presentation-request.dto";
 import { PresentationTestContext, setupPresentationTestApp } from "../utils";
+
+/**
+ * Compute the x509_hash client_id from the DER bytes of a PEM certificate.
+ * Mirrors the logic in CertService.getCertHash().
+ */
+function computeCertHash(leafPem: string): string {
+    const b64 = leafPem
+        .replace(/-----BEGIN CERTIFICATE-----/, "")
+        .replace(/-----END CERTIFICATE-----/, "")
+        .replace(/\s+/g, "");
+    const derBytes = Buffer.from(b64, "base64");
+    return createHash("sha256")
+        .update(derBytes)
+        .digest()
+        .toString("base64")
+        .replace(/\+/g, "-")
+        .replace(/\//g, "_")
+        .replace(/=+$/, "");
+}
 
 describe("Presentation - Offer Creation", () => {
     let app: INestApplication<App>;
@@ -60,5 +82,92 @@ describe("Presentation - Offer Creation", () => {
                     "Request ID invalid not found",
                 );
             });
+    });
+
+    test("client_id in offer URI matches the accessKeyChainId certificate when multiple access keys exist", async () => {
+        // A second access key chain with a distinct certificate (different from the fixture default)
+        const secondKeyMaterial = {
+            kty: "EC",
+            crv: "P-256",
+            d: "rqv47L1jWkbFAGMCK8TORQ1FknBUYGY6OLU1dYHNDqU",
+            x: "pmn8SKQKZ0t2zFlrUXzJaJwwQ0WnQxcSYoS_D6ZSGho",
+            y: "rMd9JTAovcOI_OvOXWCWZ1yVZieVYK2UgvB2IPuSk2o",
+        };
+        const secondKeyChainId = "second-access-key-chain";
+
+        // Import a second access key chain
+        await request(app.getHttpServer())
+            .post("/key-chain/import")
+            .trustLocalhost()
+            .set("Authorization", `Bearer ${authToken}`)
+            .send({
+                id: secondKeyChainId,
+                key: secondKeyMaterial,
+                usageType: KeyUsageType.Access,
+                description: "Second access key chain for bug regression test",
+            } as KeyChainImportDto)
+            .expect(201);
+
+        // Create a presentation config that explicitly references the second access key chain
+        const presentationConfigId = "pid-second-access-key";
+        await request(app.getHttpServer())
+            .post("/verifier/config")
+            .trustLocalhost()
+            .set("Authorization", `Bearer ${authToken}`)
+            .send({
+                id: presentationConfigId,
+                description: "Presentation config using second access key",
+                accessKeyChainId: secondKeyChainId,
+                dcql_query: {
+                    credentials: [
+                        {
+                            id: "pid",
+                            format: "dc+sd-jwt",
+                            meta: { vct_values: ["https://example.com/pid"] },
+                        },
+                    ],
+                },
+            })
+            .expect(201);
+
+        // Retrieve the leaf certificate of the second key chain to compute the expected client_id
+        const keyChainRes = await request(app.getHttpServer())
+            .get(`/key-chain/${secondKeyChainId}`)
+            .trustLocalhost()
+            .set("Authorization", `Bearer ${authToken}`)
+            .expect(200);
+
+        const activeCertPem: string = keyChainRes.body.activeCertificate.pem;
+        const expectedHash = computeCertHash(activeCertPem);
+        const expectedClientId = `x509_hash:${expectedHash}`;
+
+        // Generate a presentation offer using the config with the second access key
+        const offerRes = await request(app.getHttpServer())
+            .post("/verifier/offer")
+            .trustLocalhost()
+            .set("Authorization", `Bearer ${authToken}`)
+            .send({
+                response_type: ResponseType.URI,
+                requestId: presentationConfigId,
+            })
+            .expect(201);
+
+        // The client_id in the offer URI (used by the QR code) must match the
+        // certificate hash of the configured second access key chain, not the first one.
+        const offerUri: string = offerRes.body.uri;
+        const params = new URLSearchParams(offerUri.split("?")[1] ?? offerUri);
+        const clientIdFromOffer = params.get("client_id");
+
+        expect(clientIdFromOffer).toBe(expectedClientId);
+
+        // The signed authorization request JWT must carry the same client_id
+        const sessionId: string = offerRes.body.session;
+        const sessionRes = await request(app.getHttpServer())
+            .get(`/session/${sessionId}`)
+            .trustLocalhost()
+            .set("Authorization", `Bearer ${authToken}`)
+            .expect(200);
+
+        expect(sessionRes.body.clientId).toBe(expectedClientId);
     });
 });


### PR DESCRIPTION
## Summary

Fixes #687 — When multiple `KeyUsageType.Access` key chains existed and a presentation config had `accessKeyChainId` set, the `client_id` in the Offer URI / QR code was always computed from the **first** access key chain, while the signed Authorization Request JWT correctly used the **configured** key chain. This mismatch caused wallets to reject the request with:

> `ClientId does not match leaf certificate's SHA-256 hash`

## Root Cause

In `Oid4vpService.createRequest()`, `certService.find()` was called without `certId`, so it always resolved to the first access key chain regardless of configuration:

```ts
// Before (buggy)
const cert = await this.certService.find({
    tenantId: tenantId,
    type: KeyUsageType.Access,
    // ❌ certId missing — always picks the first key chain
});
```

`createAuthorizationRequest()` already passed `certId: presentationConfig.accessKeyChainId ?? undefined` correctly — `createRequest()` just didn't.

## Fix

Pass `certId: presentationConfig.accessKeyChainId ?? undefined` to `certService.find()` in `createRequest()`, making it consistent with `createAuthorizationRequest()`:

```ts
// After (fixed)
const cert = await this.certService.find({
    tenantId: tenantId,
    type: KeyUsageType.Access,
    certId: presentationConfig.accessKeyChainId ?? undefined,
});
```

## Test

Added a regression test in `presentation-offer.e2e-spec.ts` that:
1. Imports two distinct access key chains
2. Creates a presentation config with `accessKeyChainId` pointing to the second key chain
3. Generates a presentation offer and asserts the `client_id` in the Offer URI matches the SHA-256 hash of the second key chain's certificate (not the first)

## Breaking Changes

None.