### PR TITLE
ci: align pnpm setup with packageManager

### DIFF
--- a/.github/workflows/check-stale-overrides.yml
+++ b/.github/workflows/check-stale-overrides.yml
@@ -9,23 +9,20 @@ on:
     - cron: '0 6 * * 1' # Weekly on Monday 6 AM UTC
   workflow_dispatch: # Manual trigger
 
+concurrency:
+  group: stale-overrides-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-overrides:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
-
-      - uses: pnpm/action-setup@v6
-        with:
-          version: 10
 
       - uses: actions/setup-node@v6
         with:
           node-version: '22'
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
 
       - name: Check for stale overrides
         id: check

--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
           run_install: false
@@ -67,7 +67,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
           run_install: false
@@ -92,7 +92,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
           run_install: false
@@ -117,7 +117,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
           run_install: false
@@ -145,7 +145,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
           run_install: false
@@ -170,7 +170,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
           run_install: false
@@ -221,7 +221,7 @@ jobs:
         with:
           fetch-depth: 0 # Fetch full history for mike versioning
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
           run_install: false
@@ -272,7 +272,7 @@ jobs:
       - name: Add entry to /etc/hosts
         run: echo "127.0.0.1       host.testcontainers.internal" | sudo tee -a /etc/hosts
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
           run_install: false
@@ -650,7 +650,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
           run_install: false
@@ -705,7 +705,7 @@ jobs:
         with:
           fetch-depth: 0 # Fetch full history for mike versioning
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
           run_install: false


### PR DESCRIPTION
## Summary

This PR fixes pnpm version resolution issues in GitHub Actions and streamlines the stale-overrides workflow.

## Changes

- Upgraded all `pnpm/action-setup` usages in `ci-and-release.yml` from `@v4` to `@v6`.
- Removed unnecessary pnpm setup and dependency installation from `check-stale-overrides.yml`.
  - This workflow only reads `package.json` and creates/issues updates, so pnpm install was not needed.
- Added workflow concurrency control for stale-overrides to avoid overlapping runs.
- Added a timeout to the stale-overrides job for better CI reliability.

## Why

A workflow failed with:

- `Multiple versions of pnpm specified`

The conflict was caused by explicit action-side versioning while `package.json` already defines pnpm via `packageManager`. These changes avoid mismatch risk and reduce CI runtime for the stale-overrides job.

## Validation

- Verified all `pnpm/action-setup` entries in workflows are now consistent and no longer pin conflicting pnpm versions.
- Confirmed stale-overrides workflow still performs the intended override detection and issue creation logic.