### PR TITLE
Move token endpoint under admin API

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ pnpm --filter @eudiplo/client run dev
 ```bash
 # Get a token and start using the API
 # Replace with your configured AUTH_CLIENT_ID and AUTH_CLIENT_SECRET
-curl -X POST http://localhost:3000/oauth2/token \
+curl -X POST http://localhost:3000/api/oauth2/token \
   -H "Content-Type: application/json" \
   -d '{
     "client_id": "your-client-id",

--- a/apps/backend/src/auth/auth.controller.ts
+++ b/apps/backend/src/auth/auth.controller.ts
@@ -29,7 +29,7 @@ export class AuthController {
      * @param headers
      * @returns
      */
-    @Post("oauth2/token")
+    @Post("api/oauth2/token")
     @ApiBody({
         type: ClientCredentialsDto,
         examples: {

--- a/apps/backend/src/auth/auth.service.ts
+++ b/apps/backend/src/auth/auth.service.ts
@@ -124,7 +124,7 @@ export class AuthService {
 
         return {
             issuer: oidc ?? publicUrl,
-            token_endpoint: `${publicUrl}/oauth2/token`,
+            token_endpoint: `${publicUrl}/api/oauth2/token`,
             jwks_uri: `${publicUrl}/.well-known/jwks.json`,
             response_types_supported: ["token"],
             grant_types_supported: ["client_credentials"],

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -19,16 +19,19 @@ import { ValidationErrorFilter } from "./shared/common/filters/validation-error.
 import otelSDK from "./tracing";
 
 /**
- * Protocol routes excluded from the `/api` global prefix.
- * These are wallet-facing and infrastructure endpoints that must remain
- * at the root path for protocol compliance and discoverability.
+ * Routes excluded from the automatic `/api` global prefix.
+ * Wallet-facing and infrastructure endpoints stay at the root path for protocol
+ * compliance and discoverability. The integrated OAuth2 token endpoint is
+ * already mounted under `/api` so firewalls can treat it as part of the admin
+ * surface without receiving a duplicate `/api/api` prefix.
  */
-const PROTOCOL_ROUTE_EXCLUSIONS: { path: string; method: RequestMethod }[] = [
+const GLOBAL_PREFIX_EXCLUSIONS: { path: string; method: RequestMethod }[] = [
     // Infrastructure
     { path: "/", method: RequestMethod.GET },
     { path: "health", method: RequestMethod.ALL },
-    // OAuth2 & Discovery
-    { path: "oauth2/{*path}", method: RequestMethod.ALL },
+    // Admin authentication
+    { path: "api/oauth2/{*path}", method: RequestMethod.ALL },
+    // Discovery
     { path: ".well-known/{*path}", method: RequestMethod.ALL },
     // OID4VCI Protocol
     { path: "issuers/:tenantId/vci/{*path}", method: RequestMethod.ALL },
@@ -188,7 +191,7 @@ async function bootstrap() {
 
     // Global route prefix: all management endpoints under /api/,
     // protocol endpoints (wallet-facing) stay at root for compliance
-    app.setGlobalPrefix("api", { exclude: PROTOCOL_ROUTE_EXCLUSIONS });
+    app.setGlobalPrefix("api", { exclude: GLOBAL_PREFIX_EXCLUSIONS });
 
     // Global exception filter for ValidationError
     app.useGlobalFilters(
@@ -244,7 +247,7 @@ async function bootstrap() {
                 type: "oauth2",
                 flows: {
                     clientCredentials: {
-                        tokenUrl: `${publicUrl}/oauth2/token`,
+                        tokenUrl: `${publicUrl}/api/oauth2/token`,
                         scopes: {},
                     },
                 },
@@ -383,7 +386,7 @@ async function bootstrap() {
                 logger.log(
                     `   → Mode:         Integrated OAuth2 (Client Credentials)`,
                 );
-                logger.log(`   → Token URL:    ${publicUrl}/oauth2/token`);
+                logger.log(`   → Token URL:    ${publicUrl}/api/oauth2/token`);
             }
         });
     }

--- a/apps/backend/test/auth.e2e-spec.ts
+++ b/apps/backend/test/auth.e2e-spec.ts
@@ -30,7 +30,7 @@ describe("Authentication (e2e)", () => {
 
     test("should get OAuth2 token with valid client credentials in request body", async () => {
         const response = await request(app.getHttpServer())
-            .post("/oauth2/token")
+            .post("/api/oauth2/token")
             .send({
                 grant_type: "client_credentials",
                 client_id: clientId,
@@ -50,7 +50,7 @@ describe("Authentication (e2e)", () => {
         );
 
         const response = await request(app.getHttpServer())
-            .post("/oauth2/token")
+            .post("/api/oauth2/token")
             .set("Authorization", `Basic ${credentials}`)
             .send({
                 grant_type: "client_credentials",
@@ -65,7 +65,7 @@ describe("Authentication (e2e)", () => {
 
     test("should reject invalid client credentials", async () => {
         await request(app.getHttpServer())
-            .post("/oauth2/token")
+            .post("/api/oauth2/token")
             .send({
                 grant_type: "client_credentials",
                 client_id: "invalid-client",
@@ -79,7 +79,7 @@ describe("Authentication (e2e)", () => {
 
     test("should reject unsupported grant type", async () => {
         await request(app.getHttpServer())
-            .post("/oauth2/token")
+            .post("/api/oauth2/token")
             .send({
                 grant_type: "authorization_code",
                 client_id: clientId,
@@ -95,7 +95,7 @@ describe("Authentication (e2e)", () => {
 
     test("should reject missing client credentials", async () => {
         await request(app.getHttpServer())
-            .post("/oauth2/token")
+            .post("/api/oauth2/token")
             .send({
                 grant_type: "client_credentials",
                 client_id: clientId,

--- a/apps/backend/test/client-resource-access.e2e-spec.ts
+++ b/apps/backend/test/client-resource-access.e2e-spec.ts
@@ -72,7 +72,7 @@ describe("Client Resource-Level Access Control (e2e)", () => {
 
         restrictedClientSecret = client.clientSecret;
         const restrictedTokenRes = await request(app.getHttpServer())
-            .post("/oauth2/token")
+            .post("/api/oauth2/token")
             .send({
                 client_id: client.clientId,
                 client_secret: client.clientSecret,
@@ -96,7 +96,7 @@ describe("Client Resource-Level Access Control (e2e)", () => {
             .then((res) => res.body);
 
         const unrestrictedTokenRes = await request(app.getHttpServer())
-            .post("/oauth2/token")
+            .post("/api/oauth2/token")
             .send({
                 client_id: client.clientId,
                 client_secret: client.clientSecret,
@@ -258,7 +258,7 @@ describe("Client Resource-Level Access Control (e2e)", () => {
                 .then((res) => res.body);
 
             const newTokenRes = await request(ctx.app.getHttpServer())
-                .post("/oauth2/token")
+                .post("/api/oauth2/token")
                 .send({
                     client_id: "restricted-client",
                     client_secret: restrictedClientSecret,
@@ -306,7 +306,7 @@ describe("Client Resource-Level Access Control (e2e)", () => {
                 .then((res) => res.body);
 
             const tokenRes = await request(ctx.app.getHttpServer())
-                .post("/oauth2/token")
+                .post("/api/oauth2/token")
                 .send({
                     client_id: client.clientId,
                     client_secret: client.clientSecret,

--- a/apps/backend/test/oidf/oidf-issuance.e2e-spec.ts
+++ b/apps/backend/test/oidf/oidf-issuance.e2e-spec.ts
@@ -532,7 +532,7 @@ describe("OIDF - oid4vci-1_0-issuer-haip-test-plan", () => {
         // Acquire JWT token using client credentials
         const tokenResponse = await axiosBackendInstance.post<{
             access_token: string;
-        }>("/oauth2/token", {
+        }>("/api/oauth2/token", {
             client_id: clientId,
             client_secret: clientSecret,
             grant_type: "client_credentials",

--- a/apps/backend/test/oidf/oidf-presentation.e2e-spec.ts
+++ b/apps/backend/test/oidf/oidf-presentation.e2e-spec.ts
@@ -84,7 +84,7 @@ describe("OIDF", () => {
         // Acquire JWT token using client credentials
         const tokenResponse = await axiosBackendInstance.post<{
             access_token: string;
-        }>("/oauth2/token", {
+        }>("/api/oauth2/token", {
             client_id: clientId,
             client_secret: clientSecret,
             grant_type: "client_credentials",

--- a/apps/backend/test/utils.ts
+++ b/apps/backend/test/utils.ts
@@ -374,7 +374,7 @@ export async function getToken(
 ) {
     // Get JWT token using client credentials
     const tokenResponse = await request(app.getHttpServer())
-        .post("/oauth2/token")
+        .post("/api/oauth2/token")
         .trustLocalhost()
         .send({
             client_id: clientId,
@@ -404,7 +404,7 @@ export async function getToken(
         .then((res) => res.body.client);
 
     return request(app.getHttpServer())
-        .post("/oauth2/token")
+        .post("/api/oauth2/token")
         .trustLocalhost()
         .send({
             client_id: client.clientId,

--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -56,7 +56,7 @@ EUDIPLO includes a built-in OAuth2 server for simple deployments:
     **Option 1: Credentials in Authorization Header (OAuth2 Standard):**
 
     ```bash
-    curl -X POST http://localhost:3000/oauth2/token \
+    curl -X POST http://localhost:3000/api/oauth2/token \
       -H "Content-Type: application/json" \
       -H "Authorization: Basic $(echo -n 'client_id:client_secret' | base64)" \
       -d '{
@@ -67,7 +67,7 @@ EUDIPLO includes a built-in OAuth2 server for simple deployments:
     **Option 2: Credentials in Request Body:**
 
     ```bash
-    curl -X POST http://localhost:3000/oauth2/token \
+    curl -X POST http://localhost:3000/api/oauth2/token \
       -H "Content-Type: application/json" \
       -d '{
         "grant_type": "client_credentials",
@@ -121,7 +121,7 @@ AUTH_CLIENT_SECRET=root-secret
 
 In external OIDC mode:
 
-- EUDIPLO does not issue tokens from `/oauth2/token`
+- EUDIPLO does not issue tokens from `/api/oauth2/token`
 - `OIDC_CLIENT_ID` and `OIDC_CLIENT_SECRET` are used by EUDIPLO to manage
   roles/clients in Keycloak
 - `AUTH_CLIENT_ID` and `AUTH_CLIENT_SECRET` are optional; when both are set,
@@ -221,7 +221,7 @@ If the client attempts to use a config not in their allowed list, a `403 Forbidd
    `manage-clients`, `manage-users`, `view-realm`, `view-clients`, `view-users`)
 2. If bootstrap root login fails, ensure both `AUTH_CLIENT_ID` and
    `AUTH_CLIENT_SECRET` are set and obtain tokens from Keycloak's token endpoint
-   (not from EUDIPLO `/oauth2/token`)
+   (not from EUDIPLO `/api/oauth2/token`)
 
 ## Security Considerations
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -20,14 +20,27 @@ When running EUDIPLO, the following endpoints are available:
     The API is split into two OpenAPI documents:
 
     - **Management API** (`/api/docs`): Endpoints for managing credentials, sessions, keys, and configurations (requires authentication).
-    - **Protocol API** (`/docs`): Wallet-facing protocol endpoints for OID4VCI, OID4VP, and related standards (public).
+    - **Protocol API** (`/docs`): Developer documentation for wallet-facing protocol endpoints such as OID4VCI, OID4VP, and related standards.
 
     Because all management endpoints share the `/api/` prefix, a reverse proxy
     (e.g. nginx) can enforce additional network-level protections such as IP
     allowlisting on management routes while keeping protocol endpoints publicly
-    accessible:
+    accessible. The root endpoint (`/`) and OpenAPI documentation endpoints
+    (`/docs`, `/docs-json`) are for operators and developers, not wallets. If
+    public documentation access is not required, they can be blocked at the
+    edge. The management documentation endpoints (`/api/docs`, `/api/docs-json`)
+    are covered by the `/api/` rule below:
 
     ```nginx
+    location = / {
+        deny all;
+    }
+
+    # Optional: disable public developer documentation endpoints.
+    location ~ ^/(docs|docs-json)$ {
+        deny all;
+    }
+
     location /api/ {
         allow 10.0.0.0/8;
         deny all;

--- a/docs/migration/3.x-to-4.0.md
+++ b/docs/migration/3.x-to-4.0.md
@@ -36,10 +36,11 @@ Update all API client URLs:
 | `GET /sessions/{id}`             | `GET /api/sessions/{id}`             |
 | `GET /docs` (Swagger UI)         | `GET /api/docs`                      |
 | `GET /docs-json` (OpenAPI spec)  | `GET /api/docs-json`                 |
+| `POST /oauth2/token`             | `POST /api/oauth2/token`             |
 
 !!! note "Protocol endpoints unchanged"
 
-    OID4VCI and OID4VP protocol endpoints (e.g., `/.well-known/openid-credential-issuer`, `/authorize`, `/token`, `/credential`) are **not** affected. Only management/admin endpoints have the new prefix.
+    OID4VCI and OID4VP protocol endpoints (e.g., `/.well-known/openid-credential-issuer`, `/authorize`, `/token`, `/credential`) are **not** affected. The integrated OAuth2 client credentials endpoint moved to `/api/oauth2/token` because it belongs to the management/admin surface.
 
 ### Code Examples
 

--- a/packages/eudiplo-sdk-core/src/client.ts
+++ b/packages/eudiplo-sdk-core/src/client.ts
@@ -249,7 +249,7 @@ export class EudiploClient {
 
   private async _doAuthenticate(): Promise<void> {
     const fetchFn = this.config.fetch ?? globalThis.fetch;
-    const res = await fetchFn(`${this.config.baseUrl}/oauth2/token`, {
+    const res = await fetchFn(`${this.config.baseUrl}/api/oauth2/token`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({


### PR DESCRIPTION
Moves the integrated OAuth2 client credentials token endpoint into the `/api` admin surface so it can be protected with the rest of the management API.

Summary:
- Mount `POST /api/oauth2/token` and update discovery, Swagger auth config, startup logs, and SDK authentication.
- Update e2e tests and documentation references to the new token URL.
- Clarify reverse-proxy guidance for root and developer documentation endpoints.

Validation:
- `apps/backend/test/auth.e2e-spec.ts` passed, 7/7
- `pnpm --filter @eudiplo/backend build` passed