### PR TITLE
fix: add PostgreSQL SSL cert-path support and SSL e2e coverage

### DIFF
--- a/apps/backend/src/database/data-source.ts
+++ b/apps/backend/src/database/data-source.ts
@@ -1,13 +1,13 @@
 import { join } from "node:path";
 import { config } from "dotenv";
 import { DataSource, DataSourceOptions } from "typeorm";
+import { buildPostgresSslOptions } from "./postgres-ssl-options";
 
 // Load environment variables
 config({ path: join(__dirname, "..", "..", ".env") });
 config({ path: join(__dirname, "..", "..", "..", "..", ".env") });
 
 const dbType = process.env.DB_TYPE as "sqlite" | "postgres" | undefined;
-const dbSsl = process.env.DB_SSL === "true";
 
 const commonOptions: Partial<DataSourceOptions> = {
     synchronize: false,
@@ -28,7 +28,7 @@ if (dbType === "postgres") {
         username: process.env.DB_USERNAME || "postgres",
         password: process.env.DB_PASSWORD || "postgres",
         database: process.env.DB_DATABASE || "eudiplo",
-        ssl: dbSsl,
+        ssl: buildPostgresSslOptions((key: string) => process.env[key]),
         ...commonOptions,
     } as DataSourceOptions;
 } else {

--- a/apps/backend/src/database/database-validation.schema.ts
+++ b/apps/backend/src/database/database-validation.schema.ts
@@ -50,14 +50,42 @@ export const DB_VALIDATION_SCHEMA = Joi.object({
         .default(false)
         .description("Enable SSL/TLS for PostgreSQL database connections")
         .meta({ group: "database", order: 55 }),
+    DB_SSL_REJECT_UNAUTHORIZED: Joi.boolean()
+        .default(true)
+        .description(
+            "Reject PostgreSQL TLS certificates that cannot be validated against trusted CAs",
+        )
+        .meta({ group: "database", order: 56 }),
+    DB_SSL_CA_PATH: Joi.string()
+        .optional()
+        .allow("")
+        .description(
+            "Path to CA certificate file used to validate PostgreSQL TLS certificates",
+        )
+        .meta({ group: "database", order: 57 }),
+    DB_SSL_CERT_PATH: Joi.string()
+        .optional()
+        .allow("")
+        .description("Path to client certificate file for PostgreSQL TLS")
+        .meta({ group: "database", order: 58 }),
+    DB_SSL_KEY_PATH: Joi.string()
+        .optional()
+        .allow("")
+        .description("Path to client private key file for PostgreSQL TLS")
+        .meta({ group: "database", order: 59 }),
+    DB_SSL_KEY_PASSPHRASE: Joi.string()
+        .optional()
+        .allow("")
+        .description("Passphrase for encrypted DB_SSL_KEY_PATH private key")
+        .meta({ group: "database", order: 60 }),
     DB_SYNCHRONIZE: Joi.boolean()
         .default(true)
         .description(
             "Enable TypeORM schema synchronization. Set to false in production after initial setup and rely on migrations instead.",
         )
-        .meta({ group: "database", order: 60 }),
+        .meta({ group: "database", order: 70 }),
     DB_MIGRATIONS_RUN: Joi.boolean()
         .default(true)
         .description("Run pending database migrations automatically on startup")
-        .meta({ group: "database", order: 70 }),
+        .meta({ group: "database", order: 80 }),
 });

--- a/apps/backend/src/database/database.module.ts
+++ b/apps/backend/src/database/database.module.ts
@@ -6,6 +6,7 @@ import { DataSource } from "typeorm";
 import { PostgresConnectionOptions } from "typeorm/driver/postgres/PostgresConnectionOptions.js";
 import { SqliteConnectionOptions } from "typeorm/driver/sqlite/SqliteConnectionOptions.js";
 import * as migrations from "./migrations";
+import { buildPostgresSslOptions } from "./postgres-ssl-options";
 
 @Module({
     imports: [
@@ -47,7 +48,9 @@ import * as migrations from "./migrations";
                             configService.getOrThrow<string>("DB_PASSWORD"),
                         database:
                             configService.getOrThrow<string>("DB_DATABASE"),
-                        ssl: configService.get<boolean>("DB_SSL", false),
+                        ssl: buildPostgresSslOptions((key: string) =>
+                            configService.get(key),
+                        ),
                         ...commonOptions,
                     } as PostgresConnectionOptions;
                 }

--- a/apps/backend/src/database/postgres-ssl-options.ts
+++ b/apps/backend/src/database/postgres-ssl-options.ts
@@ -1,0 +1,107 @@
+import { readFileSync } from "node:fs";
+import { TlsOptions } from "node:tls";
+
+function parseBoolean(value: unknown): boolean | undefined {
+    if (typeof value === "boolean") {
+        return value;
+    }
+
+    if (typeof value !== "string") {
+        return undefined;
+    }
+
+    const normalized = value.trim().toLowerCase();
+    if (normalized === "true") {
+        return true;
+    }
+
+    if (normalized === "false") {
+        return false;
+    }
+
+    return undefined;
+}
+
+function parseOptionalString(value: unknown): string | undefined {
+    if (typeof value !== "string") {
+        return undefined;
+    }
+
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function readOptionalFile(path: string, variableName: string): Buffer {
+    try {
+        return readFileSync(path);
+    } catch (error) {
+        throw new Error(
+            `Failed to read ${variableName} at path \"${path}\": ${error instanceof Error ? error.message : String(error)}`,
+        );
+    }
+}
+
+/**
+ * Build PostgreSQL SSL settings from environment/config values.
+ *
+ * Supported variables:
+ * - DB_SSL=true|false
+ * - DB_SSL_REJECT_UNAUTHORIZED=true|false
+ * - DB_SSL_CA_PATH=/path/to/ca.crt
+ * - DB_SSL_CERT_PATH=/path/to/client.crt
+ * - DB_SSL_KEY_PATH=/path/to/client.key
+ * - DB_SSL_KEY_PASSPHRASE=secret
+ */
+export function buildPostgresSslOptions(
+    readValue: (key: string) => unknown,
+): boolean | TlsOptions {
+    const sslEnabled = parseBoolean(readValue("DB_SSL")) ?? false;
+    if (!sslEnabled) {
+        return false;
+    }
+
+    const rejectUnauthorized = parseBoolean(
+        readValue("DB_SSL_REJECT_UNAUTHORIZED"),
+    );
+    const caPath = parseOptionalString(readValue("DB_SSL_CA_PATH"));
+    const certPath = parseOptionalString(readValue("DB_SSL_CERT_PATH"));
+    const keyPath = parseOptionalString(readValue("DB_SSL_KEY_PATH"));
+    const keyPassphrase = parseOptionalString(
+        readValue("DB_SSL_KEY_PASSPHRASE"),
+    );
+
+    if (
+        rejectUnauthorized === undefined &&
+        !caPath &&
+        !certPath &&
+        !keyPath &&
+        !keyPassphrase
+    ) {
+        // Preserve existing behavior when only DB_SSL=true is set.
+        return true;
+    }
+
+    const sslOptions: TlsOptions = {};
+
+    if (rejectUnauthorized !== undefined) {
+        sslOptions.rejectUnauthorized = rejectUnauthorized;
+    }
+
+    if (caPath) {
+        sslOptions.ca = readOptionalFile(caPath, "DB_SSL_CA_PATH");
+    }
+
+    if (certPath) {
+        sslOptions.cert = readOptionalFile(certPath, "DB_SSL_CERT_PATH");
+    }
+
+    if (keyPath) {
+        sslOptions.key = readOptionalFile(keyPath, "DB_SSL_KEY_PATH");
+    }
+
+    if (keyPassphrase) {
+        sslOptions.passphrase = keyPassphrase;
+    }
+
+    return sslOptions;
+}

--- a/apps/backend/test/db-ssl.e2e-spec.ts
+++ b/apps/backend/test/db-ssl.e2e-spec.ts
@@ -70,6 +70,7 @@ describe("Database SSL with CA path (positive)", () => {
             "",
             "[alt_names]",
             "DNS.1 = localhost",
+            "DNS.2 = host.testcontainers.internal",
             "IP.1 = 127.0.0.1",
         ].join("\n");
         writeFileSync(join(certDir, "openssl.cnf"), opensslCnf);

--- a/apps/backend/test/db-ssl.e2e-spec.ts
+++ b/apps/backend/test/db-ssl.e2e-spec.ts
@@ -1,0 +1,135 @@
+import { execSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { INestApplication, ValidationPipe } from "@nestjs/common";
+import { ConfigModule } from "@nestjs/config";
+import { Test } from "@nestjs/testing";
+import {
+    PostgreSqlContainer,
+    StartedPostgreSqlContainer,
+} from "@testcontainers/postgresql";
+import request from "supertest";
+import { App } from "supertest/types";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { AppModule } from "../src/app.module";
+
+describe("Database SSL invalid CA path", () => {
+    test("bootstrap fails early when DB_SSL_CA_PATH cannot be read", async () => {
+        const appModulePromise = Test.createTestingModule({
+            imports: [
+                ConfigModule.forRoot({
+                    isGlobal: true,
+                    load: [
+                        () => ({
+                            DB_TYPE: "postgres",
+                            DB_HOST: "localhost",
+                            DB_PORT: "5432",
+                            DB_USERNAME: "postgres",
+                            DB_PASSWORD: "postgres",
+                            DB_DATABASE: "postgres",
+                            DB_SSL: "true",
+                            DB_SSL_CA_PATH: "/path/does/not/exist/ca.crt",
+                        }),
+                    ],
+                }),
+                AppModule,
+            ],
+        }).compile();
+
+        await expect(async () => {
+            const moduleFixture = await appModulePromise;
+            const app = moduleFixture.createNestApplication();
+            await app.init();
+        }).rejects.toThrowError(/Failed to read DB_SSL_CA_PATH/);
+    });
+});
+
+describe("Database SSL with CA path (positive)", () => {
+    let app: INestApplication<App>;
+    let container: StartedPostgreSqlContainer;
+    let certDir: string;
+
+    beforeAll(async () => {
+        // Generate a self-signed cert with SAN so Node.js hostname verification
+        // passes when connecting to localhost / 127.0.0.1.
+        certDir = join(tmpdir(), `pg-ssl-e2e-${Date.now()}`);
+        mkdirSync(certDir, { recursive: true });
+
+        const opensslCnf = [
+            "[req]",
+            "distinguished_name = req_distinguished_name",
+            "x509_extensions = v3_req",
+            "prompt = no",
+            "",
+            "[req_distinguished_name]",
+            "CN = localhost",
+            "",
+            "[v3_req]",
+            "subjectAltName = @alt_names",
+            "",
+            "[alt_names]",
+            "DNS.1 = localhost",
+            "IP.1 = 127.0.0.1",
+        ].join("\n");
+        writeFileSync(join(certDir, "openssl.cnf"), opensslCnf);
+
+        execSync(
+            `openssl req -x509 -newkey rsa:2048 \
+                -keyout "${join(certDir, "server.key")}" \
+                -out "${join(certDir, "server.crt")}" \
+                -days 1 -nodes \
+                -config "${join(certDir, "openssl.cnf")}"`,
+            { stdio: "pipe" },
+        );
+
+        container = await new PostgreSqlContainer("postgres:16")
+            .withDatabase("test_db")
+            .withUsername("test")
+            .withPassword("test_password")
+            .withSSLCert(
+                join(certDir, "server.crt"),
+                join(certDir, "server.crt"),
+                join(certDir, "server.key"),
+            )
+            .start();
+
+        const moduleFixture = await Test.createTestingModule({
+            imports: [
+                ConfigModule.forRoot({
+                    isGlobal: true,
+                    load: [
+                        () => ({
+                            DB_TYPE: "postgres",
+                            DB_HOST: container.getHost(),
+                            DB_PORT: container.getPort().toString(),
+                            DB_USERNAME: "test",
+                            DB_PASSWORD: "test_password",
+                            DB_DATABASE: "test_db",
+                            DB_SSL: "true",
+                            DB_SSL_CA_PATH: join(certDir, "server.crt"),
+                            DB_SYNCHRONIZE: "true",
+                            DB_MIGRATIONS_RUN: "true",
+                        }),
+                    ],
+                }),
+                AppModule,
+            ],
+        }).compile();
+
+        app = moduleFixture.createNestApplication();
+        app.useGlobalPipes(new ValidationPipe());
+        await app.init();
+    }, 120_000);
+
+    afterAll(async () => {
+        await app?.close();
+        await container?.stop();
+    });
+
+    test("health check returns OK over SSL", async () => {
+        const res = await request(app.getHttpServer()).get("/health");
+        expect(res.status).toBe(200);
+        expect(res.body.status).toBe("ok");
+    });
+});

--- a/docs/architecture/database.md
+++ b/docs/architecture/database.md
@@ -44,6 +44,32 @@ Set `DB_SSL=true` when your PostgreSQL server requires TLS encryption
 If your server accepts plaintext connections in a trusted internal network,
 you can keep `DB_SSL=false`.
 
+When using private CAs or self-signed certificates, configure certificate
+validation explicitly:
+
+```env
+DB_SSL=true
+DB_SSL_REJECT_UNAUTHORIZED=true
+DB_SSL_CA_PATH=/app/certs/postgres-ca.crt
+```
+
+Optional mutual TLS settings are also supported:
+
+```env
+DB_SSL_CERT_PATH=/app/certs/postgres-client.crt
+DB_SSL_KEY_PATH=/app/certs/postgres-client.key
+DB_SSL_KEY_PASSPHRASE=optional-passphrase
+```
+
+For local development only, you can disable certificate validation:
+
+```env
+DB_SSL=true
+DB_SSL_REJECT_UNAUTHORIZED=false
+```
+
+Do not use `DB_SSL_REJECT_UNAUTHORIZED=false` in production.
+
 Example for a TLS-required PostgreSQL deployment:
 
 ```env

--- a/docs/generated/config-database.md
+++ b/docs/generated/config-database.md
@@ -1,11 +1,16 @@
-| Key | Type | Notes |
-| --- | ---- | ----- |
-| `DB_TYPE` | `string` | Database type  (default: `sqlite`) |
-| `DB_HOST` | `string` | Database host [when DB_TYPE is {"override":true} \| "sqlite" → otherwise required] |
-| `DB_PORT` | `number` | Database port [when DB_TYPE is {"override":true} \| "sqlite" → otherwise required] |
-| `DB_USERNAME` | `string` | Database username [when DB_TYPE is {"override":true} \| "sqlite" → otherwise required] |
-| `DB_PASSWORD` | `string` | Database password [when DB_TYPE is {"override":true} \| "sqlite" → otherwise required] |
-| `DB_DATABASE` | `string` | Database name [when DB_TYPE is {"override":true} \| "sqlite" → otherwise required] |
-| `DB_SSL` | `boolean` | Enable SSL/TLS for PostgreSQL database connections  (default: `false`) |
-| `DB_SYNCHRONIZE` | `boolean` | Enable TypeORM schema synchronization. Set to false in production after initial setup and rely on migrations instead.  (default: `true`) |
-| `DB_MIGRATIONS_RUN` | `boolean` | Run pending database migrations automatically on startup  (default: `true`) |
+| Key                          | Type      | Notes                                                                                                                                   |
+| ---------------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `DB_TYPE`                    | `string`  | Database type (default: `sqlite`)                                                                                                       |
+| `DB_HOST`                    | `string`  | Database host [when DB_TYPE is {"override":true} \| "sqlite" → otherwise required]                                                      |
+| `DB_PORT`                    | `number`  | Database port [when DB_TYPE is {"override":true} \| "sqlite" → otherwise required]                                                      |
+| `DB_USERNAME`                | `string`  | Database username [when DB_TYPE is {"override":true} \| "sqlite" → otherwise required]                                                  |
+| `DB_PASSWORD`                | `string`  | Database password [when DB_TYPE is {"override":true} \| "sqlite" → otherwise required]                                                  |
+| `DB_DATABASE`                | `string`  | Database name [when DB_TYPE is {"override":true} \| "sqlite" → otherwise required]                                                      |
+| `DB_SSL`                     | `boolean` | Enable SSL/TLS for PostgreSQL database connections (default: `false`)                                                                   |
+| `DB_SSL_REJECT_UNAUTHORIZED` | `boolean` | Reject PostgreSQL TLS certificates that cannot be validated against trusted CAs (default: `true`)                                       |
+| `DB_SSL_CA_PATH`             | `string`  | Path to CA certificate file used to validate PostgreSQL TLS certificates                                                                |
+| `DB_SSL_CERT_PATH`           | `string`  | Path to client certificate file for PostgreSQL TLS                                                                                      |
+| `DB_SSL_KEY_PATH`            | `string`  | Path to client private key file for PostgreSQL TLS                                                                                      |
+| `DB_SSL_KEY_PASSPHRASE`      | `string`  | Passphrase for encrypted DB_SSL_KEY_PATH private key                                                                                    |
+| `DB_SYNCHRONIZE`             | `boolean` | Enable TypeORM schema synchronization. Set to false in production after initial setup and rely on migrations instead. (default: `true`) |
+| `DB_MIGRATIONS_RUN`          | `boolean` | Run pending database migrations automatically on startup (default: `true`)                                                              |


### PR DESCRIPTION
## Summary
- add a shared PostgreSQL SSL options builder to support TLS file-based configuration
- wire SSL option building into Nest runtime DB config and TypeORM datasource config
- extend DB env validation for SSL controls (`DB_SSL_REJECT_UNAUTHORIZED`, `DB_SSL_CA_PATH`, `DB_SSL_CERT_PATH`, `DB_SSL_KEY_PATH`, `DB_SSL_KEY_PASSPHRASE`)
- add e2e coverage for:
  - negative path: invalid `DB_SSL_CA_PATH` fails early
  - positive path: TLS connection succeeds with provided CA/cert/key using Testcontainers PostgreSQL SSL support
- update database documentation for new SSL-related environment variables

## Verification
- `pnpm exec vitest run --config ./test/vitest.config.ts test/db-ssl.e2e-spec.ts --coverage=false`

## Commit
- c885cf72