### PR TITLE
docs: add bi-weekly community call Zoom link

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ Curious about EUDIPLO? Check out our recorded webinar (September 17, 2025) for a
 
 [Watch on YouTube](https://www.youtube.com/watch?v=GQlvHK-EFlU)
 
+## 🤝 Community Call
+
+Join our bi-weekly community call every Thursday:
+
+[Participate via Zoom](https://zoom-lfx.platform.linuxfoundation.org/meeting/94494306854?password=0d272140-5b2b-4bd4-a8fe-0b70efe1aa86)
+
 ## 🚀 Quick Start
 
 ### Demo Setup (Easiest)

--- a/docs/index.md
+++ b/docs/index.md
@@ -70,6 +70,14 @@ Learn more about EUDIPLO in our recorded webinar (September 17, 2025), featuring
 
 ---
 
+## 🤝 Community Call
+
+Join our bi-weekly community call every Thursday:
+
+[Participate via Zoom](https://zoom-lfx.platform.linuxfoundation.org/meeting/94494306854?password=0d272140-5b2b-4bd4-a8fe-0b70efe1aa86)
+
+---
+
 ## How Do I Use It?
 
 EUDIPLO is distributed as a Docker container and can be configured in minutes.


### PR DESCRIPTION
## Summary
- add a new **Community Call** section to the root README
- add the same **Community Call** section to docs homepage
- include the bi-weekly Thursday schedule and Zoom participation link

## Files changed
- README.md
- docs/index.md