### PR TITLE
fix: align credential schemas for vct and claim field path

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -112,5 +112,9 @@
     "**/dist/**",
     "**/site/**",
     "**/tmp/**"
+  ],
+  "angular.enable-strict-mode-prompt": false,
+  "cSpell.words": [
+    "disclosable"
   ]
 }

--- a/apps/backend/src/issuer/configuration/credentials/dto/claim-field-definition.dto.ts
+++ b/apps/backend/src/issuer/configuration/credentials/dto/claim-field-definition.dto.ts
@@ -32,7 +32,10 @@ export class ClaimFieldDefinitionDto {
     @ApiProperty({
         description: "Path to claim value",
         example: ["address", "locality"],
-        type: [String],
+        type: "array",
+        items: {
+            oneOf: [{ type: "string" }, { type: "number" }, { type: "null" }],
+        },
     })
     @IsArray()
     path!: Array<string | number | null>;

--- a/apps/backend/src/issuer/configuration/credentials/entities/credential.entity.ts
+++ b/apps/backend/src/issuer/configuration/credentials/entities/credential.entity.ts
@@ -196,13 +196,13 @@ export class CredentialConfig {
     webhookEndpoint?: WebhookEndpointEntity;
 
     @IsOptional()
-    @ApiProperty({
+    @ApiPropertyOptional({
         description:
             "VCT as a URI string (e.g., urn:eudi:pid:de:1) or as an object for EUDIPLO-hosted VCT",
-        nullable: true,
-        oneOf: [
+        anyOf: [
             { type: "string", description: "VCT URI string" },
             { $ref: getSchemaPath(VCT) },
+            { type: "null" },
         ],
     })
     @Column("json", { nullable: true })

--- a/apps/client/src/app/utils/schemas.json
+++ b/apps/client/src/app/utils/schemas.json
@@ -1,7 +1,9 @@
 [
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/GrafanaConfigDto.schema.json",
-    "fileMatch": ["a://b/GrafanaConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/GrafanaConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/GrafanaConfigDto.schema.json",
@@ -24,13 +26,18 @@
           "example": "loki"
         }
       },
-      "required": ["tempoUid", "lokiUid"],
+      "required": [
+        "tempoUid",
+        "lokiUid"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FrontendConfigResponseDto.schema.json",
-    "fileMatch": ["a://b/FrontendConfigResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/FrontendConfigResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FrontendConfigResponseDto.schema.json",
@@ -46,13 +53,17 @@
           ]
         }
       },
-      "required": ["grafana"],
+      "required": [
+        "grafana"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RoleDto.schema.json",
-    "fileMatch": ["a://b/RoleDto*.schema.json"],
+    "fileMatch": [
+      "a://b/RoleDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RoleDto.schema.json",
@@ -75,13 +86,17 @@
           "example": "issuance:manage"
         }
       },
-      "required": ["role"],
+      "required": [
+        "role"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientCredentialsDto.schema.json",
-    "fileMatch": ["a://b/ClientCredentialsDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ClientCredentialsDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientCredentialsDto.schema.json",
@@ -99,13 +114,18 @@
           "type": "string"
         }
       },
-      "required": ["client_id", "client_secret"],
+      "required": [
+        "client_id",
+        "client_secret"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TokenResponse.schema.json",
-    "fileMatch": ["a://b/TokenResponse*.schema.json"],
+    "fileMatch": [
+      "a://b/TokenResponse*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TokenResponse.schema.json",
@@ -125,13 +145,19 @@
           "type": "number"
         }
       },
-      "required": ["access_token", "token_type", "expires_in"],
+      "required": [
+        "access_token",
+        "token_type",
+        "expires_in"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ImportTenantDto.schema.json",
-    "fileMatch": ["a://b/ImportTenantDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ImportTenantDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ImportTenantDto.schema.json",
@@ -147,13 +173,17 @@
           "description": "The description of the tenant."
         }
       },
-      "required": ["name"],
+      "required": [
+        "name"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SessionStorageConfig.schema.json",
-    "fileMatch": ["a://b/SessionStorageConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/SessionStorageConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SessionStorageConfig.schema.json",
@@ -169,7 +199,10 @@
         "cleanupMode": {
           "type": "string",
           "description": "Cleanup mode: 'full' deletes everything, 'anonymize' keeps metadata but removes PII.",
-          "enum": ["full", "anonymize"],
+          "enum": [
+            "full",
+            "anonymize"
+          ],
           "default": "full"
         }
       },
@@ -178,7 +211,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListConfig.schema.json",
-    "fileMatch": ["a://b/StatusListConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/StatusListConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListConfig.schema.json",
@@ -194,7 +229,12 @@
         "bits": {
           "type": "number",
           "description": "Bits per status entry: 1 (valid/revoked), 2 (with suspended), 4/8 (extended). If not set, uses global STATUS_BITS.",
-          "enum": [1, 2, 4, 8],
+          "enum": [
+            1,
+            2,
+            4,
+            8
+          ],
           "default": 1
         },
         "ttl": {
@@ -219,7 +259,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TenantEntity.schema.json",
-    "fileMatch": ["a://b/TenantEntity*.schema.json"],
+    "fileMatch": [
+      "a://b/TenantEntity*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TenantEntity.schema.json",
@@ -270,13 +312,20 @@
           }
         }
       },
-      "required": ["id", "name", "status", "clients"],
+      "required": [
+        "id",
+        "name",
+        "status",
+        "clients"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientEntity.schema.json",
-    "fileMatch": ["a://b/ClientEntity*.schema.json"],
+    "fileMatch": [
+      "a://b/ClientEntity*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientEntity.schema.json",
@@ -286,7 +335,10 @@
         "allowedPresentationConfigs": {
           "nullable": true,
           "description": "List of presentation config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": ["age-verification", "kyc-basic"],
+          "example": [
+            "age-verification",
+            "kyc-basic"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -295,7 +347,10 @@
         "allowedIssuanceConfigs": {
           "nullable": true,
           "description": "List of issuance config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": ["pid", "mdl"],
+          "example": [
+            "pid",
+            "mdl"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -343,13 +398,18 @@
           ]
         }
       },
-      "required": ["clientId", "roles"],
+      "required": [
+        "clientId",
+        "roles"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateTenantDto.schema.json",
-    "fileMatch": ["a://b/CreateTenantDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CreateTenantDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateTenantDto.schema.json",
@@ -403,13 +463,18 @@
           }
         }
       },
-      "required": ["id", "name"],
+      "required": [
+        "id",
+        "name"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateTenantDto.schema.json",
-    "fileMatch": ["a://b/UpdateTenantDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateTenantDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateTenantDto.schema.json",
@@ -464,7 +529,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuditLogResponseDto.schema.json",
-    "fileMatch": ["a://b/AuditLogResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/AuditLogResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuditLogResponseDto.schema.json",
@@ -502,7 +569,11 @@
         },
         "actorType": {
           "type": "string",
-          "enum": ["user", "client", "system"]
+          "enum": [
+            "user",
+            "client",
+            "system"
+          ]
         },
         "actorId": {
           "type": "string"
@@ -532,13 +603,21 @@
           "type": "string"
         }
       },
-      "required": ["id", "tenantId", "actionType", "actorType", "timestamp"],
+      "required": [
+        "id",
+        "tenantId",
+        "actionType",
+        "actorType",
+        "timestamp"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientSecretResponseDto.schema.json",
-    "fileMatch": ["a://b/ClientSecretResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ClientSecretResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientSecretResponseDto.schema.json",
@@ -549,13 +628,17 @@
           "type": "string"
         }
       },
-      "required": ["secret"],
+      "required": [
+        "secret"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateClientDto.schema.json",
-    "fileMatch": ["a://b/UpdateClientDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateClientDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateClientDto.schema.json",
@@ -565,7 +648,10 @@
         "allowedPresentationConfigs": {
           "nullable": true,
           "description": "List of presentation config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": ["age-verification", "kyc-basic"],
+          "example": [
+            "age-verification",
+            "kyc-basic"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -574,7 +660,10 @@
         "allowedIssuanceConfigs": {
           "nullable": true,
           "description": "List of issuance config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": ["pid", "mdl"],
+          "example": [
+            "pid",
+            "mdl"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -602,13 +691,17 @@
           }
         }
       },
-      "required": ["roles"],
+      "required": [
+        "roles"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateClientDto.schema.json",
-    "fileMatch": ["a://b/CreateClientDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CreateClientDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateClientDto.schema.json",
@@ -618,7 +711,10 @@
         "allowedPresentationConfigs": {
           "nullable": true,
           "description": "List of presentation config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": ["age-verification", "kyc-basic"],
+          "example": [
+            "age-verification",
+            "kyc-basic"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -627,7 +723,10 @@
         "allowedIssuanceConfigs": {
           "nullable": true,
           "description": "List of issuance config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": ["pid", "mdl"],
+          "example": [
+            "pid",
+            "mdl"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -663,13 +762,18 @@
           }
         }
       },
-      "required": ["clientId", "roles"],
+      "required": [
+        "clientId",
+        "roles"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListImportDto.schema.json",
-    "fileMatch": ["a://b/StatusListImportDto*.schema.json"],
+    "fileMatch": [
+      "a://b/StatusListImportDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListImportDto.schema.json",
@@ -700,17 +804,26 @@
         "bits": {
           "type": "number",
           "description": "Bits per status value. If not provided, uses tenant or global defaults.",
-          "enum": [1, 2, 4, 8],
+          "enum": [
+            1,
+            2,
+            4,
+            8
+          ],
           "example": 1
         }
       },
-      "required": ["id"],
+      "required": [
+        "id"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListAggregationDto.schema.json",
-    "fileMatch": ["a://b/StatusListAggregationDto*.schema.json"],
+    "fileMatch": [
+      "a://b/StatusListAggregationDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListAggregationDto.schema.json",
@@ -729,13 +842,17 @@
           }
         }
       },
-      "required": ["status_lists"],
+      "required": [
+        "status_lists"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateStatusListConfigDto.schema.json",
-    "fileMatch": ["a://b/UpdateStatusListConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateStatusListConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateStatusListConfigDto.schema.json",
@@ -753,7 +870,12 @@
           "type": "number",
           "nullable": true,
           "description": "Bits per status entry. Set to null to reset to global default.",
-          "enum": [1, 2, 4, 8]
+          "enum": [
+            1,
+            2,
+            4,
+            8
+          ]
         },
         "ttl": {
           "type": "number",
@@ -778,7 +900,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListResponseDto.schema.json",
-    "fileMatch": ["a://b/StatusListResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/StatusListResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListResponseDto.schema.json",
@@ -810,7 +934,12 @@
         "bits": {
           "type": "number",
           "description": "Bits per status value",
-          "enum": [1, 2, 4, 8],
+          "enum": [
+            1,
+            2,
+            4,
+            8
+          ],
           "example": 1
         },
         "capacity": {
@@ -862,7 +991,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateStatusListDto.schema.json",
-    "fileMatch": ["a://b/CreateStatusListDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CreateStatusListDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateStatusListDto.schema.json",
@@ -882,7 +1013,12 @@
         "bits": {
           "type": "number",
           "description": "Bits per status value. More bits allow more status states. Defaults to tenant configuration.",
-          "enum": [1, 2, 4, 8],
+          "enum": [
+            1,
+            2,
+            4,
+            8
+          ],
           "example": 1
         },
         "capacity": {
@@ -897,7 +1033,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateStatusListDto.schema.json",
-    "fileMatch": ["a://b/UpdateStatusListDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateStatusListDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateStatusListDto.schema.json",
@@ -922,7 +1060,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthorizeQueries.schema.json",
-    "fileMatch": ["a://b/AuthorizeQueries*.schema.json"],
+    "fileMatch": [
+      "a://b/AuthorizeQueries*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthorizeQueries.schema.json",
@@ -975,7 +1115,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/OfferRequestDto.schema.json",
-    "fileMatch": ["a://b/OfferRequestDto*.schema.json"],
+    "fileMatch": [
+      "a://b/OfferRequestDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/OfferRequestDto.schema.json",
@@ -983,7 +1125,10 @@
       "type": "object",
       "properties": {
         "response_type": {
-          "enum": ["uri", "dc-api"],
+          "enum": [
+            "uri",
+            "dc-api"
+          ],
           "type": "string",
           "examples": [
             {
@@ -1003,14 +1148,19 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": ["inline"]
+                      "enum": [
+                        "inline"
+                      ]
                     },
                     "claims": {
                       "type": "object",
                       "additionalProperties": true
                     }
                   },
-                  "required": ["type", "claims"],
+                  "required": [
+                    "type",
+                    "claims"
+                  ],
                   "additionalProperties": false
                 },
                 {
@@ -1018,13 +1168,18 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": ["attributeProvider"]
+                      "enum": [
+                        "attributeProvider"
+                      ]
                     },
                     "attributeProviderId": {
                       "type": "string"
                     }
                   },
-                  "required": ["type", "attributeProviderId"],
+                  "required": [
+                    "type",
+                    "attributeProviderId"
+                  ],
                   "additionalProperties": false
                 },
                 {
@@ -1032,7 +1187,9 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": ["webhook"]
+                      "enum": [
+                        "webhook"
+                      ]
                     },
                     "webhook": {
                       "type": "object",
@@ -1044,11 +1201,16 @@
                           "type": "object"
                         }
                       },
-                      "required": ["url"],
+                      "required": [
+                        "url"
+                      ],
                       "additionalProperties": false
                     }
                   },
-                  "required": ["type", "webhook"],
+                  "required": [
+                    "type",
+                    "webhook"
+                  ],
                   "additionalProperties": false
                 }
               ]
@@ -1067,7 +1229,10 @@
         },
         "flow": {
           "description": "The flow type for the offer request.",
-          "enum": ["authorization_code", "pre_authorized_code"],
+          "enum": [
+            "authorization_code",
+            "pre_authorized_code"
+          ],
           "type": "string"
         },
         "tx_code": {
@@ -1094,13 +1259,19 @@
           "description": "ID of the webhook endpoint to notify about the status of the issuance process."
         }
       },
-      "required": ["response_type", "flow", "credentialConfigurationIds"],
+      "required": [
+        "response_type",
+        "flow",
+        "credentialConfigurationIds"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebHookAuthConfigNone.schema.json",
-    "fileMatch": ["a://b/WebHookAuthConfigNone*.schema.json"],
+    "fileMatch": [
+      "a://b/WebHookAuthConfigNone*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebHookAuthConfigNone.schema.json",
@@ -1110,16 +1281,22 @@
         "type": {
           "type": "string",
           "description": "The type of authentication used for the webhook.",
-          "enum": ["none"]
+          "enum": [
+            "none"
+          ]
         }
       },
-      "required": ["type"],
+      "required": [
+        "type"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ApiKeyConfig.schema.json",
-    "fileMatch": ["a://b/ApiKeyConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/ApiKeyConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ApiKeyConfig.schema.json",
@@ -1135,13 +1312,18 @@
           "description": "The value of the API key to be sent in the header."
         }
       },
-      "required": ["headerName", "value"],
+      "required": [
+        "headerName",
+        "value"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebHookAuthConfigHeader.schema.json",
-    "fileMatch": ["a://b/WebHookAuthConfigHeader*.schema.json"],
+    "fileMatch": [
+      "a://b/WebHookAuthConfigHeader*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebHookAuthConfigHeader.schema.json",
@@ -1151,7 +1333,9 @@
         "type": {
           "type": "string",
           "description": "The type of authentication used for the webhook.",
-          "enum": ["apiKey"]
+          "enum": [
+            "apiKey"
+          ]
         },
         "config": {
           "description": "Configuration for API key authentication.\nThis is required if the type is 'apiKey'.",
@@ -1162,13 +1346,18 @@
           ]
         }
       },
-      "required": ["type", "config"],
+      "required": [
+        "type",
+        "config"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebhookConfig.schema.json",
-    "fileMatch": ["a://b/WebhookConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/WebhookConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebhookConfig.schema.json",
@@ -1198,13 +1387,18 @@
           "description": "The URL to which the webhook will send notifications."
         }
       },
-      "required": ["auth", "url"],
+      "required": [
+        "auth",
+        "url"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TransactionData.schema.json",
-    "fileMatch": ["a://b/TransactionData*.schema.json"],
+    "fileMatch": [
+      "a://b/TransactionData*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TransactionData.schema.json",
@@ -1221,13 +1415,18 @@
           }
         }
       },
-      "required": ["type", "credential_ids"],
+      "required": [
+        "type",
+        "credential_ids"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Session.schema.json",
-    "fileMatch": ["a://b/Session*.schema.json"],
+    "fileMatch": [
+      "a://b/Session*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Session.schema.json",
@@ -1236,7 +1435,13 @@
       "properties": {
         "status": {
           "description": "Status of the session.",
-          "enum": ["active", "fetched", "completed", "expired", "failed"],
+          "enum": [
+            "active",
+            "fetched",
+            "completed",
+            "expired",
+            "failed"
+          ],
           "type": "string"
         },
         "id": {
@@ -1425,7 +1630,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SessionLogEntryResponseDto.schema.json",
-    "fileMatch": ["a://b/SessionLogEntryResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/SessionLogEntryResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SessionLogEntryResponseDto.schema.json",
@@ -1448,7 +1655,11 @@
         "level": {
           "type": "string",
           "description": "Log level",
-          "enum": ["info", "warn", "error"]
+          "enum": [
+            "info",
+            "warn",
+            "error"
+          ]
         },
         "stage": {
           "type": "string",
@@ -1463,13 +1674,21 @@
           "description": "Additional structured detail"
         }
       },
-      "required": ["id", "sessionId", "timestamp", "level", "message"],
+      "required": [
+        "id",
+        "sessionId",
+        "timestamp",
+        "level",
+        "message"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusUpdateDto.schema.json",
-    "fileMatch": ["a://b/StatusUpdateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/StatusUpdateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusUpdateDto.schema.json",
@@ -1489,13 +1708,18 @@
           "description": "The status of the credential\n0 = valid, 1 = revoked, 2 = suspended"
         }
       },
-      "required": ["sessionId", "status"],
+      "required": [
+        "sessionId",
+        "status"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateSessionConfigDto.schema.json",
-    "fileMatch": ["a://b/UpdateSessionConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateSessionConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateSessionConfigDto.schema.json",
@@ -1511,7 +1735,10 @@
         },
         "cleanupMode": {
           "description": "Cleanup mode: 'full' deletes everything, 'anonymize' keeps metadata but removes PII.",
-          "enum": ["full", "anonymize"],
+          "enum": [
+            "full",
+            "anonymize"
+          ],
           "type": "string",
           "default": "full"
         }
@@ -1521,7 +1748,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ManagedUserDto.schema.json",
-    "fileMatch": ["a://b/ManagedUserDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ManagedUserDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ManagedUserDto.schema.json",
@@ -1570,13 +1799,20 @@
           "description": "One-time temporary password returned only on user creation."
         }
       },
-      "required": ["id", "username", "enabled", "roles"],
+      "required": [
+        "id",
+        "username",
+        "enabled",
+        "roles"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateUserDto.schema.json",
-    "fileMatch": ["a://b/CreateUserDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CreateUserDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateUserDto.schema.json",
@@ -1618,13 +1854,18 @@
           "example": true
         }
       },
-      "required": ["username", "roles"],
+      "required": [
+        "username",
+        "roles"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateUserDto.schema.json",
-    "fileMatch": ["a://b/UpdateUserDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateUserDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateUserDto.schema.json",
@@ -1676,7 +1917,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodNone.schema.json",
-    "fileMatch": ["a://b/AuthenticationMethodNone*.schema.json"],
+    "fileMatch": [
+      "a://b/AuthenticationMethodNone*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodNone.schema.json",
@@ -1685,16 +1928,22 @@
       "properties": {
         "method": {
           "type": "string",
-          "enum": ["none"]
+          "enum": [
+            "none"
+          ]
         }
       },
-      "required": ["method"],
+      "required": [
+        "method"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationUrlConfig.schema.json",
-    "fileMatch": ["a://b/AuthenticationUrlConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/AuthenticationUrlConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationUrlConfig.schema.json",
@@ -1714,13 +1963,17 @@
           ]
         }
       },
-      "required": ["url"],
+      "required": [
+        "url"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodAuth.schema.json",
-    "fileMatch": ["a://b/AuthenticationMethodAuth*.schema.json"],
+    "fileMatch": [
+      "a://b/AuthenticationMethodAuth*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodAuth.schema.json",
@@ -1729,19 +1982,26 @@
       "properties": {
         "method": {
           "type": "string",
-          "enum": ["auth"]
+          "enum": [
+            "auth"
+          ]
         },
         "config": {
           "$ref": "./AuthenticationUrlConfig.schema.json"
         }
       },
-      "required": ["method", "config"],
+      "required": [
+        "method",
+        "config"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationDuringIssuanceConfig.schema.json",
-    "fileMatch": ["a://b/PresentationDuringIssuanceConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/PresentationDuringIssuanceConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationDuringIssuanceConfig.schema.json",
@@ -1753,13 +2013,17 @@
           "description": "Link to the presentation configuration that is relevant for the issuance process"
         }
       },
-      "required": ["type"],
+      "required": [
+        "type"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodPresentation.schema.json",
-    "fileMatch": ["a://b/AuthenticationMethodPresentation*.schema.json"],
+    "fileMatch": [
+      "a://b/AuthenticationMethodPresentation*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodPresentation.schema.json",
@@ -1768,19 +2032,26 @@
       "properties": {
         "method": {
           "type": "string",
-          "enum": ["presentationDuringIssuance"]
+          "enum": [
+            "presentationDuringIssuance"
+          ]
         },
         "config": {
           "$ref": "./PresentationDuringIssuanceConfig.schema.json"
         }
       },
-      "required": ["method", "config"],
+      "required": [
+        "method",
+        "config"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpstreamOidcConfig.schema.json",
-    "fileMatch": ["a://b/UpstreamOidcConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/UpstreamOidcConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpstreamOidcConfig.schema.json",
@@ -1804,20 +2075,28 @@
         },
         "scopes": {
           "description": "Scopes to request from the upstream provider",
-          "default": ["openid", "profile"],
+          "default": [
+            "openid",
+            "profile"
+          ],
           "type": "array",
           "items": {
             "type": "string"
           }
         }
       },
-      "required": ["issuer", "clientId"],
+      "required": [
+        "issuer",
+        "clientId"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenConfig.schema.json",
-    "fileMatch": ["a://b/ChainedAsTokenConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/ChainedAsTokenConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenConfig.schema.json",
@@ -1840,7 +2119,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsConfig.schema.json",
-    "fileMatch": ["a://b/ChainedAsConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/ChainedAsConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsConfig.schema.json",
@@ -1874,13 +2155,17 @@
           "default": true
         }
       },
-      "required": ["enabled"],
+      "required": [
+        "enabled"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FederationTrustAnchorConfig.schema.json",
-    "fileMatch": ["a://b/FederationTrustAnchorConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/FederationTrustAnchorConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FederationTrustAnchorConfig.schema.json",
@@ -1898,13 +2183,18 @@
           "example": "https://ta.example.org/.well-known/openid-federation"
         }
       },
-      "required": ["entityId", "entityConfigurationUri"],
+      "required": [
+        "entityId",
+        "entityConfigurationUri"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FederationConfig.schema.json",
-    "fileMatch": ["a://b/FederationConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/FederationConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FederationConfig.schema.json",
@@ -1912,13 +2202,20 @@
       "type": "object",
       "properties": {
         "role": {
-          "enum": ["trust_anchor", "intermediate", "leaf"],
+          "enum": [
+            "trust_anchor",
+            "intermediate",
+            "leaf"
+          ],
           "type": "string",
           "description": "Role this tenant plays in the OpenID Federation topology.",
           "default": "leaf"
         },
         "mode": {
-          "enum": ["federation-only", "lote-only", "hybrid"],
+          "enum": [
+            "federation-only",
+            "hybrid"
+          ],
           "type": "string",
           "description": "Trust decision strategy when both LoTE trust lists and OpenID Federation are configured.",
           "default": "hybrid"
@@ -1946,13 +2243,17 @@
           }
         }
       },
-      "required": ["trustAnchors"],
+      "required": [
+        "trustAnchors"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayLogo.schema.json",
-    "fileMatch": ["a://b/DisplayLogo*.schema.json"],
+    "fileMatch": [
+      "a://b/DisplayLogo*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayLogo.schema.json",
@@ -1966,13 +2267,17 @@
           "type": "string"
         }
       },
-      "required": ["uri"],
+      "required": [
+        "uri"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayInfo.schema.json",
-    "fileMatch": ["a://b/DisplayInfo*.schema.json"],
+    "fileMatch": [
+      "a://b/DisplayInfo*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayInfo.schema.json",
@@ -1994,7 +2299,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuanceConfig.schema.json",
-    "fileMatch": ["a://b/IssuanceConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/IssuanceConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuanceConfig.schema.json",
@@ -2107,13 +2414,20 @@
           "description": "The timestamp when the VP request was last updated."
         }
       },
-      "required": ["tenant", "display", "createdAt", "updatedAt"],
+      "required": [
+        "tenant",
+        "display",
+        "createdAt",
+        "updatedAt"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuanceDto.schema.json",
-    "fileMatch": ["a://b/IssuanceDto*.schema.json"],
+    "fileMatch": [
+      "a://b/IssuanceDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuanceDto.schema.json",
@@ -2208,13 +2522,17 @@
           }
         }
       },
-      "required": ["display"],
+      "required": [
+        "display"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClaimsQuery.schema.json",
-    "fileMatch": ["a://b/ClaimsQuery*.schema.json"],
+    "fileMatch": [
+      "a://b/ClaimsQuery*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClaimsQuery.schema.json",
@@ -2237,13 +2555,17 @@
           }
         }
       },
-      "required": ["path"],
+      "required": [
+        "path"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustedAuthorityQuery.schema.json",
-    "fileMatch": ["a://b/TrustedAuthorityQuery*.schema.json"],
+    "fileMatch": [
+      "a://b/TrustedAuthorityQuery*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustedAuthorityQuery.schema.json",
@@ -2252,7 +2574,10 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["aki", "etsi_tl", "openid_federation"]
+          "enum": [
+            "etsi_tl",
+            "openid_federation"
+          ]
         },
         "values": {
           "type": "array",
@@ -2261,13 +2586,18 @@
           }
         }
       },
-      "required": ["type", "values"],
+      "required": [
+        "type",
+        "values"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialQuery.schema.json",
-    "fileMatch": ["a://b/CredentialQuery*.schema.json"],
+    "fileMatch": [
+      "a://b/CredentialQuery*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialQuery.schema.json",
@@ -2299,13 +2629,19 @@
           }
         }
       },
-      "required": ["id", "format", "meta"],
+      "required": [
+        "id",
+        "format",
+        "meta"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialSetQuery.schema.json",
-    "fileMatch": ["a://b/CredentialSetQuery*.schema.json"],
+    "fileMatch": [
+      "a://b/CredentialSetQuery*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialSetQuery.schema.json",
@@ -2325,13 +2661,17 @@
           "type": "boolean"
         }
       },
-      "required": ["options"],
+      "required": [
+        "options"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PolicyCredential.schema.json",
-    "fileMatch": ["a://b/PolicyCredential*.schema.json"],
+    "fileMatch": [
+      "a://b/PolicyCredential*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PolicyCredential.schema.json",
@@ -2357,13 +2697,17 @@
           }
         }
       },
-      "required": ["credentials"],
+      "required": [
+        "credentials"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AttestationBasedPolicy.schema.json",
-    "fileMatch": ["a://b/AttestationBasedPolicy*.schema.json"],
+    "fileMatch": [
+      "a://b/AttestationBasedPolicy*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AttestationBasedPolicy.schema.json",
@@ -2372,7 +2716,9 @@
       "properties": {
         "policy": {
           "type": "string",
-          "enum": ["attestationBased"]
+          "enum": [
+            "attestationBased"
+          ]
         },
         "values": {
           "type": "array",
@@ -2381,13 +2727,18 @@
           }
         }
       },
-      "required": ["policy", "values"],
+      "required": [
+        "policy",
+        "values"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/NoneTrustPolicy.schema.json",
-    "fileMatch": ["a://b/NoneTrustPolicy*.schema.json"],
+    "fileMatch": [
+      "a://b/NoneTrustPolicy*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/NoneTrustPolicy.schema.json",
@@ -2396,16 +2747,22 @@
       "properties": {
         "policy": {
           "type": "string",
-          "enum": ["none"]
+          "enum": [
+            "none"
+          ]
         }
       },
-      "required": ["policy"],
+      "required": [
+        "policy"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AllowListPolicy.schema.json",
-    "fileMatch": ["a://b/AllowListPolicy*.schema.json"],
+    "fileMatch": [
+      "a://b/AllowListPolicy*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AllowListPolicy.schema.json",
@@ -2414,7 +2771,9 @@
       "properties": {
         "policy": {
           "type": "string",
-          "enum": ["allowList"]
+          "enum": [
+            "allowList"
+          ]
         },
         "values": {
           "type": "array",
@@ -2423,13 +2782,18 @@
           }
         }
       },
-      "required": ["policy", "values"],
+      "required": [
+        "policy",
+        "values"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RootOfTrustPolicy.schema.json",
-    "fileMatch": ["a://b/RootOfTrustPolicy*.schema.json"],
+    "fileMatch": [
+      "a://b/RootOfTrustPolicy*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RootOfTrustPolicy.schema.json",
@@ -2438,19 +2802,26 @@
       "properties": {
         "policy": {
           "type": "string",
-          "enum": ["rootOfTrust"]
+          "enum": [
+            "rootOfTrust"
+          ]
         },
         "values": {
           "type": "string"
         }
       },
-      "required": ["policy", "values"],
+      "required": [
+        "policy",
+        "values"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/VCT.schema.json",
-    "fileMatch": ["a://b/VCT*.schema.json"],
+    "fileMatch": [
+      "a://b/VCT*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/VCT.schema.json",
@@ -2484,7 +2855,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IaeActionOpenid4vpPresentation.schema.json",
-    "fileMatch": ["a://b/IaeActionOpenid4vpPresentation*.schema.json"],
+    "fileMatch": [
+      "a://b/IaeActionOpenid4vpPresentation*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IaeActionOpenid4vpPresentation.schema.json",
@@ -2492,7 +2865,9 @@
       "type": "object",
       "properties": {
         "type": {
-          "enum": ["openid4vp_presentation"],
+          "enum": [
+            "openid4vp_presentation"
+          ],
           "type": "string",
           "description": "Action type discriminator",
           "example": "openid4vp_presentation"
@@ -2508,13 +2883,18 @@
           "example": "pid-presentation-config"
         }
       },
-      "required": ["type", "presentationConfigId"],
+      "required": [
+        "type",
+        "presentationConfigId"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IaeActionRedirectToWeb.schema.json",
-    "fileMatch": ["a://b/IaeActionRedirectToWeb*.schema.json"],
+    "fileMatch": [
+      "a://b/IaeActionRedirectToWeb*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IaeActionRedirectToWeb.schema.json",
@@ -2522,7 +2902,9 @@
       "type": "object",
       "properties": {
         "type": {
-          "enum": ["redirect_to_web"],
+          "enum": [
+            "redirect_to_web"
+          ],
           "type": "string",
           "description": "Action type discriminator",
           "example": "redirect_to_web"
@@ -2550,13 +2932,18 @@
           "example": "Please complete the identity verification form"
         }
       },
-      "required": ["type", "url"],
+      "required": [
+        "type",
+        "url"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebhookEndpointEntity.schema.json",
-    "fileMatch": ["a://b/WebhookEndpointEntity*.schema.json"],
+    "fileMatch": [
+      "a://b/WebhookEndpointEntity*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebhookEndpointEntity.schema.json",
@@ -2594,13 +2981,22 @@
           "type": "string"
         }
       },
-      "required": ["id", "auth", "tenantId", "tenant", "name", "url"],
+      "required": [
+        "id",
+        "auth",
+        "tenantId",
+        "tenant",
+        "name",
+        "url"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaUriEntry.schema.json",
-    "fileMatch": ["a://b/SchemaUriEntry*.schema.json"],
+    "fileMatch": [
+      "a://b/SchemaUriEntry*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaUriEntry.schema.json",
@@ -2627,13 +3023,17 @@
           "additionalProperties": true
         }
       },
-      "required": ["meta"],
+      "required": [
+        "meta"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustAuthorityEntry.schema.json",
-    "fileMatch": ["a://b/TrustAuthorityEntry*.schema.json"],
+    "fileMatch": [
+      "a://b/TrustAuthorityEntry*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustAuthorityEntry.schema.json",
@@ -2645,7 +3045,11 @@
           "description": "Trust list ID to resolve from the database. When set, frameworkType, value, and verificationMethod are derived automatically."
         },
         "frameworkType": {
-          "enum": ["aki", "etsi_tl", "openid_federation"],
+          "enum": [
+            "aki",
+            "etsi_tl",
+            "openid_federation"
+          ],
           "type": "string",
           "description": "Trust framework type (ignored when trustListId is set)"
         },
@@ -2668,7 +3072,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetaConfig.schema.json",
-    "fileMatch": ["a://b/SchemaMetaConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/SchemaMetaConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetaConfig.schema.json",
@@ -2701,7 +3107,12 @@
           "description": "Attestation Level of Security"
         },
         "bindingType": {
-          "enum": ["claim", "key", "biometric", "none"],
+          "enum": [
+            "claim",
+            "key",
+            "biometric",
+            "none"
+          ],
           "type": "string",
           "description": "Cryptographic binding type"
         },
@@ -2725,7 +3136,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EmbeddedDisclosurePolicy.schema.json",
-    "fileMatch": ["a://b/EmbeddedDisclosurePolicy*.schema.json"],
+    "fileMatch": [
+      "a://b/EmbeddedDisclosurePolicy*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EmbeddedDisclosurePolicy.schema.json",
@@ -2736,13 +3149,17 @@
           "type": "string"
         }
       },
-      "required": ["policy"],
+      "required": [
+        "policy"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyAttestationsRequired.schema.json",
-    "fileMatch": ["a://b/KeyAttestationsRequired*.schema.json"],
+    "fileMatch": [
+      "a://b/KeyAttestationsRequired*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyAttestationsRequired.schema.json",
@@ -2751,7 +3168,10 @@
       "properties": {
         "key_storage": {
           "description": "List of required key storage types (e.g., iso_18045_high, iso_18045_moderate)",
-          "example": ["iso_18045_high", "iso_18045_moderate"],
+          "example": [
+            "iso_18045_high",
+            "iso_18045_moderate"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -2759,7 +3179,10 @@
         },
         "user_authentication": {
           "description": "List of required user authentication types (e.g., iso_18045_high, iso_18045_moderate)",
-          "example": ["iso_18045_high", "iso_18045_moderate"],
+          "example": [
+            "iso_18045_high",
+            "iso_18045_moderate"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -2771,7 +3194,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayImage.schema.json",
-    "fileMatch": ["a://b/DisplayImage*.schema.json"],
+    "fileMatch": [
+      "a://b/DisplayImage*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayImage.schema.json",
@@ -2782,13 +3207,17 @@
           "type": "string"
         }
       },
-      "required": ["uri"],
+      "required": [
+        "uri"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Display.schema.json",
-    "fileMatch": ["a://b/Display*.schema.json"],
+    "fileMatch": [
+      "a://b/Display*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Display.schema.json",
@@ -2817,13 +3246,19 @@
           "$ref": "./DisplayImage.schema.json"
         }
       },
-      "required": ["name", "description", "locale"],
+      "required": [
+        "name",
+        "description",
+        "locale"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerMetadataCredentialConfig.schema.json",
-    "fileMatch": ["a://b/IssuerMetadataCredentialConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/IssuerMetadataCredentialConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerMetadataCredentialConfig.schema.json",
@@ -2840,7 +3275,10 @@
         },
         "format": {
           "type": "string",
-          "enum": ["mso_mdoc", "dc+sd-jwt"]
+          "enum": [
+            "mso_mdoc",
+            "dc+sd-jwt"
+          ]
         },
         "display": {
           "type": "array",
@@ -2856,13 +3294,18 @@
           "description": "Document type for mDOC credentials (e.g., \"org.iso.18013.5.1.mDL\").\nOnly applicable when format is \"mso_mdoc\"."
         }
       },
-      "required": ["format", "display"],
+      "required": [
+        "format",
+        "display"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FieldDisplayDto.schema.json",
-    "fileMatch": ["a://b/FieldDisplayDto*.schema.json"],
+    "fileMatch": [
+      "a://b/FieldDisplayDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FieldDisplayDto.schema.json",
@@ -2885,13 +3328,18 @@
           "example": "Primary first name"
         }
       },
-      "required": ["lang", "label"],
+      "required": [
+        "lang",
+        "label"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClaimFieldDefinitionDto.schema.json",
-    "fileMatch": ["a://b/ClaimFieldDefinitionDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ClaimFieldDefinitionDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClaimFieldDefinitionDto.schema.json",
@@ -2899,16 +3347,37 @@
       "type": "object",
       "properties": {
         "path": {
-          "description": "Path to claim value",
-          "example": ["address", "locality"],
           "type": "array",
+          "description": "Path to claim value",
+          "example": [
+            "address",
+            "locality"
+          ],
           "items": {
-            "type": "string"
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "type": {
           "type": "string",
-          "enum": ["string", "number", "integer", "boolean", "object", "array", "date"],
+          "enum": [
+            "string",
+            "number",
+            "integer",
+            "boolean",
+            "object",
+            "array",
+            "date"
+          ],
           "description": "Claim value type"
         },
         "defaultValue": {
@@ -2960,13 +3429,18 @@
           "description": "Additional JSON schema constraints for this field"
         }
       },
-      "required": ["path", "type"],
+      "required": [
+        "path",
+        "type"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AttributeProviderEntity.schema.json",
-    "fileMatch": ["a://b/AttributeProviderEntity*.schema.json"],
+    "fileMatch": [
+      "a://b/AttributeProviderEntity*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AttributeProviderEntity.schema.json",
@@ -3003,13 +3477,22 @@
           "type": "string"
         }
       },
-      "required": ["auth", "id", "tenantId", "tenant", "name", "url"],
+      "required": [
+        "auth",
+        "id",
+        "tenantId",
+        "tenant",
+        "name",
+        "url"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainEntity.schema.json",
-    "fileMatch": ["a://b/KeyChainEntity*.schema.json"],
+    "fileMatch": [
+      "a://b/KeyChainEntity*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainEntity.schema.json",
@@ -3039,12 +3522,21 @@
         "usageType": {
           "type": "string",
           "description": "The purpose/role of this key chain in the system.",
-          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"]
+          "enum": [
+            "access",
+            "attestation",
+            "trustList",
+            "statusList",
+            "encrypt"
+          ]
         },
         "usage": {
           "type": "string",
           "description": "The usage type of the keys (sign or encrypt).",
-          "enum": ["sign", "encrypt"]
+          "enum": [
+            "sign",
+            "encrypt"
+          ]
         },
         "kmsProvider": {
           "type": "string",
@@ -3124,7 +3616,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfig.schema.json",
-    "fileMatch": ["a://b/CredentialConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/CredentialConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfig.schema.json",
@@ -3132,16 +3626,17 @@
       "type": "object",
       "properties": {
         "vct": {
-          "type": "object",
           "description": "VCT as a URI string (e.g., urn:eudi:pid:de:1) or as an object for EUDIPLO-hosted VCT",
-          "nullable": true,
-          "oneOf": [
+          "anyOf": [
             {
               "type": "string",
               "description": "VCT URI string"
             },
             {
               "$ref": "./VCT.schema.json"
+            },
+            {
+              "type": "null"
             }
           ]
         },
@@ -3251,17 +3746,34 @@
         "statusManagement": {
           "type": "boolean"
         },
+        "sdJwtTrustFormat": {
+          "nullable": true,
+          "description": "For SD-JWT credentials: determines whether to include certificate chain (x5c)\nor use federation-based trust (iss claim).\nDefault: \"x5c\" (federation must be explicitly selected)",
+          "enum": [
+            "x5c",
+            "federation"
+          ],
+          "type": "string"
+        },
         "lifeTime": {
           "type": "number"
         }
       },
-      "required": ["id", "tenant", "config", "configVersion", "fields"],
+      "required": [
+        "id",
+        "tenant",
+        "config",
+        "configVersion",
+        "fields"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfigCreate.schema.json",
-    "fileMatch": ["a://b/CredentialConfigCreate*.schema.json"],
+    "fileMatch": [
+      "a://b/CredentialConfigCreate*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfigCreate.schema.json",
@@ -3269,16 +3781,17 @@
       "type": "object",
       "properties": {
         "vct": {
-          "type": "object",
           "description": "VCT as a URI string (e.g., urn:eudi:pid:de:1) or as an object for EUDIPLO-hosted VCT",
-          "nullable": true,
-          "oneOf": [
+          "anyOf": [
             {
               "type": "string",
               "description": "VCT URI string"
             },
             {
               "$ref": "./VCT.schema.json"
+            },
+            {
+              "type": "null"
             }
           ]
         },
@@ -3371,17 +3884,33 @@
         "statusManagement": {
           "type": "boolean"
         },
+        "sdJwtTrustFormat": {
+          "nullable": true,
+          "description": "For SD-JWT credentials: determines whether to include certificate chain (x5c)\nor use federation-based trust (iss claim).\nDefault: \"x5c\" (federation must be explicitly selected)",
+          "enum": [
+            "x5c",
+            "federation"
+          ],
+          "type": "string"
+        },
         "lifeTime": {
           "type": "number"
         }
       },
-      "required": ["id", "config", "configVersion", "fields"],
+      "required": [
+        "id",
+        "config",
+        "configVersion",
+        "fields"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfigUpdate.schema.json",
-    "fileMatch": ["a://b/CredentialConfigUpdate*.schema.json"],
+    "fileMatch": [
+      "a://b/CredentialConfigUpdate*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfigUpdate.schema.json",
@@ -3389,16 +3918,17 @@
       "type": "object",
       "properties": {
         "vct": {
-          "type": "object",
           "description": "VCT as a URI string (e.g., urn:eudi:pid:de:1) or as an object for EUDIPLO-hosted VCT",
-          "nullable": true,
-          "oneOf": [
+          "anyOf": [
             {
               "type": "string",
               "description": "VCT URI string"
             },
             {
               "$ref": "./VCT.schema.json"
+            },
+            {
+              "type": "null"
             }
           ]
         },
@@ -3490,6 +4020,15 @@
         },
         "statusManagement": {
           "type": "boolean"
+        },
+        "sdJwtTrustFormat": {
+          "nullable": true,
+          "description": "For SD-JWT credentials: determines whether to include certificate chain (x5c)\nor use federation-based trust (iss claim).\nDefault: \"x5c\" (federation must be explicitly selected)",
+          "enum": [
+            "x5c",
+            "federation"
+          ],
+          "type": "string"
         },
         "lifeTime": {
           "type": "number"
@@ -3500,7 +4039,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SignSchemaMetaConfigDto.schema.json",
-    "fileMatch": ["a://b/SignSchemaMetaConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/SignSchemaMetaConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SignSchemaMetaConfigDto.schema.json",
@@ -3524,13 +4065,17 @@
           "description": "ID of the credential config to link back after submission. When provided, schemaMeta.id on the credential config is updated with the reserved attestation ID."
         }
       },
-      "required": ["config"],
+      "required": [
+        "config"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SignVersionSchemaMetaConfigDto.schema.json",
-    "fileMatch": ["a://b/SignVersionSchemaMetaConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/SignVersionSchemaMetaConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SignVersionSchemaMetaConfigDto.schema.json",
@@ -3550,13 +4095,17 @@
           "description": "ID of the key chain to use for signing. Defaults to the tenant's default key chain."
         }
       },
-      "required": ["config"],
+      "required": [
+        "config"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/VocabularyEntryDto.schema.json",
-    "fileMatch": ["a://b/VocabularyEntryDto*.schema.json"],
+    "fileMatch": [
+      "a://b/VocabularyEntryDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/VocabularyEntryDto.schema.json",
@@ -3574,20 +4123,29 @@
         "status": {
           "type": "string",
           "description": "Vocabulary lifecycle status.",
-          "enum": ["active", "deprecated"]
+          "enum": [
+            "active",
+            "deprecated"
+          ]
         },
         "replacedBy": {
           "type": "string",
           "description": "Replacement code when status is deprecated."
         }
       },
-      "required": ["code", "label", "status"],
+      "required": [
+        "code",
+        "label",
+        "status"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetadataVocabulariesDto.schema.json",
-    "fileMatch": ["a://b/SchemaMetadataVocabulariesDto*.schema.json"],
+    "fileMatch": [
+      "a://b/SchemaMetadataVocabulariesDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetadataVocabulariesDto.schema.json",
@@ -3613,13 +4171,19 @@
           }
         }
       },
-      "required": ["version", "categories", "tags"],
+      "required": [
+        "version",
+        "categories",
+        "tags"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/MetadataSchemaDto.schema.json",
-    "fileMatch": ["a://b/MetadataSchemaDto*.schema.json"],
+    "fileMatch": [
+      "a://b/MetadataSchemaDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/MetadataSchemaDto.schema.json",
@@ -3633,7 +4197,10 @@
         "formatIdentifier": {
           "type": "string",
           "description": "The credential format identifier",
-          "enum": ["dc+sd-jwt", "mso_mdoc"]
+          "enum": [
+            "dc+sd-jwt",
+            "mso_mdoc"
+          ]
         },
         "uri": {
           "type": "string",
@@ -3649,13 +4216,18 @@
           "description": "Subresource Integrity hash for the schema"
         }
       },
-      "required": ["id", "formatIdentifier"],
+      "required": [
+        "id",
+        "formatIdentifier"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustAuthorityDto.schema.json",
-    "fileMatch": ["a://b/TrustAuthorityDto*.schema.json"],
+    "fileMatch": [
+      "a://b/TrustAuthorityDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustAuthorityDto.schema.json",
@@ -3669,7 +4241,9 @@
         "frameworkType": {
           "type": "string",
           "description": "Type of trust framework",
-          "enum": ["etsi_tl"]
+          "enum": [
+            "etsi_tl"
+          ]
         },
         "value": {
           "type": "string",
@@ -3681,13 +4255,19 @@
           "additionalProperties": true
         }
       },
-      "required": ["id", "frameworkType", "value"],
+      "required": [
+        "id",
+        "frameworkType",
+        "value"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AccessCertificateRefDto.schema.json",
-    "fileMatch": ["a://b/AccessCertificateRefDto*.schema.json"],
+    "fileMatch": [
+      "a://b/AccessCertificateRefDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AccessCertificateRefDto.schema.json",
@@ -3710,13 +4290,21 @@
           "type": "string"
         }
       },
-      "required": ["id", "relyingPartyId", "certificate", "revoked", "createdAt"],
+      "required": [
+        "id",
+        "relyingPartyId",
+        "certificate",
+        "revoked",
+        "createdAt"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetadataResponseDto.schema.json",
-    "fileMatch": ["a://b/SchemaMetadataResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/SchemaMetadataResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetadataResponseDto.schema.json",
@@ -3752,14 +4340,22 @@
         "bindingType": {
           "type": "string",
           "description": "Required binding type between attestation and holder",
-          "enum": ["claim", "key", "biometric", "none"]
+          "enum": [
+            "claim",
+            "key",
+            "biometric",
+            "none"
+          ]
         },
         "supportedFormats": {
           "type": "array",
           "description": "Credential formats in which this attestation is available",
           "items": {
             "type": "string",
-            "enum": ["dc+sd-jwt", "mso_mdoc"]
+            "enum": [
+              "dc+sd-jwt",
+              "mso_mdoc"
+            ]
           }
         },
         "schemaURIs": {
@@ -3779,7 +4375,15 @@
         "category": {
           "type": "string",
           "description": "Domain category for filtering",
-          "enum": ["identity", "health", "finance", "education", "mobility", "employment", "other"]
+          "enum": [
+            "identity",
+            "health",
+            "finance",
+            "education",
+            "mobility",
+            "employment",
+            "other"
+          ]
         },
         "tags": {
           "description": "Free-form tags for filtering and search",
@@ -3853,7 +4457,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateSchemaMetadataDto.schema.json",
-    "fileMatch": ["a://b/UpdateSchemaMetadataDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateSchemaMetadataDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateSchemaMetadataDto.schema.json",
@@ -3863,7 +4469,15 @@
         "category": {
           "type": "string",
           "description": "Domain category for filtering",
-          "enum": ["identity", "health", "finance", "education", "mobility", "employment", "other"]
+          "enum": [
+            "identity",
+            "health",
+            "finance",
+            "education",
+            "mobility",
+            "employment",
+            "other"
+          ]
         },
         "tags": {
           "type": "array",
@@ -3890,7 +4504,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeprecateSchemaMetadataDto.schema.json",
-    "fileMatch": ["a://b/DeprecateSchemaMetadataDto*.schema.json"],
+    "fileMatch": [
+      "a://b/DeprecateSchemaMetadataDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeprecateSchemaMetadataDto.schema.json",
@@ -3910,13 +4526,17 @@
           "description": "The version that supersedes this one"
         }
       },
-      "required": ["deprecated"],
+      "required": [
+        "deprecated"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateAttributeProviderDto.schema.json",
-    "fileMatch": ["a://b/CreateAttributeProviderDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CreateAttributeProviderDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateAttributeProviderDto.schema.json",
@@ -3947,13 +4567,20 @@
           "type": "string"
         }
       },
-      "required": ["auth", "id", "name", "url"],
+      "required": [
+        "auth",
+        "id",
+        "name",
+        "url"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateAttributeProviderDto.schema.json",
-    "fileMatch": ["a://b/UpdateAttributeProviderDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateAttributeProviderDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateAttributeProviderDto.schema.json",
@@ -3989,7 +4616,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateWebhookEndpointDto.schema.json",
-    "fileMatch": ["a://b/CreateWebhookEndpointDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CreateWebhookEndpointDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateWebhookEndpointDto.schema.json",
@@ -4021,13 +4650,20 @@
           "type": "string"
         }
       },
-      "required": ["id", "auth", "name", "url"],
+      "required": [
+        "id",
+        "auth",
+        "name",
+        "url"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateWebhookEndpointDto.schema.json",
-    "fileMatch": ["a://b/UpdateWebhookEndpointDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateWebhookEndpointDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateWebhookEndpointDto.schema.json",
@@ -4064,7 +4700,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListEntityInfo.schema.json",
-    "fileMatch": ["a://b/TrustListEntityInfo*.schema.json"],
+    "fileMatch": [
+      "a://b/TrustListEntityInfo*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListEntityInfo.schema.json",
@@ -4096,13 +4734,17 @@
           "type": "string"
         }
       },
-      "required": ["name"],
+      "required": [
+        "name"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InternalTrustListEntity.schema.json",
-    "fileMatch": ["a://b/InternalTrustListEntity*.schema.json"],
+    "fileMatch": [
+      "a://b/InternalTrustListEntity*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InternalTrustListEntity.schema.json",
@@ -4111,7 +4753,9 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["internal"]
+          "enum": [
+            "internal"
+          ]
         },
         "issuerKeyChainId": {
           "type": "string"
@@ -4123,13 +4767,20 @@
           "$ref": "./TrustListEntityInfo.schema.json"
         }
       },
-      "required": ["type", "issuerKeyChainId", "revocationKeyChainId", "info"],
+      "required": [
+        "type",
+        "issuerKeyChainId",
+        "revocationKeyChainId",
+        "info"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExternalTrustListEntity.schema.json",
-    "fileMatch": ["a://b/ExternalTrustListEntity*.schema.json"],
+    "fileMatch": [
+      "a://b/ExternalTrustListEntity*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExternalTrustListEntity.schema.json",
@@ -4138,7 +4789,9 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["external"]
+          "enum": [
+            "external"
+          ]
         },
         "issuerCertPem": {
           "type": "string"
@@ -4150,13 +4803,20 @@
           "$ref": "./TrustListEntityInfo.schema.json"
         }
       },
-      "required": ["type", "issuerCertPem", "revocationCertPem", "info"],
+      "required": [
+        "type",
+        "issuerCertPem",
+        "revocationCertPem",
+        "info"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListCreateDto.schema.json",
-    "fileMatch": ["a://b/TrustListCreateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/TrustListCreateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListCreateDto.schema.json",
@@ -4197,13 +4857,17 @@
           "type": "string"
         }
       },
-      "required": ["entities"],
+      "required": [
+        "entities"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustList.schema.json",
-    "fileMatch": ["a://b/TrustList*.schema.json"],
+    "fileMatch": [
+      "a://b/TrustList*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustList.schema.json",
@@ -4279,7 +4943,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListVersion.schema.json",
-    "fileMatch": ["a://b/TrustListVersion*.schema.json"],
+    "fileMatch": [
+      "a://b/TrustListVersion*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListVersion.schema.json",
@@ -4334,7 +5000,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DCQL.schema.json",
-    "fileMatch": ["a://b/DCQL*.schema.json"],
+    "fileMatch": [
+      "a://b/DCQL*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DCQL.schema.json",
@@ -4354,13 +5022,17 @@
           }
         }
       },
-      "required": ["credentials"],
+      "required": [
+        "credentials"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificatePurpose.schema.json",
-    "fileMatch": ["a://b/RegistrationCertificatePurpose*.schema.json"],
+    "fileMatch": [
+      "a://b/RegistrationCertificatePurpose*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificatePurpose.schema.json",
@@ -4374,13 +5046,18 @@
           "type": "string"
         }
       },
-      "required": ["lang", "content"],
+      "required": [
+        "lang",
+        "content"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateBody.schema.json",
-    "fileMatch": ["a://b/RegistrationCertificateBody*.schema.json"],
+    "fileMatch": [
+      "a://b/RegistrationCertificateBody*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateBody.schema.json",
@@ -4420,7 +5097,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateRequest.schema.json",
-    "fileMatch": ["a://b/RegistrationCertificateRequest*.schema.json"],
+    "fileMatch": [
+      "a://b/RegistrationCertificateRequest*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateRequest.schema.json",
@@ -4449,7 +5128,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationAttachment.schema.json",
-    "fileMatch": ["a://b/PresentationAttachment*.schema.json"],
+    "fileMatch": [
+      "a://b/PresentationAttachment*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationAttachment.schema.json",
@@ -4469,13 +5150,18 @@
           }
         }
       },
-      "required": ["format", "data"],
+      "required": [
+        "format",
+        "data"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfig.schema.json",
-    "fileMatch": ["a://b/PresentationConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/PresentationConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfig.schema.json",
@@ -4575,13 +5261,21 @@
           "description": "Optional ID of the access certificate to use for signing the presentation request.\nIf not provided, the default access certificate for the tenant will be used.\n\nNote: This is intentionally NOT a TypeORM relationship because CertEntity uses\na composite primary key (id + tenantId), and SQLite cannot create foreign keys\nthat reference only part of a composite primary key. The relationship is handled\nat the application level in the service layer."
         }
       },
-      "required": ["id", "tenant", "dcql_query", "createdAt", "updatedAt"],
+      "required": [
+        "id",
+        "tenant",
+        "dcql_query",
+        "createdAt",
+        "updatedAt"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ResolveIssuerMetadataDto.schema.json",
-    "fileMatch": ["a://b/ResolveIssuerMetadataDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ResolveIssuerMetadataDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ResolveIssuerMetadataDto.schema.json",
@@ -4595,13 +5289,17 @@
           "example": "https://issuer.example.com/issuers/tenant-a"
         }
       },
-      "required": ["issuerUrl"],
+      "required": [
+        "issuerUrl"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ResolveSchemaMetadataDto.schema.json",
-    "fileMatch": ["a://b/ResolveSchemaMetadataDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ResolveSchemaMetadataDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ResolveSchemaMetadataDto.schema.json",
@@ -4615,13 +5313,17 @@
           "example": "https://registrar.example.com/schema-metadata/5c0d7dbb-ef2e-448b-b84f-b8103575947b"
         }
       },
-      "required": ["schemaMetadataUrl"],
+      "required": [
+        "schemaMetadataUrl"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfigCreateDto.schema.json",
-    "fileMatch": ["a://b/PresentationConfigCreateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/PresentationConfigCreateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfigCreateDto.schema.json",
@@ -4695,13 +5397,18 @@
           "description": "Optional ID of the access certificate to use for signing the presentation request.\nIf not provided, the default access certificate for the tenant will be used.\n\nNote: This is intentionally NOT a TypeORM relationship because CertEntity uses\na composite primary key (id + tenantId), and SQLite cannot create foreign keys\nthat reference only part of a composite primary key. The relationship is handled\nat the application level in the service layer."
         }
       },
-      "required": ["id", "dcql_query"],
+      "required": [
+        "id",
+        "dcql_query"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfigUpdateDto.schema.json",
-    "fileMatch": ["a://b/PresentationConfigUpdateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/PresentationConfigUpdateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfigUpdateDto.schema.json",
@@ -4780,7 +5487,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateDefaults.schema.json",
-    "fileMatch": ["a://b/RegistrationCertificateDefaults*.schema.json"],
+    "fileMatch": [
+      "a://b/RegistrationCertificateDefaults*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateDefaults.schema.json",
@@ -4803,7 +5512,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrarConfigResponseDto.schema.json",
-    "fileMatch": ["a://b/RegistrarConfigResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/RegistrarConfigResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrarConfigResponseDto.schema.json",
@@ -4851,13 +5562,21 @@
           "example": true
         }
       },
-      "required": ["registrarUrl", "oidcUrl", "clientId", "username", "hasPassword"],
+      "required": [
+        "registrarUrl",
+        "oidcUrl",
+        "clientId",
+        "username",
+        "hasPassword"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateRegistrarConfigDto.schema.json",
-    "fileMatch": ["a://b/CreateRegistrarConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CreateRegistrarConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateRegistrarConfigDto.schema.json",
@@ -4904,13 +5623,21 @@
           ]
         }
       },
-      "required": ["registrarUrl", "oidcUrl", "clientId", "username", "password"],
+      "required": [
+        "registrarUrl",
+        "oidcUrl",
+        "clientId",
+        "username",
+        "password"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateRegistrarConfigDto.schema.json",
-    "fileMatch": ["a://b/UpdateRegistrarConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateRegistrarConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateRegistrarConfigDto.schema.json",
@@ -4962,7 +5689,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateAccessCertificateDto.schema.json",
-    "fileMatch": ["a://b/CreateAccessCertificateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CreateAccessCertificateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateAccessCertificateDto.schema.json",
@@ -4975,13 +5704,17 @@
           "example": "my-signing-key"
         }
       },
-      "required": ["keyId"],
+      "required": [
+        "keyId"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeferredCredentialRequestDto.schema.json",
-    "fileMatch": ["a://b/DeferredCredentialRequestDto*.schema.json"],
+    "fileMatch": [
+      "a://b/DeferredCredentialRequestDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeferredCredentialRequestDto.schema.json",
@@ -4994,13 +5727,17 @@
           "example": "8xLOxBtZp8"
         }
       },
-      "required": ["transaction_id"],
+      "required": [
+        "transaction_id"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/NotificationRequestDto.schema.json",
-    "fileMatch": ["a://b/NotificationRequestDto*.schema.json"],
+    "fileMatch": [
+      "a://b/NotificationRequestDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/NotificationRequestDto.schema.json",
@@ -5014,13 +5751,18 @@
           "type": "object"
         }
       },
-      "required": ["notification_id", "event"],
+      "required": [
+        "notification_id",
+        "event"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Object.schema.json",
-    "fileMatch": ["a://b/Object*.schema.json"],
+    "fileMatch": [
+      "a://b/Object*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Object.schema.json",
@@ -5032,7 +5774,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ParResponseDto.schema.json",
-    "fileMatch": ["a://b/ParResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ParResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ParResponseDto.schema.json",
@@ -5048,13 +5792,18 @@
           "description": "The expiration time for the request URI in seconds."
         }
       },
-      "required": ["request_uri", "expires_in"],
+      "required": [
+        "request_uri",
+        "expires_in"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationRequestDto.schema.json",
-    "fileMatch": ["a://b/InteractiveAuthorizationRequestDto*.schema.json"],
+    "fileMatch": [
+      "a://b/InteractiveAuthorizationRequestDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationRequestDto.schema.json",
@@ -5127,7 +5876,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationCodeResponseDto.schema.json",
-    "fileMatch": ["a://b/InteractiveAuthorizationCodeResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/InteractiveAuthorizationCodeResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationCodeResponseDto.schema.json",
@@ -5145,13 +5896,18 @@
           "example": "auth-code-123"
         }
       },
-      "required": ["status", "code"],
+      "required": [
+        "status",
+        "code"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationErrorResponseDto.schema.json",
-    "fileMatch": ["a://b/InteractiveAuthorizationErrorResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/InteractiveAuthorizationErrorResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationErrorResponseDto.schema.json",
@@ -5169,13 +5925,17 @@
           "example": "Missing required parameter: interaction_types_supported"
         }
       },
-      "required": ["error"],
+      "required": [
+        "error"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsParResponseDto.schema.json",
-    "fileMatch": ["a://b/ChainedAsParResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ChainedAsParResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsParResponseDto.schema.json",
@@ -5193,13 +5953,18 @@
           "example": 600
         }
       },
-      "required": ["request_uri", "expires_in"],
+      "required": [
+        "request_uri",
+        "expires_in"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsErrorResponseDto.schema.json",
-    "fileMatch": ["a://b/ChainedAsErrorResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ChainedAsErrorResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsErrorResponseDto.schema.json",
@@ -5216,13 +5981,17 @@
           "description": "Human-readable error description"
         }
       },
-      "required": ["error"],
+      "required": [
+        "error"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenRequestDto.schema.json",
-    "fileMatch": ["a://b/ChainedAsTokenRequestDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ChainedAsTokenRequestDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenRequestDto.schema.json",
@@ -5255,13 +6024,17 @@
           "description": "PKCE code verifier"
         }
       },
-      "required": ["grant_type"],
+      "required": [
+        "grant_type"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenResponseDto.schema.json",
-    "fileMatch": ["a://b/ChainedAsTokenResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ChainedAsTokenResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenResponseDto.schema.json",
@@ -5306,13 +6079,19 @@
           "description": "Refresh token (issued when refresh tokens are enabled)"
         }
       },
-      "required": ["access_token", "token_type", "expires_in"],
+      "required": [
+        "access_token",
+        "token_type",
+        "expires_in"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/OfferResponse.schema.json",
-    "fileMatch": ["a://b/OfferResponse*.schema.json"],
+    "fileMatch": [
+      "a://b/OfferResponse*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/OfferResponse.schema.json",
@@ -5330,13 +6109,18 @@
           "type": "string"
         }
       },
-      "required": ["uri", "session"],
+      "required": [
+        "uri",
+        "session"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CompleteDeferredDto.schema.json",
-    "fileMatch": ["a://b/CompleteDeferredDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CompleteDeferredDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CompleteDeferredDto.schema.json",
@@ -5353,13 +6137,17 @@
           }
         }
       },
-      "required": ["claims"],
+      "required": [
+        "claims"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeferredOperationResponse.schema.json",
-    "fileMatch": ["a://b/DeferredOperationResponse*.schema.json"],
+    "fileMatch": [
+      "a://b/DeferredOperationResponse*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeferredOperationResponse.schema.json",
@@ -5372,7 +6160,13 @@
         },
         "status": {
           "description": "The new status of the transaction",
-          "enum": ["pending", "ready", "retrieved", "expired", "failed"],
+          "enum": [
+            "pending",
+            "ready",
+            "retrieved",
+            "expired",
+            "failed"
+          ],
           "type": "string"
         },
         "message": {
@@ -5380,13 +6174,18 @@
           "description": "Optional message"
         }
       },
-      "required": ["transactionId", "status"],
+      "required": [
+        "transactionId",
+        "status"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FailDeferredDto.schema.json",
-    "fileMatch": ["a://b/FailDeferredDto*.schema.json"],
+    "fileMatch": [
+      "a://b/FailDeferredDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FailDeferredDto.schema.json",
@@ -5404,7 +6203,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EC_Public.schema.json",
-    "fileMatch": ["a://b/EC_Public*.schema.json"],
+    "fileMatch": [
+      "a://b/EC_Public*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EC_Public.schema.json",
@@ -5428,13 +6229,20 @@
           "description": "The y coordinate of the EC public key."
         }
       },
-      "required": ["kty", "crv", "x", "y"],
+      "required": [
+        "kty",
+        "crv",
+        "x",
+        "y"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/JwksResponseDto.schema.json",
-    "fileMatch": ["a://b/JwksResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/JwksResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/JwksResponseDto.schema.json",
@@ -5449,13 +6257,17 @@
           }
         }
       },
-      "required": ["keys"],
+      "required": [
+        "keys"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthorizationResponse.schema.json",
-    "fileMatch": ["a://b/AuthorizationResponse*.schema.json"],
+    "fileMatch": [
+      "a://b/AuthorizationResponse*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthorizationResponse.schema.json",
@@ -5491,7 +6303,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProviderCapabilitiesDto.schema.json",
-    "fileMatch": ["a://b/KmsProviderCapabilitiesDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KmsProviderCapabilitiesDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProviderCapabilitiesDto.schema.json",
@@ -5514,13 +6328,19 @@
           "example": true
         }
       },
-      "required": ["canImport", "canCreate", "canDelete"],
+      "required": [
+        "canImport",
+        "canCreate",
+        "canDelete"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProviderInfoDto.schema.json",
-    "fileMatch": ["a://b/KmsProviderInfoDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KmsProviderInfoDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProviderInfoDto.schema.json",
@@ -5551,13 +6371,19 @@
           ]
         }
       },
-      "required": ["name", "type", "capabilities"],
+      "required": [
+        "name",
+        "type",
+        "capabilities"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProvidersResponseDto.schema.json",
-    "fileMatch": ["a://b/KmsProvidersResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KmsProvidersResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProvidersResponseDto.schema.json",
@@ -5577,13 +6403,18 @@
           "example": "db"
         }
       },
-      "required": ["providers", "default"],
+      "required": [
+        "providers",
+        "default"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CertificateInfoDto.schema.json",
-    "fileMatch": ["a://b/CertificateInfoDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CertificateInfoDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CertificateInfoDto.schema.json",
@@ -5617,13 +6448,17 @@
           "description": "Serial number."
         }
       },
-      "required": ["pem"],
+      "required": [
+        "pem"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PublicKeyInfoDto.schema.json",
-    "fileMatch": ["a://b/PublicKeyInfoDto*.schema.json"],
+    "fileMatch": [
+      "a://b/PublicKeyInfoDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PublicKeyInfoDto.schema.json",
@@ -5650,13 +6485,17 @@
           "example": "P-256"
         }
       },
-      "required": ["kty"],
+      "required": [
+        "kty"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyResponseDto.schema.json",
-    "fileMatch": ["a://b/RotationPolicyResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/RotationPolicyResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyResponseDto.schema.json",
@@ -5681,13 +6520,17 @@
           "description": "Next scheduled rotation date."
         }
       },
-      "required": ["enabled"],
+      "required": [
+        "enabled"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainResponseDto.schema.json",
-    "fileMatch": ["a://b/KeyChainResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KeyChainResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainResponseDto.schema.json",
@@ -5699,12 +6542,21 @@
           "description": "Unique identifier for the key chain."
         },
         "usageType": {
-          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"],
+          "enum": [
+            "access",
+            "attestation",
+            "trustList",
+            "statusList",
+            "encrypt"
+          ],
           "type": "string",
           "description": "Usage type of the key chain."
         },
         "type": {
-          "enum": ["standalone", "internalChain"],
+          "enum": [
+            "standalone",
+            "internalChain"
+          ],
           "type": "string",
           "description": "Type of key chain (standalone or internalChain)."
         },
@@ -5795,7 +6647,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExportEcJwk.schema.json",
-    "fileMatch": ["a://b/ExportEcJwk*.schema.json"],
+    "fileMatch": [
+      "a://b/ExportEcJwk*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExportEcJwk.schema.json",
@@ -5834,13 +6688,21 @@
           "description": "Key ID"
         }
       },
-      "required": ["kty", "crv", "x", "y", "d"],
+      "required": [
+        "kty",
+        "crv",
+        "x",
+        "y",
+        "d"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExportRotationPolicyDto.schema.json",
-    "fileMatch": ["a://b/ExportRotationPolicyDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ExportRotationPolicyDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExportRotationPolicyDto.schema.json",
@@ -5860,13 +6722,17 @@
           "description": "Certificate validity in days."
         }
       },
-      "required": ["enabled"],
+      "required": [
+        "enabled"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainExportDto.schema.json",
-    "fileMatch": ["a://b/KeyChainExportDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KeyChainExportDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainExportDto.schema.json",
@@ -5882,7 +6748,13 @@
           "description": "Human-readable description."
         },
         "usageType": {
-          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"],
+          "enum": [
+            "access",
+            "attestation",
+            "trustList",
+            "statusList",
+            "encrypt"
+          ],
           "type": "string",
           "description": "Usage type for this key chain."
         },
@@ -5914,13 +6786,19 @@
           ]
         }
       },
-      "required": ["id", "usageType", "key"],
+      "required": [
+        "id",
+        "usageType",
+        "key"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyCreateDto.schema.json",
-    "fileMatch": ["a://b/RotationPolicyCreateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/RotationPolicyCreateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyCreateDto.schema.json",
@@ -5947,13 +6825,17 @@
           "example": 365
         }
       },
-      "required": ["enabled"],
+      "required": [
+        "enabled"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainCreateDto.schema.json",
-    "fileMatch": ["a://b/KeyChainCreateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KeyChainCreateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainCreateDto.schema.json",
@@ -5961,13 +6843,22 @@
       "type": "object",
       "properties": {
         "usageType": {
-          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"],
+          "enum": [
+            "access",
+            "attestation",
+            "trustList",
+            "statusList",
+            "encrypt"
+          ],
           "type": "string",
           "description": "Usage type determines the purpose of this key chain (access, attestation, etc.).",
           "example": "attestation"
         },
         "type": {
-          "enum": ["standalone", "internalChain"],
+          "enum": [
+            "standalone",
+            "internalChain"
+          ],
           "type": "string",
           "description": "Type of key chain to create.",
           "example": "internalChain"
@@ -5991,13 +6882,18 @@
           ]
         }
       },
-      "required": ["usageType", "type"],
+      "required": [
+        "usageType",
+        "type"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EcJwk.schema.json",
-    "fileMatch": ["a://b/EcJwk*.schema.json"],
+    "fileMatch": [
+      "a://b/EcJwk*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EcJwk.schema.json",
@@ -6026,13 +6922,21 @@
           "type": "string"
         }
       },
-      "required": ["kty", "x", "y", "crv", "d"],
+      "required": [
+        "kty",
+        "x",
+        "y",
+        "crv",
+        "d"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyImportDto.schema.json",
-    "fileMatch": ["a://b/RotationPolicyImportDto*.schema.json"],
+    "fileMatch": [
+      "a://b/RotationPolicyImportDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyImportDto.schema.json",
@@ -6059,13 +6963,17 @@
           "example": 365
         }
       },
-      "required": ["enabled"],
+      "required": [
+        "enabled"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainImportDto.schema.json",
-    "fileMatch": ["a://b/KeyChainImportDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KeyChainImportDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainImportDto.schema.json",
@@ -6089,7 +6997,13 @@
           "description": "Human-readable description."
         },
         "usageType": {
-          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"],
+          "enum": [
+            "access",
+            "attestation",
+            "trustList",
+            "statusList",
+            "encrypt"
+          ],
           "type": "string",
           "description": "Usage type for this key chain."
         },
@@ -6113,13 +7027,18 @@
           ]
         }
       },
-      "required": ["key", "usageType"],
+      "required": [
+        "key",
+        "usageType"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyUpdateDto.schema.json",
-    "fileMatch": ["a://b/RotationPolicyUpdateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/RotationPolicyUpdateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyUpdateDto.schema.json",
@@ -6148,7 +7067,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainUpdateDto.schema.json",
-    "fileMatch": ["a://b/KeyChainUpdateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KeyChainUpdateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainUpdateDto.schema.json",
@@ -6177,7 +7098,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationRequest.schema.json",
-    "fileMatch": ["a://b/PresentationRequest*.schema.json"],
+    "fileMatch": [
+      "a://b/PresentationRequest*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationRequest.schema.json",
@@ -6187,7 +7110,10 @@
         "response_type": {
           "type": "string",
           "description": "The type of response expected from the presentation request.",
-          "enum": ["uri", "dc-api"]
+          "enum": [
+            "uri",
+            "dc-api"
+          ]
         },
         "requestId": {
           "type": "string",
@@ -6214,13 +7140,18 @@
           }
         }
       },
-      "required": ["response_type", "requestId"],
+      "required": [
+        "response_type",
+        "requestId"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FileUploadDto.schema.json",
-    "fileMatch": ["a://b/FileUploadDto*.schema.json"],
+    "fileMatch": [
+      "a://b/FileUploadDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FileUploadDto.schema.json",
@@ -6232,7 +7163,9 @@
           "format": "binary"
         }
       },
-      "required": ["file"],
+      "required": [
+        "file"
+      ],
       "additionalProperties": false
     }
   }

--- a/apps/client/src/app/utils/schemas.json
+++ b/apps/client/src/app/utils/schemas.json
@@ -1,9 +1,7 @@
 [
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/GrafanaConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/GrafanaConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/GrafanaConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/GrafanaConfigDto.schema.json",
@@ -26,18 +24,13 @@
           "example": "loki"
         }
       },
-      "required": [
-        "tempoUid",
-        "lokiUid"
-      ],
+      "required": ["tempoUid", "lokiUid"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FrontendConfigResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/FrontendConfigResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/FrontendConfigResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FrontendConfigResponseDto.schema.json",
@@ -53,17 +46,13 @@
           ]
         }
       },
-      "required": [
-        "grafana"
-      ],
+      "required": ["grafana"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RoleDto.schema.json",
-    "fileMatch": [
-      "a://b/RoleDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/RoleDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RoleDto.schema.json",
@@ -86,17 +75,13 @@
           "example": "issuance:manage"
         }
       },
-      "required": [
-        "role"
-      ],
+      "required": ["role"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientCredentialsDto.schema.json",
-    "fileMatch": [
-      "a://b/ClientCredentialsDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ClientCredentialsDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientCredentialsDto.schema.json",
@@ -114,18 +99,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "client_id",
-        "client_secret"
-      ],
+      "required": ["client_id", "client_secret"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TokenResponse.schema.json",
-    "fileMatch": [
-      "a://b/TokenResponse*.schema.json"
-    ],
+    "fileMatch": ["a://b/TokenResponse*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TokenResponse.schema.json",
@@ -145,19 +125,13 @@
           "type": "number"
         }
       },
-      "required": [
-        "access_token",
-        "token_type",
-        "expires_in"
-      ],
+      "required": ["access_token", "token_type", "expires_in"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ImportTenantDto.schema.json",
-    "fileMatch": [
-      "a://b/ImportTenantDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ImportTenantDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ImportTenantDto.schema.json",
@@ -173,17 +147,13 @@
           "description": "The description of the tenant."
         }
       },
-      "required": [
-        "name"
-      ],
+      "required": ["name"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SessionStorageConfig.schema.json",
-    "fileMatch": [
-      "a://b/SessionStorageConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/SessionStorageConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SessionStorageConfig.schema.json",
@@ -199,10 +169,7 @@
         "cleanupMode": {
           "type": "string",
           "description": "Cleanup mode: 'full' deletes everything, 'anonymize' keeps metadata but removes PII.",
-          "enum": [
-            "full",
-            "anonymize"
-          ],
+          "enum": ["full", "anonymize"],
           "default": "full"
         }
       },
@@ -211,9 +178,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListConfig.schema.json",
-    "fileMatch": [
-      "a://b/StatusListConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/StatusListConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListConfig.schema.json",
@@ -229,12 +194,7 @@
         "bits": {
           "type": "number",
           "description": "Bits per status entry: 1 (valid/revoked), 2 (with suspended), 4/8 (extended). If not set, uses global STATUS_BITS.",
-          "enum": [
-            1,
-            2,
-            4,
-            8
-          ],
+          "enum": [1, 2, 4, 8],
           "default": 1
         },
         "ttl": {
@@ -259,9 +219,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TenantEntity.schema.json",
-    "fileMatch": [
-      "a://b/TenantEntity*.schema.json"
-    ],
+    "fileMatch": ["a://b/TenantEntity*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TenantEntity.schema.json",
@@ -312,20 +270,13 @@
           }
         }
       },
-      "required": [
-        "id",
-        "name",
-        "status",
-        "clients"
-      ],
+      "required": ["id", "name", "status", "clients"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientEntity.schema.json",
-    "fileMatch": [
-      "a://b/ClientEntity*.schema.json"
-    ],
+    "fileMatch": ["a://b/ClientEntity*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientEntity.schema.json",
@@ -335,10 +286,7 @@
         "allowedPresentationConfigs": {
           "nullable": true,
           "description": "List of presentation config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": [
-            "age-verification",
-            "kyc-basic"
-          ],
+          "example": ["age-verification", "kyc-basic"],
           "type": "array",
           "items": {
             "type": "string"
@@ -347,10 +295,7 @@
         "allowedIssuanceConfigs": {
           "nullable": true,
           "description": "List of issuance config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": [
-            "pid",
-            "mdl"
-          ],
+          "example": ["pid", "mdl"],
           "type": "array",
           "items": {
             "type": "string"
@@ -398,18 +343,13 @@
           ]
         }
       },
-      "required": [
-        "clientId",
-        "roles"
-      ],
+      "required": ["clientId", "roles"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateTenantDto.schema.json",
-    "fileMatch": [
-      "a://b/CreateTenantDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CreateTenantDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateTenantDto.schema.json",
@@ -463,18 +403,13 @@
           }
         }
       },
-      "required": [
-        "id",
-        "name"
-      ],
+      "required": ["id", "name"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateTenantDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateTenantDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateTenantDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateTenantDto.schema.json",
@@ -529,9 +464,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuditLogResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/AuditLogResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/AuditLogResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuditLogResponseDto.schema.json",
@@ -569,11 +502,7 @@
         },
         "actorType": {
           "type": "string",
-          "enum": [
-            "user",
-            "client",
-            "system"
-          ]
+          "enum": ["user", "client", "system"]
         },
         "actorId": {
           "type": "string"
@@ -603,21 +532,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "id",
-        "tenantId",
-        "actionType",
-        "actorType",
-        "timestamp"
-      ],
+      "required": ["id", "tenantId", "actionType", "actorType", "timestamp"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientSecretResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/ClientSecretResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ClientSecretResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientSecretResponseDto.schema.json",
@@ -628,17 +549,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "secret"
-      ],
+      "required": ["secret"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateClientDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateClientDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateClientDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateClientDto.schema.json",
@@ -648,10 +565,7 @@
         "allowedPresentationConfigs": {
           "nullable": true,
           "description": "List of presentation config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": [
-            "age-verification",
-            "kyc-basic"
-          ],
+          "example": ["age-verification", "kyc-basic"],
           "type": "array",
           "items": {
             "type": "string"
@@ -660,10 +574,7 @@
         "allowedIssuanceConfigs": {
           "nullable": true,
           "description": "List of issuance config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": [
-            "pid",
-            "mdl"
-          ],
+          "example": ["pid", "mdl"],
           "type": "array",
           "items": {
             "type": "string"
@@ -691,17 +602,13 @@
           }
         }
       },
-      "required": [
-        "roles"
-      ],
+      "required": ["roles"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateClientDto.schema.json",
-    "fileMatch": [
-      "a://b/CreateClientDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CreateClientDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateClientDto.schema.json",
@@ -711,10 +618,7 @@
         "allowedPresentationConfigs": {
           "nullable": true,
           "description": "List of presentation config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": [
-            "age-verification",
-            "kyc-basic"
-          ],
+          "example": ["age-verification", "kyc-basic"],
           "type": "array",
           "items": {
             "type": "string"
@@ -723,10 +627,7 @@
         "allowedIssuanceConfigs": {
           "nullable": true,
           "description": "List of issuance config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": [
-            "pid",
-            "mdl"
-          ],
+          "example": ["pid", "mdl"],
           "type": "array",
           "items": {
             "type": "string"
@@ -762,18 +663,13 @@
           }
         }
       },
-      "required": [
-        "clientId",
-        "roles"
-      ],
+      "required": ["clientId", "roles"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListImportDto.schema.json",
-    "fileMatch": [
-      "a://b/StatusListImportDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/StatusListImportDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListImportDto.schema.json",
@@ -804,26 +700,17 @@
         "bits": {
           "type": "number",
           "description": "Bits per status value. If not provided, uses tenant or global defaults.",
-          "enum": [
-            1,
-            2,
-            4,
-            8
-          ],
+          "enum": [1, 2, 4, 8],
           "example": 1
         }
       },
-      "required": [
-        "id"
-      ],
+      "required": ["id"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListAggregationDto.schema.json",
-    "fileMatch": [
-      "a://b/StatusListAggregationDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/StatusListAggregationDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListAggregationDto.schema.json",
@@ -842,17 +729,13 @@
           }
         }
       },
-      "required": [
-        "status_lists"
-      ],
+      "required": ["status_lists"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateStatusListConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateStatusListConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateStatusListConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateStatusListConfigDto.schema.json",
@@ -870,12 +753,7 @@
           "type": "number",
           "nullable": true,
           "description": "Bits per status entry. Set to null to reset to global default.",
-          "enum": [
-            1,
-            2,
-            4,
-            8
-          ]
+          "enum": [1, 2, 4, 8]
         },
         "ttl": {
           "type": "number",
@@ -900,9 +778,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/StatusListResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/StatusListResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListResponseDto.schema.json",
@@ -934,12 +810,7 @@
         "bits": {
           "type": "number",
           "description": "Bits per status value",
-          "enum": [
-            1,
-            2,
-            4,
-            8
-          ],
+          "enum": [1, 2, 4, 8],
           "example": 1
         },
         "capacity": {
@@ -991,9 +862,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateStatusListDto.schema.json",
-    "fileMatch": [
-      "a://b/CreateStatusListDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CreateStatusListDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateStatusListDto.schema.json",
@@ -1013,12 +882,7 @@
         "bits": {
           "type": "number",
           "description": "Bits per status value. More bits allow more status states. Defaults to tenant configuration.",
-          "enum": [
-            1,
-            2,
-            4,
-            8
-          ],
+          "enum": [1, 2, 4, 8],
           "example": 1
         },
         "capacity": {
@@ -1033,9 +897,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateStatusListDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateStatusListDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateStatusListDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateStatusListDto.schema.json",
@@ -1060,9 +922,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthorizeQueries.schema.json",
-    "fileMatch": [
-      "a://b/AuthorizeQueries*.schema.json"
-    ],
+    "fileMatch": ["a://b/AuthorizeQueries*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthorizeQueries.schema.json",
@@ -1115,9 +975,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/OfferRequestDto.schema.json",
-    "fileMatch": [
-      "a://b/OfferRequestDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/OfferRequestDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/OfferRequestDto.schema.json",
@@ -1125,10 +983,7 @@
       "type": "object",
       "properties": {
         "response_type": {
-          "enum": [
-            "uri",
-            "dc-api"
-          ],
+          "enum": ["uri", "dc-api"],
           "type": "string",
           "examples": [
             {
@@ -1148,19 +1003,14 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": [
-                        "inline"
-                      ]
+                      "enum": ["inline"]
                     },
                     "claims": {
                       "type": "object",
                       "additionalProperties": true
                     }
                   },
-                  "required": [
-                    "type",
-                    "claims"
-                  ],
+                  "required": ["type", "claims"],
                   "additionalProperties": false
                 },
                 {
@@ -1168,18 +1018,13 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": [
-                        "attributeProvider"
-                      ]
+                      "enum": ["attributeProvider"]
                     },
                     "attributeProviderId": {
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "type",
-                    "attributeProviderId"
-                  ],
+                  "required": ["type", "attributeProviderId"],
                   "additionalProperties": false
                 },
                 {
@@ -1187,9 +1032,7 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": [
-                        "webhook"
-                      ]
+                      "enum": ["webhook"]
                     },
                     "webhook": {
                       "type": "object",
@@ -1201,16 +1044,11 @@
                           "type": "object"
                         }
                       },
-                      "required": [
-                        "url"
-                      ],
+                      "required": ["url"],
                       "additionalProperties": false
                     }
                   },
-                  "required": [
-                    "type",
-                    "webhook"
-                  ],
+                  "required": ["type", "webhook"],
                   "additionalProperties": false
                 }
               ]
@@ -1229,10 +1067,7 @@
         },
         "flow": {
           "description": "The flow type for the offer request.",
-          "enum": [
-            "authorization_code",
-            "pre_authorized_code"
-          ],
+          "enum": ["authorization_code", "pre_authorized_code"],
           "type": "string"
         },
         "tx_code": {
@@ -1259,19 +1094,13 @@
           "description": "ID of the webhook endpoint to notify about the status of the issuance process."
         }
       },
-      "required": [
-        "response_type",
-        "flow",
-        "credentialConfigurationIds"
-      ],
+      "required": ["response_type", "flow", "credentialConfigurationIds"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebHookAuthConfigNone.schema.json",
-    "fileMatch": [
-      "a://b/WebHookAuthConfigNone*.schema.json"
-    ],
+    "fileMatch": ["a://b/WebHookAuthConfigNone*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebHookAuthConfigNone.schema.json",
@@ -1281,22 +1110,16 @@
         "type": {
           "type": "string",
           "description": "The type of authentication used for the webhook.",
-          "enum": [
-            "none"
-          ]
+          "enum": ["none"]
         }
       },
-      "required": [
-        "type"
-      ],
+      "required": ["type"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ApiKeyConfig.schema.json",
-    "fileMatch": [
-      "a://b/ApiKeyConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/ApiKeyConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ApiKeyConfig.schema.json",
@@ -1312,18 +1135,13 @@
           "description": "The value of the API key to be sent in the header."
         }
       },
-      "required": [
-        "headerName",
-        "value"
-      ],
+      "required": ["headerName", "value"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebHookAuthConfigHeader.schema.json",
-    "fileMatch": [
-      "a://b/WebHookAuthConfigHeader*.schema.json"
-    ],
+    "fileMatch": ["a://b/WebHookAuthConfigHeader*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebHookAuthConfigHeader.schema.json",
@@ -1333,9 +1151,7 @@
         "type": {
           "type": "string",
           "description": "The type of authentication used for the webhook.",
-          "enum": [
-            "apiKey"
-          ]
+          "enum": ["apiKey"]
         },
         "config": {
           "description": "Configuration for API key authentication.\nThis is required if the type is 'apiKey'.",
@@ -1346,18 +1162,13 @@
           ]
         }
       },
-      "required": [
-        "type",
-        "config"
-      ],
+      "required": ["type", "config"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebhookConfig.schema.json",
-    "fileMatch": [
-      "a://b/WebhookConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/WebhookConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebhookConfig.schema.json",
@@ -1387,18 +1198,13 @@
           "description": "The URL to which the webhook will send notifications."
         }
       },
-      "required": [
-        "auth",
-        "url"
-      ],
+      "required": ["auth", "url"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TransactionData.schema.json",
-    "fileMatch": [
-      "a://b/TransactionData*.schema.json"
-    ],
+    "fileMatch": ["a://b/TransactionData*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TransactionData.schema.json",
@@ -1415,18 +1221,13 @@
           }
         }
       },
-      "required": [
-        "type",
-        "credential_ids"
-      ],
+      "required": ["type", "credential_ids"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Session.schema.json",
-    "fileMatch": [
-      "a://b/Session*.schema.json"
-    ],
+    "fileMatch": ["a://b/Session*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Session.schema.json",
@@ -1435,13 +1236,7 @@
       "properties": {
         "status": {
           "description": "Status of the session.",
-          "enum": [
-            "active",
-            "fetched",
-            "completed",
-            "expired",
-            "failed"
-          ],
+          "enum": ["active", "fetched", "completed", "expired", "failed"],
           "type": "string"
         },
         "id": {
@@ -1630,9 +1425,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SessionLogEntryResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/SessionLogEntryResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/SessionLogEntryResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SessionLogEntryResponseDto.schema.json",
@@ -1655,11 +1448,7 @@
         "level": {
           "type": "string",
           "description": "Log level",
-          "enum": [
-            "info",
-            "warn",
-            "error"
-          ]
+          "enum": ["info", "warn", "error"]
         },
         "stage": {
           "type": "string",
@@ -1674,21 +1463,13 @@
           "description": "Additional structured detail"
         }
       },
-      "required": [
-        "id",
-        "sessionId",
-        "timestamp",
-        "level",
-        "message"
-      ],
+      "required": ["id", "sessionId", "timestamp", "level", "message"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusUpdateDto.schema.json",
-    "fileMatch": [
-      "a://b/StatusUpdateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/StatusUpdateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusUpdateDto.schema.json",
@@ -1708,18 +1489,13 @@
           "description": "The status of the credential\n0 = valid, 1 = revoked, 2 = suspended"
         }
       },
-      "required": [
-        "sessionId",
-        "status"
-      ],
+      "required": ["sessionId", "status"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateSessionConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateSessionConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateSessionConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateSessionConfigDto.schema.json",
@@ -1735,10 +1511,7 @@
         },
         "cleanupMode": {
           "description": "Cleanup mode: 'full' deletes everything, 'anonymize' keeps metadata but removes PII.",
-          "enum": [
-            "full",
-            "anonymize"
-          ],
+          "enum": ["full", "anonymize"],
           "type": "string",
           "default": "full"
         }
@@ -1748,9 +1521,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ManagedUserDto.schema.json",
-    "fileMatch": [
-      "a://b/ManagedUserDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ManagedUserDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ManagedUserDto.schema.json",
@@ -1799,20 +1570,13 @@
           "description": "One-time temporary password returned only on user creation."
         }
       },
-      "required": [
-        "id",
-        "username",
-        "enabled",
-        "roles"
-      ],
+      "required": ["id", "username", "enabled", "roles"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateUserDto.schema.json",
-    "fileMatch": [
-      "a://b/CreateUserDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CreateUserDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateUserDto.schema.json",
@@ -1854,18 +1618,13 @@
           "example": true
         }
       },
-      "required": [
-        "username",
-        "roles"
-      ],
+      "required": ["username", "roles"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateUserDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateUserDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateUserDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateUserDto.schema.json",
@@ -1917,9 +1676,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodNone.schema.json",
-    "fileMatch": [
-      "a://b/AuthenticationMethodNone*.schema.json"
-    ],
+    "fileMatch": ["a://b/AuthenticationMethodNone*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodNone.schema.json",
@@ -1928,22 +1685,16 @@
       "properties": {
         "method": {
           "type": "string",
-          "enum": [
-            "none"
-          ]
+          "enum": ["none"]
         }
       },
-      "required": [
-        "method"
-      ],
+      "required": ["method"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationUrlConfig.schema.json",
-    "fileMatch": [
-      "a://b/AuthenticationUrlConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/AuthenticationUrlConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationUrlConfig.schema.json",
@@ -1963,17 +1714,13 @@
           ]
         }
       },
-      "required": [
-        "url"
-      ],
+      "required": ["url"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodAuth.schema.json",
-    "fileMatch": [
-      "a://b/AuthenticationMethodAuth*.schema.json"
-    ],
+    "fileMatch": ["a://b/AuthenticationMethodAuth*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodAuth.schema.json",
@@ -1982,26 +1729,19 @@
       "properties": {
         "method": {
           "type": "string",
-          "enum": [
-            "auth"
-          ]
+          "enum": ["auth"]
         },
         "config": {
           "$ref": "./AuthenticationUrlConfig.schema.json"
         }
       },
-      "required": [
-        "method",
-        "config"
-      ],
+      "required": ["method", "config"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationDuringIssuanceConfig.schema.json",
-    "fileMatch": [
-      "a://b/PresentationDuringIssuanceConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/PresentationDuringIssuanceConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationDuringIssuanceConfig.schema.json",
@@ -2013,17 +1753,13 @@
           "description": "Link to the presentation configuration that is relevant for the issuance process"
         }
       },
-      "required": [
-        "type"
-      ],
+      "required": ["type"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodPresentation.schema.json",
-    "fileMatch": [
-      "a://b/AuthenticationMethodPresentation*.schema.json"
-    ],
+    "fileMatch": ["a://b/AuthenticationMethodPresentation*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodPresentation.schema.json",
@@ -2032,26 +1768,19 @@
       "properties": {
         "method": {
           "type": "string",
-          "enum": [
-            "presentationDuringIssuance"
-          ]
+          "enum": ["presentationDuringIssuance"]
         },
         "config": {
           "$ref": "./PresentationDuringIssuanceConfig.schema.json"
         }
       },
-      "required": [
-        "method",
-        "config"
-      ],
+      "required": ["method", "config"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpstreamOidcConfig.schema.json",
-    "fileMatch": [
-      "a://b/UpstreamOidcConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpstreamOidcConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpstreamOidcConfig.schema.json",
@@ -2075,28 +1804,20 @@
         },
         "scopes": {
           "description": "Scopes to request from the upstream provider",
-          "default": [
-            "openid",
-            "profile"
-          ],
+          "default": ["openid", "profile"],
           "type": "array",
           "items": {
             "type": "string"
           }
         }
       },
-      "required": [
-        "issuer",
-        "clientId"
-      ],
+      "required": ["issuer", "clientId"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenConfig.schema.json",
-    "fileMatch": [
-      "a://b/ChainedAsTokenConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/ChainedAsTokenConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenConfig.schema.json",
@@ -2119,9 +1840,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsConfig.schema.json",
-    "fileMatch": [
-      "a://b/ChainedAsConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/ChainedAsConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsConfig.schema.json",
@@ -2155,17 +1874,13 @@
           "default": true
         }
       },
-      "required": [
-        "enabled"
-      ],
+      "required": ["enabled"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FederationTrustAnchorConfig.schema.json",
-    "fileMatch": [
-      "a://b/FederationTrustAnchorConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/FederationTrustAnchorConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FederationTrustAnchorConfig.schema.json",
@@ -2183,18 +1898,13 @@
           "example": "https://ta.example.org/.well-known/openid-federation"
         }
       },
-      "required": [
-        "entityId",
-        "entityConfigurationUri"
-      ],
+      "required": ["entityId", "entityConfigurationUri"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FederationConfig.schema.json",
-    "fileMatch": [
-      "a://b/FederationConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/FederationConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FederationConfig.schema.json",
@@ -2202,20 +1912,13 @@
       "type": "object",
       "properties": {
         "role": {
-          "enum": [
-            "trust_anchor",
-            "intermediate",
-            "leaf"
-          ],
+          "enum": ["trust_anchor", "intermediate", "leaf"],
           "type": "string",
           "description": "Role this tenant plays in the OpenID Federation topology.",
           "default": "leaf"
         },
         "mode": {
-          "enum": [
-            "federation-only",
-            "hybrid"
-          ],
+          "enum": ["federation-only", "hybrid"],
           "type": "string",
           "description": "Trust decision strategy when both LoTE trust lists and OpenID Federation are configured.",
           "default": "hybrid"
@@ -2243,17 +1946,13 @@
           }
         }
       },
-      "required": [
-        "trustAnchors"
-      ],
+      "required": ["trustAnchors"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayLogo.schema.json",
-    "fileMatch": [
-      "a://b/DisplayLogo*.schema.json"
-    ],
+    "fileMatch": ["a://b/DisplayLogo*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayLogo.schema.json",
@@ -2267,17 +1966,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "uri"
-      ],
+      "required": ["uri"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayInfo.schema.json",
-    "fileMatch": [
-      "a://b/DisplayInfo*.schema.json"
-    ],
+    "fileMatch": ["a://b/DisplayInfo*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayInfo.schema.json",
@@ -2299,9 +1994,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuanceConfig.schema.json",
-    "fileMatch": [
-      "a://b/IssuanceConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/IssuanceConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuanceConfig.schema.json",
@@ -2414,20 +2107,13 @@
           "description": "The timestamp when the VP request was last updated."
         }
       },
-      "required": [
-        "tenant",
-        "display",
-        "createdAt",
-        "updatedAt"
-      ],
+      "required": ["tenant", "display", "createdAt", "updatedAt"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuanceDto.schema.json",
-    "fileMatch": [
-      "a://b/IssuanceDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/IssuanceDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuanceDto.schema.json",
@@ -2522,17 +2208,13 @@
           }
         }
       },
-      "required": [
-        "display"
-      ],
+      "required": ["display"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClaimsQuery.schema.json",
-    "fileMatch": [
-      "a://b/ClaimsQuery*.schema.json"
-    ],
+    "fileMatch": ["a://b/ClaimsQuery*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClaimsQuery.schema.json",
@@ -2555,17 +2237,13 @@
           }
         }
       },
-      "required": [
-        "path"
-      ],
+      "required": ["path"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustedAuthorityQuery.schema.json",
-    "fileMatch": [
-      "a://b/TrustedAuthorityQuery*.schema.json"
-    ],
+    "fileMatch": ["a://b/TrustedAuthorityQuery*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustedAuthorityQuery.schema.json",
@@ -2574,10 +2252,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": [
-            "etsi_tl",
-            "openid_federation"
-          ]
+          "enum": ["etsi_tl", "openid_federation"]
         },
         "values": {
           "type": "array",
@@ -2586,18 +2261,13 @@
           }
         }
       },
-      "required": [
-        "type",
-        "values"
-      ],
+      "required": ["type", "values"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialQuery.schema.json",
-    "fileMatch": [
-      "a://b/CredentialQuery*.schema.json"
-    ],
+    "fileMatch": ["a://b/CredentialQuery*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialQuery.schema.json",
@@ -2629,19 +2299,13 @@
           }
         }
       },
-      "required": [
-        "id",
-        "format",
-        "meta"
-      ],
+      "required": ["id", "format", "meta"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialSetQuery.schema.json",
-    "fileMatch": [
-      "a://b/CredentialSetQuery*.schema.json"
-    ],
+    "fileMatch": ["a://b/CredentialSetQuery*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialSetQuery.schema.json",
@@ -2661,17 +2325,13 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "options"
-      ],
+      "required": ["options"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PolicyCredential.schema.json",
-    "fileMatch": [
-      "a://b/PolicyCredential*.schema.json"
-    ],
+    "fileMatch": ["a://b/PolicyCredential*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PolicyCredential.schema.json",
@@ -2697,17 +2357,13 @@
           }
         }
       },
-      "required": [
-        "credentials"
-      ],
+      "required": ["credentials"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AttestationBasedPolicy.schema.json",
-    "fileMatch": [
-      "a://b/AttestationBasedPolicy*.schema.json"
-    ],
+    "fileMatch": ["a://b/AttestationBasedPolicy*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AttestationBasedPolicy.schema.json",
@@ -2716,9 +2372,7 @@
       "properties": {
         "policy": {
           "type": "string",
-          "enum": [
-            "attestationBased"
-          ]
+          "enum": ["attestationBased"]
         },
         "values": {
           "type": "array",
@@ -2727,18 +2381,13 @@
           }
         }
       },
-      "required": [
-        "policy",
-        "values"
-      ],
+      "required": ["policy", "values"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/NoneTrustPolicy.schema.json",
-    "fileMatch": [
-      "a://b/NoneTrustPolicy*.schema.json"
-    ],
+    "fileMatch": ["a://b/NoneTrustPolicy*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/NoneTrustPolicy.schema.json",
@@ -2747,22 +2396,16 @@
       "properties": {
         "policy": {
           "type": "string",
-          "enum": [
-            "none"
-          ]
+          "enum": ["none"]
         }
       },
-      "required": [
-        "policy"
-      ],
+      "required": ["policy"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AllowListPolicy.schema.json",
-    "fileMatch": [
-      "a://b/AllowListPolicy*.schema.json"
-    ],
+    "fileMatch": ["a://b/AllowListPolicy*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AllowListPolicy.schema.json",
@@ -2771,9 +2414,7 @@
       "properties": {
         "policy": {
           "type": "string",
-          "enum": [
-            "allowList"
-          ]
+          "enum": ["allowList"]
         },
         "values": {
           "type": "array",
@@ -2782,18 +2423,13 @@
           }
         }
       },
-      "required": [
-        "policy",
-        "values"
-      ],
+      "required": ["policy", "values"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RootOfTrustPolicy.schema.json",
-    "fileMatch": [
-      "a://b/RootOfTrustPolicy*.schema.json"
-    ],
+    "fileMatch": ["a://b/RootOfTrustPolicy*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RootOfTrustPolicy.schema.json",
@@ -2802,26 +2438,19 @@
       "properties": {
         "policy": {
           "type": "string",
-          "enum": [
-            "rootOfTrust"
-          ]
+          "enum": ["rootOfTrust"]
         },
         "values": {
           "type": "string"
         }
       },
-      "required": [
-        "policy",
-        "values"
-      ],
+      "required": ["policy", "values"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/VCT.schema.json",
-    "fileMatch": [
-      "a://b/VCT*.schema.json"
-    ],
+    "fileMatch": ["a://b/VCT*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/VCT.schema.json",
@@ -2855,9 +2484,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IaeActionOpenid4vpPresentation.schema.json",
-    "fileMatch": [
-      "a://b/IaeActionOpenid4vpPresentation*.schema.json"
-    ],
+    "fileMatch": ["a://b/IaeActionOpenid4vpPresentation*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IaeActionOpenid4vpPresentation.schema.json",
@@ -2865,9 +2492,7 @@
       "type": "object",
       "properties": {
         "type": {
-          "enum": [
-            "openid4vp_presentation"
-          ],
+          "enum": ["openid4vp_presentation"],
           "type": "string",
           "description": "Action type discriminator",
           "example": "openid4vp_presentation"
@@ -2883,18 +2508,13 @@
           "example": "pid-presentation-config"
         }
       },
-      "required": [
-        "type",
-        "presentationConfigId"
-      ],
+      "required": ["type", "presentationConfigId"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IaeActionRedirectToWeb.schema.json",
-    "fileMatch": [
-      "a://b/IaeActionRedirectToWeb*.schema.json"
-    ],
+    "fileMatch": ["a://b/IaeActionRedirectToWeb*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IaeActionRedirectToWeb.schema.json",
@@ -2902,9 +2522,7 @@
       "type": "object",
       "properties": {
         "type": {
-          "enum": [
-            "redirect_to_web"
-          ],
+          "enum": ["redirect_to_web"],
           "type": "string",
           "description": "Action type discriminator",
           "example": "redirect_to_web"
@@ -2932,18 +2550,13 @@
           "example": "Please complete the identity verification form"
         }
       },
-      "required": [
-        "type",
-        "url"
-      ],
+      "required": ["type", "url"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebhookEndpointEntity.schema.json",
-    "fileMatch": [
-      "a://b/WebhookEndpointEntity*.schema.json"
-    ],
+    "fileMatch": ["a://b/WebhookEndpointEntity*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebhookEndpointEntity.schema.json",
@@ -2981,22 +2594,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "id",
-        "auth",
-        "tenantId",
-        "tenant",
-        "name",
-        "url"
-      ],
+      "required": ["id", "auth", "tenantId", "tenant", "name", "url"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaUriEntry.schema.json",
-    "fileMatch": [
-      "a://b/SchemaUriEntry*.schema.json"
-    ],
+    "fileMatch": ["a://b/SchemaUriEntry*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaUriEntry.schema.json",
@@ -3023,17 +2627,13 @@
           "additionalProperties": true
         }
       },
-      "required": [
-        "meta"
-      ],
+      "required": ["meta"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustAuthorityEntry.schema.json",
-    "fileMatch": [
-      "a://b/TrustAuthorityEntry*.schema.json"
-    ],
+    "fileMatch": ["a://b/TrustAuthorityEntry*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustAuthorityEntry.schema.json",
@@ -3045,11 +2645,7 @@
           "description": "Trust list ID to resolve from the database. When set, frameworkType, value, and verificationMethod are derived automatically."
         },
         "frameworkType": {
-          "enum": [
-            "aki",
-            "etsi_tl",
-            "openid_federation"
-          ],
+          "enum": ["aki", "etsi_tl", "openid_federation"],
           "type": "string",
           "description": "Trust framework type (ignored when trustListId is set)"
         },
@@ -3072,9 +2668,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetaConfig.schema.json",
-    "fileMatch": [
-      "a://b/SchemaMetaConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/SchemaMetaConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetaConfig.schema.json",
@@ -3107,12 +2701,7 @@
           "description": "Attestation Level of Security"
         },
         "bindingType": {
-          "enum": [
-            "claim",
-            "key",
-            "biometric",
-            "none"
-          ],
+          "enum": ["claim", "key", "biometric", "none"],
           "type": "string",
           "description": "Cryptographic binding type"
         },
@@ -3136,9 +2725,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EmbeddedDisclosurePolicy.schema.json",
-    "fileMatch": [
-      "a://b/EmbeddedDisclosurePolicy*.schema.json"
-    ],
+    "fileMatch": ["a://b/EmbeddedDisclosurePolicy*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EmbeddedDisclosurePolicy.schema.json",
@@ -3149,17 +2736,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "policy"
-      ],
+      "required": ["policy"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyAttestationsRequired.schema.json",
-    "fileMatch": [
-      "a://b/KeyAttestationsRequired*.schema.json"
-    ],
+    "fileMatch": ["a://b/KeyAttestationsRequired*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyAttestationsRequired.schema.json",
@@ -3168,10 +2751,7 @@
       "properties": {
         "key_storage": {
           "description": "List of required key storage types (e.g., iso_18045_high, iso_18045_moderate)",
-          "example": [
-            "iso_18045_high",
-            "iso_18045_moderate"
-          ],
+          "example": ["iso_18045_high", "iso_18045_moderate"],
           "type": "array",
           "items": {
             "type": "string"
@@ -3179,10 +2759,7 @@
         },
         "user_authentication": {
           "description": "List of required user authentication types (e.g., iso_18045_high, iso_18045_moderate)",
-          "example": [
-            "iso_18045_high",
-            "iso_18045_moderate"
-          ],
+          "example": ["iso_18045_high", "iso_18045_moderate"],
           "type": "array",
           "items": {
             "type": "string"
@@ -3194,9 +2771,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayImage.schema.json",
-    "fileMatch": [
-      "a://b/DisplayImage*.schema.json"
-    ],
+    "fileMatch": ["a://b/DisplayImage*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayImage.schema.json",
@@ -3207,17 +2782,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "uri"
-      ],
+      "required": ["uri"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Display.schema.json",
-    "fileMatch": [
-      "a://b/Display*.schema.json"
-    ],
+    "fileMatch": ["a://b/Display*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Display.schema.json",
@@ -3246,19 +2817,13 @@
           "$ref": "./DisplayImage.schema.json"
         }
       },
-      "required": [
-        "name",
-        "description",
-        "locale"
-      ],
+      "required": ["name", "description", "locale"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerMetadataCredentialConfig.schema.json",
-    "fileMatch": [
-      "a://b/IssuerMetadataCredentialConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/IssuerMetadataCredentialConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerMetadataCredentialConfig.schema.json",
@@ -3275,10 +2840,7 @@
         },
         "format": {
           "type": "string",
-          "enum": [
-            "mso_mdoc",
-            "dc+sd-jwt"
-          ]
+          "enum": ["mso_mdoc", "dc+sd-jwt"]
         },
         "display": {
           "type": "array",
@@ -3294,18 +2856,13 @@
           "description": "Document type for mDOC credentials (e.g., \"org.iso.18013.5.1.mDL\").\nOnly applicable when format is \"mso_mdoc\"."
         }
       },
-      "required": [
-        "format",
-        "display"
-      ],
+      "required": ["format", "display"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FieldDisplayDto.schema.json",
-    "fileMatch": [
-      "a://b/FieldDisplayDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/FieldDisplayDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FieldDisplayDto.schema.json",
@@ -3328,18 +2885,13 @@
           "example": "Primary first name"
         }
       },
-      "required": [
-        "lang",
-        "label"
-      ],
+      "required": ["lang", "label"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClaimFieldDefinitionDto.schema.json",
-    "fileMatch": [
-      "a://b/ClaimFieldDefinitionDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ClaimFieldDefinitionDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClaimFieldDefinitionDto.schema.json",
@@ -3349,10 +2901,7 @@
         "path": {
           "type": "array",
           "description": "Path to claim value",
-          "example": [
-            "address",
-            "locality"
-          ],
+          "example": ["address", "locality"],
           "items": {
             "oneOf": [
               {
@@ -3369,15 +2918,7 @@
         },
         "type": {
           "type": "string",
-          "enum": [
-            "string",
-            "number",
-            "integer",
-            "boolean",
-            "object",
-            "array",
-            "date"
-          ],
+          "enum": ["string", "number", "integer", "boolean", "object", "array", "date"],
           "description": "Claim value type"
         },
         "defaultValue": {
@@ -3429,18 +2970,13 @@
           "description": "Additional JSON schema constraints for this field"
         }
       },
-      "required": [
-        "path",
-        "type"
-      ],
+      "required": ["path", "type"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AttributeProviderEntity.schema.json",
-    "fileMatch": [
-      "a://b/AttributeProviderEntity*.schema.json"
-    ],
+    "fileMatch": ["a://b/AttributeProviderEntity*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AttributeProviderEntity.schema.json",
@@ -3477,22 +3013,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "auth",
-        "id",
-        "tenantId",
-        "tenant",
-        "name",
-        "url"
-      ],
+      "required": ["auth", "id", "tenantId", "tenant", "name", "url"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainEntity.schema.json",
-    "fileMatch": [
-      "a://b/KeyChainEntity*.schema.json"
-    ],
+    "fileMatch": ["a://b/KeyChainEntity*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainEntity.schema.json",
@@ -3522,21 +3049,12 @@
         "usageType": {
           "type": "string",
           "description": "The purpose/role of this key chain in the system.",
-          "enum": [
-            "access",
-            "attestation",
-            "trustList",
-            "statusList",
-            "encrypt"
-          ]
+          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"]
         },
         "usage": {
           "type": "string",
           "description": "The usage type of the keys (sign or encrypt).",
-          "enum": [
-            "sign",
-            "encrypt"
-          ]
+          "enum": ["sign", "encrypt"]
         },
         "kmsProvider": {
           "type": "string",
@@ -3616,9 +3134,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfig.schema.json",
-    "fileMatch": [
-      "a://b/CredentialConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/CredentialConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfig.schema.json",
@@ -3749,31 +3265,20 @@
         "sdJwtTrustFormat": {
           "nullable": true,
           "description": "For SD-JWT credentials: determines whether to include certificate chain (x5c)\nor use federation-based trust (iss claim).\nDefault: \"x5c\" (federation must be explicitly selected)",
-          "enum": [
-            "x5c",
-            "federation"
-          ],
+          "enum": ["x5c", "federation"],
           "type": "string"
         },
         "lifeTime": {
           "type": "number"
         }
       },
-      "required": [
-        "id",
-        "tenant",
-        "config",
-        "configVersion",
-        "fields"
-      ],
+      "required": ["id", "tenant", "config", "configVersion", "fields"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfigCreate.schema.json",
-    "fileMatch": [
-      "a://b/CredentialConfigCreate*.schema.json"
-    ],
+    "fileMatch": ["a://b/CredentialConfigCreate*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfigCreate.schema.json",
@@ -3887,30 +3392,20 @@
         "sdJwtTrustFormat": {
           "nullable": true,
           "description": "For SD-JWT credentials: determines whether to include certificate chain (x5c)\nor use federation-based trust (iss claim).\nDefault: \"x5c\" (federation must be explicitly selected)",
-          "enum": [
-            "x5c",
-            "federation"
-          ],
+          "enum": ["x5c", "federation"],
           "type": "string"
         },
         "lifeTime": {
           "type": "number"
         }
       },
-      "required": [
-        "id",
-        "config",
-        "configVersion",
-        "fields"
-      ],
+      "required": ["id", "config", "configVersion", "fields"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfigUpdate.schema.json",
-    "fileMatch": [
-      "a://b/CredentialConfigUpdate*.schema.json"
-    ],
+    "fileMatch": ["a://b/CredentialConfigUpdate*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfigUpdate.schema.json",
@@ -4024,10 +3519,7 @@
         "sdJwtTrustFormat": {
           "nullable": true,
           "description": "For SD-JWT credentials: determines whether to include certificate chain (x5c)\nor use federation-based trust (iss claim).\nDefault: \"x5c\" (federation must be explicitly selected)",
-          "enum": [
-            "x5c",
-            "federation"
-          ],
+          "enum": ["x5c", "federation"],
           "type": "string"
         },
         "lifeTime": {
@@ -4039,9 +3531,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SignSchemaMetaConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/SignSchemaMetaConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/SignSchemaMetaConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SignSchemaMetaConfigDto.schema.json",
@@ -4065,17 +3555,13 @@
           "description": "ID of the credential config to link back after submission. When provided, schemaMeta.id on the credential config is updated with the reserved attestation ID."
         }
       },
-      "required": [
-        "config"
-      ],
+      "required": ["config"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SignVersionSchemaMetaConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/SignVersionSchemaMetaConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/SignVersionSchemaMetaConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SignVersionSchemaMetaConfigDto.schema.json",
@@ -4095,17 +3581,13 @@
           "description": "ID of the key chain to use for signing. Defaults to the tenant's default key chain."
         }
       },
-      "required": [
-        "config"
-      ],
+      "required": ["config"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/VocabularyEntryDto.schema.json",
-    "fileMatch": [
-      "a://b/VocabularyEntryDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/VocabularyEntryDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/VocabularyEntryDto.schema.json",
@@ -4123,29 +3605,20 @@
         "status": {
           "type": "string",
           "description": "Vocabulary lifecycle status.",
-          "enum": [
-            "active",
-            "deprecated"
-          ]
+          "enum": ["active", "deprecated"]
         },
         "replacedBy": {
           "type": "string",
           "description": "Replacement code when status is deprecated."
         }
       },
-      "required": [
-        "code",
-        "label",
-        "status"
-      ],
+      "required": ["code", "label", "status"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetadataVocabulariesDto.schema.json",
-    "fileMatch": [
-      "a://b/SchemaMetadataVocabulariesDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/SchemaMetadataVocabulariesDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetadataVocabulariesDto.schema.json",
@@ -4171,19 +3644,13 @@
           }
         }
       },
-      "required": [
-        "version",
-        "categories",
-        "tags"
-      ],
+      "required": ["version", "categories", "tags"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/MetadataSchemaDto.schema.json",
-    "fileMatch": [
-      "a://b/MetadataSchemaDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/MetadataSchemaDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/MetadataSchemaDto.schema.json",
@@ -4197,10 +3664,7 @@
         "formatIdentifier": {
           "type": "string",
           "description": "The credential format identifier",
-          "enum": [
-            "dc+sd-jwt",
-            "mso_mdoc"
-          ]
+          "enum": ["dc+sd-jwt", "mso_mdoc"]
         },
         "uri": {
           "type": "string",
@@ -4216,18 +3680,13 @@
           "description": "Subresource Integrity hash for the schema"
         }
       },
-      "required": [
-        "id",
-        "formatIdentifier"
-      ],
+      "required": ["id", "formatIdentifier"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustAuthorityDto.schema.json",
-    "fileMatch": [
-      "a://b/TrustAuthorityDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/TrustAuthorityDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustAuthorityDto.schema.json",
@@ -4241,9 +3700,7 @@
         "frameworkType": {
           "type": "string",
           "description": "Type of trust framework",
-          "enum": [
-            "etsi_tl"
-          ]
+          "enum": ["etsi_tl"]
         },
         "value": {
           "type": "string",
@@ -4255,19 +3712,13 @@
           "additionalProperties": true
         }
       },
-      "required": [
-        "id",
-        "frameworkType",
-        "value"
-      ],
+      "required": ["id", "frameworkType", "value"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AccessCertificateRefDto.schema.json",
-    "fileMatch": [
-      "a://b/AccessCertificateRefDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/AccessCertificateRefDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AccessCertificateRefDto.schema.json",
@@ -4290,21 +3741,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "id",
-        "relyingPartyId",
-        "certificate",
-        "revoked",
-        "createdAt"
-      ],
+      "required": ["id", "relyingPartyId", "certificate", "revoked", "createdAt"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetadataResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/SchemaMetadataResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/SchemaMetadataResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetadataResponseDto.schema.json",
@@ -4340,22 +3783,14 @@
         "bindingType": {
           "type": "string",
           "description": "Required binding type between attestation and holder",
-          "enum": [
-            "claim",
-            "key",
-            "biometric",
-            "none"
-          ]
+          "enum": ["claim", "key", "biometric", "none"]
         },
         "supportedFormats": {
           "type": "array",
           "description": "Credential formats in which this attestation is available",
           "items": {
             "type": "string",
-            "enum": [
-              "dc+sd-jwt",
-              "mso_mdoc"
-            ]
+            "enum": ["dc+sd-jwt", "mso_mdoc"]
           }
         },
         "schemaURIs": {
@@ -4375,15 +3810,7 @@
         "category": {
           "type": "string",
           "description": "Domain category for filtering",
-          "enum": [
-            "identity",
-            "health",
-            "finance",
-            "education",
-            "mobility",
-            "employment",
-            "other"
-          ]
+          "enum": ["identity", "health", "finance", "education", "mobility", "employment", "other"]
         },
         "tags": {
           "description": "Free-form tags for filtering and search",
@@ -4457,9 +3884,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateSchemaMetadataDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateSchemaMetadataDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateSchemaMetadataDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateSchemaMetadataDto.schema.json",
@@ -4469,15 +3894,7 @@
         "category": {
           "type": "string",
           "description": "Domain category for filtering",
-          "enum": [
-            "identity",
-            "health",
-            "finance",
-            "education",
-            "mobility",
-            "employment",
-            "other"
-          ]
+          "enum": ["identity", "health", "finance", "education", "mobility", "employment", "other"]
         },
         "tags": {
           "type": "array",
@@ -4504,9 +3921,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeprecateSchemaMetadataDto.schema.json",
-    "fileMatch": [
-      "a://b/DeprecateSchemaMetadataDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/DeprecateSchemaMetadataDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeprecateSchemaMetadataDto.schema.json",
@@ -4526,17 +3941,13 @@
           "description": "The version that supersedes this one"
         }
       },
-      "required": [
-        "deprecated"
-      ],
+      "required": ["deprecated"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateAttributeProviderDto.schema.json",
-    "fileMatch": [
-      "a://b/CreateAttributeProviderDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CreateAttributeProviderDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateAttributeProviderDto.schema.json",
@@ -4567,20 +3978,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "auth",
-        "id",
-        "name",
-        "url"
-      ],
+      "required": ["auth", "id", "name", "url"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateAttributeProviderDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateAttributeProviderDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateAttributeProviderDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateAttributeProviderDto.schema.json",
@@ -4616,9 +4020,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateWebhookEndpointDto.schema.json",
-    "fileMatch": [
-      "a://b/CreateWebhookEndpointDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CreateWebhookEndpointDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateWebhookEndpointDto.schema.json",
@@ -4650,20 +4052,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "id",
-        "auth",
-        "name",
-        "url"
-      ],
+      "required": ["id", "auth", "name", "url"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateWebhookEndpointDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateWebhookEndpointDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateWebhookEndpointDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateWebhookEndpointDto.schema.json",
@@ -4700,9 +4095,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListEntityInfo.schema.json",
-    "fileMatch": [
-      "a://b/TrustListEntityInfo*.schema.json"
-    ],
+    "fileMatch": ["a://b/TrustListEntityInfo*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListEntityInfo.schema.json",
@@ -4734,17 +4127,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "name"
-      ],
+      "required": ["name"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InternalTrustListEntity.schema.json",
-    "fileMatch": [
-      "a://b/InternalTrustListEntity*.schema.json"
-    ],
+    "fileMatch": ["a://b/InternalTrustListEntity*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InternalTrustListEntity.schema.json",
@@ -4753,9 +4142,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": [
-            "internal"
-          ]
+          "enum": ["internal"]
         },
         "issuerKeyChainId": {
           "type": "string"
@@ -4767,20 +4154,13 @@
           "$ref": "./TrustListEntityInfo.schema.json"
         }
       },
-      "required": [
-        "type",
-        "issuerKeyChainId",
-        "revocationKeyChainId",
-        "info"
-      ],
+      "required": ["type", "issuerKeyChainId", "revocationKeyChainId", "info"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExternalTrustListEntity.schema.json",
-    "fileMatch": [
-      "a://b/ExternalTrustListEntity*.schema.json"
-    ],
+    "fileMatch": ["a://b/ExternalTrustListEntity*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExternalTrustListEntity.schema.json",
@@ -4789,9 +4169,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": [
-            "external"
-          ]
+          "enum": ["external"]
         },
         "issuerCertPem": {
           "type": "string"
@@ -4803,20 +4181,13 @@
           "$ref": "./TrustListEntityInfo.schema.json"
         }
       },
-      "required": [
-        "type",
-        "issuerCertPem",
-        "revocationCertPem",
-        "info"
-      ],
+      "required": ["type", "issuerCertPem", "revocationCertPem", "info"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListCreateDto.schema.json",
-    "fileMatch": [
-      "a://b/TrustListCreateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/TrustListCreateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListCreateDto.schema.json",
@@ -4857,17 +4228,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "entities"
-      ],
+      "required": ["entities"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustList.schema.json",
-    "fileMatch": [
-      "a://b/TrustList*.schema.json"
-    ],
+    "fileMatch": ["a://b/TrustList*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustList.schema.json",
@@ -4943,9 +4310,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListVersion.schema.json",
-    "fileMatch": [
-      "a://b/TrustListVersion*.schema.json"
-    ],
+    "fileMatch": ["a://b/TrustListVersion*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListVersion.schema.json",
@@ -5000,9 +4365,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DCQL.schema.json",
-    "fileMatch": [
-      "a://b/DCQL*.schema.json"
-    ],
+    "fileMatch": ["a://b/DCQL*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DCQL.schema.json",
@@ -5022,17 +4385,13 @@
           }
         }
       },
-      "required": [
-        "credentials"
-      ],
+      "required": ["credentials"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificatePurpose.schema.json",
-    "fileMatch": [
-      "a://b/RegistrationCertificatePurpose*.schema.json"
-    ],
+    "fileMatch": ["a://b/RegistrationCertificatePurpose*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificatePurpose.schema.json",
@@ -5046,18 +4405,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "lang",
-        "content"
-      ],
+      "required": ["lang", "content"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateBody.schema.json",
-    "fileMatch": [
-      "a://b/RegistrationCertificateBody*.schema.json"
-    ],
+    "fileMatch": ["a://b/RegistrationCertificateBody*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateBody.schema.json",
@@ -5097,9 +4451,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateRequest.schema.json",
-    "fileMatch": [
-      "a://b/RegistrationCertificateRequest*.schema.json"
-    ],
+    "fileMatch": ["a://b/RegistrationCertificateRequest*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateRequest.schema.json",
@@ -5128,9 +4480,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationAttachment.schema.json",
-    "fileMatch": [
-      "a://b/PresentationAttachment*.schema.json"
-    ],
+    "fileMatch": ["a://b/PresentationAttachment*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationAttachment.schema.json",
@@ -5150,18 +4500,13 @@
           }
         }
       },
-      "required": [
-        "format",
-        "data"
-      ],
+      "required": ["format", "data"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfig.schema.json",
-    "fileMatch": [
-      "a://b/PresentationConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/PresentationConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfig.schema.json",
@@ -5261,21 +4606,13 @@
           "description": "Optional ID of the access certificate to use for signing the presentation request.\nIf not provided, the default access certificate for the tenant will be used.\n\nNote: This is intentionally NOT a TypeORM relationship because CertEntity uses\na composite primary key (id + tenantId), and SQLite cannot create foreign keys\nthat reference only part of a composite primary key. The relationship is handled\nat the application level in the service layer."
         }
       },
-      "required": [
-        "id",
-        "tenant",
-        "dcql_query",
-        "createdAt",
-        "updatedAt"
-      ],
+      "required": ["id", "tenant", "dcql_query", "createdAt", "updatedAt"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ResolveIssuerMetadataDto.schema.json",
-    "fileMatch": [
-      "a://b/ResolveIssuerMetadataDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ResolveIssuerMetadataDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ResolveIssuerMetadataDto.schema.json",
@@ -5289,17 +4626,13 @@
           "example": "https://issuer.example.com/issuers/tenant-a"
         }
       },
-      "required": [
-        "issuerUrl"
-      ],
+      "required": ["issuerUrl"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ResolveSchemaMetadataDto.schema.json",
-    "fileMatch": [
-      "a://b/ResolveSchemaMetadataDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ResolveSchemaMetadataDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ResolveSchemaMetadataDto.schema.json",
@@ -5313,17 +4646,13 @@
           "example": "https://registrar.example.com/schema-metadata/5c0d7dbb-ef2e-448b-b84f-b8103575947b"
         }
       },
-      "required": [
-        "schemaMetadataUrl"
-      ],
+      "required": ["schemaMetadataUrl"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfigCreateDto.schema.json",
-    "fileMatch": [
-      "a://b/PresentationConfigCreateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/PresentationConfigCreateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfigCreateDto.schema.json",
@@ -5397,18 +4726,13 @@
           "description": "Optional ID of the access certificate to use for signing the presentation request.\nIf not provided, the default access certificate for the tenant will be used.\n\nNote: This is intentionally NOT a TypeORM relationship because CertEntity uses\na composite primary key (id + tenantId), and SQLite cannot create foreign keys\nthat reference only part of a composite primary key. The relationship is handled\nat the application level in the service layer."
         }
       },
-      "required": [
-        "id",
-        "dcql_query"
-      ],
+      "required": ["id", "dcql_query"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfigUpdateDto.schema.json",
-    "fileMatch": [
-      "a://b/PresentationConfigUpdateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/PresentationConfigUpdateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfigUpdateDto.schema.json",
@@ -5487,9 +4811,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateDefaults.schema.json",
-    "fileMatch": [
-      "a://b/RegistrationCertificateDefaults*.schema.json"
-    ],
+    "fileMatch": ["a://b/RegistrationCertificateDefaults*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateDefaults.schema.json",
@@ -5512,9 +4834,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrarConfigResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/RegistrarConfigResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/RegistrarConfigResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrarConfigResponseDto.schema.json",
@@ -5562,21 +4882,13 @@
           "example": true
         }
       },
-      "required": [
-        "registrarUrl",
-        "oidcUrl",
-        "clientId",
-        "username",
-        "hasPassword"
-      ],
+      "required": ["registrarUrl", "oidcUrl", "clientId", "username", "hasPassword"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateRegistrarConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/CreateRegistrarConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CreateRegistrarConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateRegistrarConfigDto.schema.json",
@@ -5623,21 +4935,13 @@
           ]
         }
       },
-      "required": [
-        "registrarUrl",
-        "oidcUrl",
-        "clientId",
-        "username",
-        "password"
-      ],
+      "required": ["registrarUrl", "oidcUrl", "clientId", "username", "password"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateRegistrarConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateRegistrarConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateRegistrarConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateRegistrarConfigDto.schema.json",
@@ -5689,9 +4993,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateAccessCertificateDto.schema.json",
-    "fileMatch": [
-      "a://b/CreateAccessCertificateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CreateAccessCertificateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateAccessCertificateDto.schema.json",
@@ -5704,17 +5006,13 @@
           "example": "my-signing-key"
         }
       },
-      "required": [
-        "keyId"
-      ],
+      "required": ["keyId"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeferredCredentialRequestDto.schema.json",
-    "fileMatch": [
-      "a://b/DeferredCredentialRequestDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/DeferredCredentialRequestDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeferredCredentialRequestDto.schema.json",
@@ -5727,17 +5025,13 @@
           "example": "8xLOxBtZp8"
         }
       },
-      "required": [
-        "transaction_id"
-      ],
+      "required": ["transaction_id"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/NotificationRequestDto.schema.json",
-    "fileMatch": [
-      "a://b/NotificationRequestDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/NotificationRequestDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/NotificationRequestDto.schema.json",
@@ -5751,18 +5045,13 @@
           "type": "object"
         }
       },
-      "required": [
-        "notification_id",
-        "event"
-      ],
+      "required": ["notification_id", "event"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Object.schema.json",
-    "fileMatch": [
-      "a://b/Object*.schema.json"
-    ],
+    "fileMatch": ["a://b/Object*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Object.schema.json",
@@ -5774,9 +5063,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ParResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/ParResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ParResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ParResponseDto.schema.json",
@@ -5792,18 +5079,13 @@
           "description": "The expiration time for the request URI in seconds."
         }
       },
-      "required": [
-        "request_uri",
-        "expires_in"
-      ],
+      "required": ["request_uri", "expires_in"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationRequestDto.schema.json",
-    "fileMatch": [
-      "a://b/InteractiveAuthorizationRequestDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/InteractiveAuthorizationRequestDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationRequestDto.schema.json",
@@ -5876,9 +5158,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationCodeResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/InteractiveAuthorizationCodeResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/InteractiveAuthorizationCodeResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationCodeResponseDto.schema.json",
@@ -5896,18 +5176,13 @@
           "example": "auth-code-123"
         }
       },
-      "required": [
-        "status",
-        "code"
-      ],
+      "required": ["status", "code"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationErrorResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/InteractiveAuthorizationErrorResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/InteractiveAuthorizationErrorResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationErrorResponseDto.schema.json",
@@ -5925,17 +5200,13 @@
           "example": "Missing required parameter: interaction_types_supported"
         }
       },
-      "required": [
-        "error"
-      ],
+      "required": ["error"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsParResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/ChainedAsParResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ChainedAsParResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsParResponseDto.schema.json",
@@ -5953,18 +5224,13 @@
           "example": 600
         }
       },
-      "required": [
-        "request_uri",
-        "expires_in"
-      ],
+      "required": ["request_uri", "expires_in"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsErrorResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/ChainedAsErrorResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ChainedAsErrorResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsErrorResponseDto.schema.json",
@@ -5981,17 +5247,13 @@
           "description": "Human-readable error description"
         }
       },
-      "required": [
-        "error"
-      ],
+      "required": ["error"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenRequestDto.schema.json",
-    "fileMatch": [
-      "a://b/ChainedAsTokenRequestDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ChainedAsTokenRequestDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenRequestDto.schema.json",
@@ -6024,17 +5286,13 @@
           "description": "PKCE code verifier"
         }
       },
-      "required": [
-        "grant_type"
-      ],
+      "required": ["grant_type"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/ChainedAsTokenResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ChainedAsTokenResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenResponseDto.schema.json",
@@ -6079,19 +5337,13 @@
           "description": "Refresh token (issued when refresh tokens are enabled)"
         }
       },
-      "required": [
-        "access_token",
-        "token_type",
-        "expires_in"
-      ],
+      "required": ["access_token", "token_type", "expires_in"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/OfferResponse.schema.json",
-    "fileMatch": [
-      "a://b/OfferResponse*.schema.json"
-    ],
+    "fileMatch": ["a://b/OfferResponse*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/OfferResponse.schema.json",
@@ -6109,18 +5361,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "uri",
-        "session"
-      ],
+      "required": ["uri", "session"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CompleteDeferredDto.schema.json",
-    "fileMatch": [
-      "a://b/CompleteDeferredDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CompleteDeferredDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CompleteDeferredDto.schema.json",
@@ -6137,17 +5384,13 @@
           }
         }
       },
-      "required": [
-        "claims"
-      ],
+      "required": ["claims"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeferredOperationResponse.schema.json",
-    "fileMatch": [
-      "a://b/DeferredOperationResponse*.schema.json"
-    ],
+    "fileMatch": ["a://b/DeferredOperationResponse*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeferredOperationResponse.schema.json",
@@ -6160,13 +5403,7 @@
         },
         "status": {
           "description": "The new status of the transaction",
-          "enum": [
-            "pending",
-            "ready",
-            "retrieved",
-            "expired",
-            "failed"
-          ],
+          "enum": ["pending", "ready", "retrieved", "expired", "failed"],
           "type": "string"
         },
         "message": {
@@ -6174,18 +5411,13 @@
           "description": "Optional message"
         }
       },
-      "required": [
-        "transactionId",
-        "status"
-      ],
+      "required": ["transactionId", "status"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FailDeferredDto.schema.json",
-    "fileMatch": [
-      "a://b/FailDeferredDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/FailDeferredDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FailDeferredDto.schema.json",
@@ -6203,9 +5435,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EC_Public.schema.json",
-    "fileMatch": [
-      "a://b/EC_Public*.schema.json"
-    ],
+    "fileMatch": ["a://b/EC_Public*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EC_Public.schema.json",
@@ -6229,20 +5459,13 @@
           "description": "The y coordinate of the EC public key."
         }
       },
-      "required": [
-        "kty",
-        "crv",
-        "x",
-        "y"
-      ],
+      "required": ["kty", "crv", "x", "y"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/JwksResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/JwksResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/JwksResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/JwksResponseDto.schema.json",
@@ -6257,17 +5480,13 @@
           }
         }
       },
-      "required": [
-        "keys"
-      ],
+      "required": ["keys"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthorizationResponse.schema.json",
-    "fileMatch": [
-      "a://b/AuthorizationResponse*.schema.json"
-    ],
+    "fileMatch": ["a://b/AuthorizationResponse*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthorizationResponse.schema.json",
@@ -6303,9 +5522,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProviderCapabilitiesDto.schema.json",
-    "fileMatch": [
-      "a://b/KmsProviderCapabilitiesDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KmsProviderCapabilitiesDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProviderCapabilitiesDto.schema.json",
@@ -6328,19 +5545,13 @@
           "example": true
         }
       },
-      "required": [
-        "canImport",
-        "canCreate",
-        "canDelete"
-      ],
+      "required": ["canImport", "canCreate", "canDelete"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProviderInfoDto.schema.json",
-    "fileMatch": [
-      "a://b/KmsProviderInfoDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KmsProviderInfoDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProviderInfoDto.schema.json",
@@ -6371,19 +5582,13 @@
           ]
         }
       },
-      "required": [
-        "name",
-        "type",
-        "capabilities"
-      ],
+      "required": ["name", "type", "capabilities"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProvidersResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/KmsProvidersResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KmsProvidersResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProvidersResponseDto.schema.json",
@@ -6403,18 +5608,13 @@
           "example": "db"
         }
       },
-      "required": [
-        "providers",
-        "default"
-      ],
+      "required": ["providers", "default"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CertificateInfoDto.schema.json",
-    "fileMatch": [
-      "a://b/CertificateInfoDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CertificateInfoDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CertificateInfoDto.schema.json",
@@ -6448,17 +5648,13 @@
           "description": "Serial number."
         }
       },
-      "required": [
-        "pem"
-      ],
+      "required": ["pem"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PublicKeyInfoDto.schema.json",
-    "fileMatch": [
-      "a://b/PublicKeyInfoDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/PublicKeyInfoDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PublicKeyInfoDto.schema.json",
@@ -6485,17 +5681,13 @@
           "example": "P-256"
         }
       },
-      "required": [
-        "kty"
-      ],
+      "required": ["kty"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/RotationPolicyResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/RotationPolicyResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyResponseDto.schema.json",
@@ -6520,17 +5712,13 @@
           "description": "Next scheduled rotation date."
         }
       },
-      "required": [
-        "enabled"
-      ],
+      "required": ["enabled"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/KeyChainResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KeyChainResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainResponseDto.schema.json",
@@ -6542,21 +5730,12 @@
           "description": "Unique identifier for the key chain."
         },
         "usageType": {
-          "enum": [
-            "access",
-            "attestation",
-            "trustList",
-            "statusList",
-            "encrypt"
-          ],
+          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"],
           "type": "string",
           "description": "Usage type of the key chain."
         },
         "type": {
-          "enum": [
-            "standalone",
-            "internalChain"
-          ],
+          "enum": ["standalone", "internalChain"],
           "type": "string",
           "description": "Type of key chain (standalone or internalChain)."
         },
@@ -6647,9 +5826,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExportEcJwk.schema.json",
-    "fileMatch": [
-      "a://b/ExportEcJwk*.schema.json"
-    ],
+    "fileMatch": ["a://b/ExportEcJwk*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExportEcJwk.schema.json",
@@ -6688,21 +5865,13 @@
           "description": "Key ID"
         }
       },
-      "required": [
-        "kty",
-        "crv",
-        "x",
-        "y",
-        "d"
-      ],
+      "required": ["kty", "crv", "x", "y", "d"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExportRotationPolicyDto.schema.json",
-    "fileMatch": [
-      "a://b/ExportRotationPolicyDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ExportRotationPolicyDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExportRotationPolicyDto.schema.json",
@@ -6722,17 +5891,13 @@
           "description": "Certificate validity in days."
         }
       },
-      "required": [
-        "enabled"
-      ],
+      "required": ["enabled"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainExportDto.schema.json",
-    "fileMatch": [
-      "a://b/KeyChainExportDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KeyChainExportDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainExportDto.schema.json",
@@ -6748,13 +5913,7 @@
           "description": "Human-readable description."
         },
         "usageType": {
-          "enum": [
-            "access",
-            "attestation",
-            "trustList",
-            "statusList",
-            "encrypt"
-          ],
+          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"],
           "type": "string",
           "description": "Usage type for this key chain."
         },
@@ -6786,19 +5945,13 @@
           ]
         }
       },
-      "required": [
-        "id",
-        "usageType",
-        "key"
-      ],
+      "required": ["id", "usageType", "key"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyCreateDto.schema.json",
-    "fileMatch": [
-      "a://b/RotationPolicyCreateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/RotationPolicyCreateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyCreateDto.schema.json",
@@ -6825,17 +5978,13 @@
           "example": 365
         }
       },
-      "required": [
-        "enabled"
-      ],
+      "required": ["enabled"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainCreateDto.schema.json",
-    "fileMatch": [
-      "a://b/KeyChainCreateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KeyChainCreateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainCreateDto.schema.json",
@@ -6843,22 +5992,13 @@
       "type": "object",
       "properties": {
         "usageType": {
-          "enum": [
-            "access",
-            "attestation",
-            "trustList",
-            "statusList",
-            "encrypt"
-          ],
+          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"],
           "type": "string",
           "description": "Usage type determines the purpose of this key chain (access, attestation, etc.).",
           "example": "attestation"
         },
         "type": {
-          "enum": [
-            "standalone",
-            "internalChain"
-          ],
+          "enum": ["standalone", "internalChain"],
           "type": "string",
           "description": "Type of key chain to create.",
           "example": "internalChain"
@@ -6882,18 +6022,13 @@
           ]
         }
       },
-      "required": [
-        "usageType",
-        "type"
-      ],
+      "required": ["usageType", "type"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EcJwk.schema.json",
-    "fileMatch": [
-      "a://b/EcJwk*.schema.json"
-    ],
+    "fileMatch": ["a://b/EcJwk*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EcJwk.schema.json",
@@ -6922,21 +6057,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "kty",
-        "x",
-        "y",
-        "crv",
-        "d"
-      ],
+      "required": ["kty", "x", "y", "crv", "d"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyImportDto.schema.json",
-    "fileMatch": [
-      "a://b/RotationPolicyImportDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/RotationPolicyImportDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyImportDto.schema.json",
@@ -6963,17 +6090,13 @@
           "example": 365
         }
       },
-      "required": [
-        "enabled"
-      ],
+      "required": ["enabled"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainImportDto.schema.json",
-    "fileMatch": [
-      "a://b/KeyChainImportDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KeyChainImportDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainImportDto.schema.json",
@@ -6997,13 +6120,7 @@
           "description": "Human-readable description."
         },
         "usageType": {
-          "enum": [
-            "access",
-            "attestation",
-            "trustList",
-            "statusList",
-            "encrypt"
-          ],
+          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"],
           "type": "string",
           "description": "Usage type for this key chain."
         },
@@ -7027,18 +6144,13 @@
           ]
         }
       },
-      "required": [
-        "key",
-        "usageType"
-      ],
+      "required": ["key", "usageType"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyUpdateDto.schema.json",
-    "fileMatch": [
-      "a://b/RotationPolicyUpdateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/RotationPolicyUpdateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyUpdateDto.schema.json",
@@ -7067,9 +6179,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainUpdateDto.schema.json",
-    "fileMatch": [
-      "a://b/KeyChainUpdateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KeyChainUpdateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainUpdateDto.schema.json",
@@ -7098,9 +6208,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationRequest.schema.json",
-    "fileMatch": [
-      "a://b/PresentationRequest*.schema.json"
-    ],
+    "fileMatch": ["a://b/PresentationRequest*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationRequest.schema.json",
@@ -7110,10 +6218,7 @@
         "response_type": {
           "type": "string",
           "description": "The type of response expected from the presentation request.",
-          "enum": [
-            "uri",
-            "dc-api"
-          ]
+          "enum": ["uri", "dc-api"]
         },
         "requestId": {
           "type": "string",
@@ -7140,18 +6245,13 @@
           }
         }
       },
-      "required": [
-        "response_type",
-        "requestId"
-      ],
+      "required": ["response_type", "requestId"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FileUploadDto.schema.json",
-    "fileMatch": [
-      "a://b/FileUploadDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/FileUploadDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FileUploadDto.schema.json",
@@ -7163,9 +6263,7 @@
           "format": "binary"
         }
       },
-      "required": [
-        "file"
-      ],
+      "required": ["file"],
       "additionalProperties": false
     }
   }

--- a/schemas/ClaimFieldDefinitionDto.schema.json
+++ b/schemas/ClaimFieldDefinitionDto.schema.json
@@ -5,14 +5,24 @@
   "type": "object",
   "properties": {
     "path": {
+      "type": "array",
       "description": "Path to claim value",
       "example": [
         "address",
         "locality"
       ],
-      "type": "array",
       "items": {
-        "type": "string"
+        "oneOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          },
+          {
+            "type": "null"
+          }
+        ]
       }
     },
     "type": {

--- a/schemas/CredentialConfig.schema.json
+++ b/schemas/CredentialConfig.schema.json
@@ -5,16 +5,17 @@
   "type": "object",
   "properties": {
     "vct": {
-      "type": "object",
       "description": "VCT as a URI string (e.g., urn:eudi:pid:de:1) or as an object for EUDIPLO-hosted VCT",
-      "nullable": true,
-      "oneOf": [
+      "anyOf": [
         {
           "type": "string",
           "description": "VCT URI string"
         },
         {
           "$ref": "./VCT.schema.json"
+        },
+        {
+          "type": "null"
         }
       ]
     },
@@ -123,6 +124,15 @@
     },
     "statusManagement": {
       "type": "boolean"
+    },
+    "sdJwtTrustFormat": {
+      "nullable": true,
+      "description": "For SD-JWT credentials: determines whether to include certificate chain (x5c)\nor use federation-based trust (iss claim).\nDefault: \"x5c\" (federation must be explicitly selected)",
+      "enum": [
+        "x5c",
+        "federation"
+      ],
+      "type": "string"
     },
     "lifeTime": {
       "type": "number"

--- a/schemas/CredentialConfigCreate.schema.json
+++ b/schemas/CredentialConfigCreate.schema.json
@@ -5,16 +5,17 @@
   "type": "object",
   "properties": {
     "vct": {
-      "type": "object",
       "description": "VCT as a URI string (e.g., urn:eudi:pid:de:1) or as an object for EUDIPLO-hosted VCT",
-      "nullable": true,
-      "oneOf": [
+      "anyOf": [
         {
           "type": "string",
           "description": "VCT URI string"
         },
         {
           "$ref": "./VCT.schema.json"
+        },
+        {
+          "type": "null"
         }
       ]
     },
@@ -106,6 +107,15 @@
     },
     "statusManagement": {
       "type": "boolean"
+    },
+    "sdJwtTrustFormat": {
+      "nullable": true,
+      "description": "For SD-JWT credentials: determines whether to include certificate chain (x5c)\nor use federation-based trust (iss claim).\nDefault: \"x5c\" (federation must be explicitly selected)",
+      "enum": [
+        "x5c",
+        "federation"
+      ],
+      "type": "string"
     },
     "lifeTime": {
       "type": "number"

--- a/schemas/CredentialConfigUpdate.schema.json
+++ b/schemas/CredentialConfigUpdate.schema.json
@@ -5,16 +5,17 @@
   "type": "object",
   "properties": {
     "vct": {
-      "type": "object",
       "description": "VCT as a URI string (e.g., urn:eudi:pid:de:1) or as an object for EUDIPLO-hosted VCT",
-      "nullable": true,
-      "oneOf": [
+      "anyOf": [
         {
           "type": "string",
           "description": "VCT URI string"
         },
         {
           "$ref": "./VCT.schema.json"
+        },
+        {
+          "type": "null"
         }
       ]
     },
@@ -106,6 +107,15 @@
     },
     "statusManagement": {
       "type": "boolean"
+    },
+    "sdJwtTrustFormat": {
+      "nullable": true,
+      "description": "For SD-JWT credentials: determines whether to include certificate chain (x5c)\nor use federation-based trust (iss claim).\nDefault: \"x5c\" (federation must be explicitly selected)",
+      "enum": [
+        "x5c",
+        "federation"
+      ],
+      "type": "string"
     },
     "lifeTime": {
       "type": "number"

--- a/schemas/FederationConfig.schema.json
+++ b/schemas/FederationConfig.schema.json
@@ -17,7 +17,6 @@
     "mode": {
       "enum": [
         "federation-only",
-        "lote-only",
         "hybrid"
       ],
       "type": "string",

--- a/schemas/TrustedAuthorityQuery.schema.json
+++ b/schemas/TrustedAuthorityQuery.schema.json
@@ -7,7 +7,6 @@
     "type": {
       "type": "string",
       "enum": [
-        "aki",
         "etsi_tl",
         "openid_federation"
       ]


### PR DESCRIPTION
## Summary
- align credential API/schema definitions so `vct` supports string/object/null consistently
- update claim field path schema to allow `string | number | null` path segments
- regenerate and align related schema artifacts used by client/VS Code validation

## Changes
- update `CredentialConfig.vct` API metadata in backend entity
- update `ClaimFieldDefinitionDto.path` API metadata to explicit union item typing
- regenerate/update related schema files:
  - `schemas/CredentialConfig.schema.json`
  - `schemas/CredentialConfigCreate.schema.json`
  - `schemas/CredentialConfigUpdate.schema.json`
  - `schemas/ClaimFieldDefinitionDto.schema.json`
  - `schemas/FederationConfig.schema.json`
  - `schemas/TrustedAuthorityQuery.schema.json`
  - `apps/client/src/app/utils/schemas.json`

## Validation
- pre-commit hooks passed on commit
