### PR TITLE
fix: registrar credential validation and dashboard config detection

### DIFF
--- a/apps/backend/src/registrar/registrar-auth.service.ts
+++ b/apps/backend/src/registrar/registrar-auth.service.ts
@@ -1,9 +1,14 @@
-import { OAuth2Client, OAuth2Token } from "@badgateway/oauth2-client";
+import {
+    OAuth2Client,
+    OAuth2HttpError,
+    OAuth2Token,
+} from "@badgateway/oauth2-client";
 import {
     BadRequestException,
     Injectable,
     Logger,
     NotFoundException,
+    ServiceUnavailableException,
 } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Repository } from "typeorm";
@@ -63,9 +68,20 @@ export class RegistrarAuthService {
             });
             this.logger.log("Registrar credentials validated successfully");
         } catch (error: any) {
-            this.logger.warn(`Credential validation failed: ${error.message}`);
-            throw new BadRequestException(
-                `Failed to authenticate with registrar. Please check your credentials. Error: ${error.message}`,
+            if (error instanceof OAuth2HttpError) {
+                this.logger.error(
+                    `Registrar rejected credentials (HTTP ${error.httpCode}): ${error.message}`,
+                );
+                throw new BadRequestException(
+                    `Invalid registrar credentials (HTTP ${error.httpCode}). Please check your username, password, client ID and secret.`,
+                );
+            }
+            // Network-level failure (DNS, connection refused, timeout, etc.)
+            this.logger.warn(
+                `Registrar is not reachable during credential check: ${error.message}`,
+            );
+            throw new ServiceUnavailableException(
+                `Registrar OIDC endpoint is not reachable. Credentials could not be verified. Error: ${error.message}`,
             );
         }
     }

--- a/apps/backend/src/registrar/registrar.controller.ts
+++ b/apps/backend/src/registrar/registrar.controller.ts
@@ -75,7 +75,8 @@ export class RegistrarController {
     })
     @ApiResponse({
         status: 503,
-        description: "Registrar OIDC endpoint unreachable — credentials could not be verified",
+        description:
+            "Registrar OIDC endpoint unreachable — credentials could not be verified",
     })
     async createConfig(
         @Token() token: TokenPayload,
@@ -108,7 +109,8 @@ export class RegistrarController {
     })
     @ApiResponse({
         status: 503,
-        description: "Registrar OIDC endpoint unreachable — credentials could not be verified",
+        description:
+            "Registrar OIDC endpoint unreachable — credentials could not be verified",
     })
     @ApiResponse({
         status: 404,

--- a/apps/backend/src/registrar/registrar.controller.ts
+++ b/apps/backend/src/registrar/registrar.controller.ts
@@ -5,6 +5,7 @@ import {
     Get,
     HttpCode,
     HttpStatus,
+    NotFoundException,
     Patch,
     Post,
 } from "@nestjs/common";
@@ -46,9 +47,12 @@ export class RegistrarController {
     })
     async getConfig(
         @Token() token: TokenPayload,
-    ): Promise<RegistrarConfigResponseDto | null> {
+    ): Promise<RegistrarConfigResponseDto> {
         const config = await this.registrarService.getConfig(token.entity!.id);
-        return config ? RegistrarConfigResponseDto.fromEntity(config) : null;
+        if (!config) {
+            throw new NotFoundException("No registrar configuration found");
+        }
+        return RegistrarConfigResponseDto.fromEntity(config);
     }
 
     /**
@@ -68,6 +72,10 @@ export class RegistrarController {
     @ApiResponse({
         status: 400,
         description: "Invalid credentials",
+    })
+    @ApiResponse({
+        status: 503,
+        description: "Registrar OIDC endpoint unreachable — credentials could not be verified",
     })
     async createConfig(
         @Token() token: TokenPayload,
@@ -97,6 +105,10 @@ export class RegistrarController {
     @ApiResponse({
         status: 400,
         description: "Invalid credentials",
+    })
+    @ApiResponse({
+        status: 503,
+        description: "Registrar OIDC endpoint unreachable — credentials could not be verified",
     })
     @ApiResponse({
         status: 404,

--- a/apps/client/src/app/dashboard/dashboard.component.html
+++ b/apps/client/src/app/dashboard/dashboard.component.html
@@ -408,7 +408,7 @@
     </mat-card-content>
   </mat-card>
 
-  @if (dashboardService.hasWarnings) {
+  @if (dashboardService.hasWarnings && !dashboardService.isLoading) {
     <mat-card class="setup-card warnings-card">
       <mat-card-header>
         <mat-icon mat-card-avatar class="setup-icon">warning</mat-icon>

--- a/apps/client/src/app/dashboard/dashboard.service.ts
+++ b/apps/client/src/app/dashboard/dashboard.service.ts
@@ -128,7 +128,7 @@ export class DashboardService {
               this.presentationConfigs = result.value.data.length;
               break;
             case 'sessions':
-              result.value.data.forEach((session: Session) => {
+              result.value.data.items.forEach((session: Session) => {
                 switch (session.status) {
                   case 'active':
                     this.sessionActive++;
@@ -171,7 +171,7 @@ export class DashboardService {
               this.hasTrustList = this.trustListCount > 0;
               break;
             case 'registrar':
-              this.hasRegistrarConfig = true;
+              this.hasRegistrarConfig = !!result.value.data;
               break;
           }
         } else if (key === 'registrar') {

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -37,6 +37,17 @@ pnpm run test:e2e
 It is also accessible via
 [codecov](https://app.codecov.io/github/openwallet-foundation/eudiplo/tree/main).
 
+---
+
+## Code Quality (SonarCloud)
+
+Static analysis and code quality metrics are tracked on
+[SonarCloud](https://sonarcloud.io/project/overview?id=openwallet-foundation_eudiplo).
+
+!!! info "Scope"
+
+    The SonarCloud analysis focuses on the **backend** (`apps/backend`). The Angular client is excluded from coverage reporting as it is considered optional and does not have E2E test coverage yet.
+
 During writing E2E tests, you can use it in watch mode to automatically re-run
 tests on file changes:
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,6 +7,9 @@ sonar.organization=openwallet-foundation
 # Source directories
 sonar.sources=apps/backend/src,apps/client/src
 
+# Coverage exclusions — client is optional, focus on backend only
+sonar.coverage.exclusions=apps/client/**
+
 # Test directories
 sonar.tests=apps/backend/test
 sonar.test.inclusions=**/*.spec.ts,**/*.test.ts,**/*.e2e-spec.ts
@@ -38,7 +41,7 @@ sonar.cpd.exclusions=\
 sonar.javascript.lcov.reportPaths=apps/backend/coverage/e2e/lcov.info
 
 # TypeScript configuration
-sonar.typescript.tsconfigPaths=apps/backend/tsconfig.json,apps/client/tsconfig.json
+sonar.typescript.tsconfigPaths=apps/backend/tsconfig.json
 
 # Encoding
 sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## Summary

Fixes several issues in the registrar credential validation flow and the dashboard registrar config detection.

### Backend

- **`testCredentials()`**: Differentiates OAuth2 HTTP auth failures from network-level errors
  - `OAuth2HttpError` (e.g. 401 from OIDC server) → `BadRequestException` (400) + `logger.error()`
  - Network failures (DNS, timeout, connection refused) → `ServiceUnavailableException` (503) + `logger.warn()`
  - Previously all errors were caught uniformly and re-thrown as 400, preventing valid credentials from being saved when the OIDC server was temporarily unreachable
  - Added `@ApiResponse({ status: 503 })` to POST and PATCH `/registrar/config`

- **`GET /registrar/config`**: Now throws `NotFoundException` (404) when no config exists instead of returning `null` with HTTP 200
  - Fixes ambiguity with the SDK client which resolved a 200/null response as successful
  - Consistent with the documented API spec and existing error types in `types.gen.ts`

### Angular Dashboard

- **`case 'registrar'`**: Changed `this.hasRegistrarConfig = true` to `this.hasRegistrarConfig = !!result.value.data` — ensures null data is not treated as a configured registrar
- **Warnings block**: Added `!dashboardService.isLoading` guard to the `@if` condition — prevents the "Registrar is not configured" warning from flashing on page load before the API call completes (root cause of the reported dashboard bug)
- **Sessions case**: Fixed `result.value.data.forEach` → `result.value.data.items.forEach` — `sessionControllerGetAllSessions` returns a `PaginatedSessionResponseDto`, not a plain array