### PR TITLE
docs: clarify issuance and presentation offer/request guidance

### DIFF
--- a/apps/backend/src/issuer/issuance/oid4vci/dto/offer-request.dto.ts
+++ b/apps/backend/src/issuer/issuance/oid4vci/dto/offer-request.dto.ts
@@ -162,51 +162,49 @@ export class OfferRequestDto {
         description:
             "Credential claims configuration per credential. Keys must match credentialConfigurationIds.",
         type: "object",
-        properties: {
-            additionalProperties: {
-                oneOf: [
-                    {
-                        type: "object",
-                        properties: {
-                            type: { type: "string", enum: ["inline"] },
-                            claims: {
-                                type: "object",
-                                additionalProperties: true,
-                            },
+        additionalProperties: {
+            oneOf: [
+                {
+                    type: "object",
+                    properties: {
+                        type: { type: "string", enum: ["inline"] },
+                        claims: {
+                            type: "object",
+                            additionalProperties: true,
                         },
-                        required: ["type", "claims"],
                     },
-                    {
-                        type: "object",
-                        properties: {
-                            type: {
-                                type: "string",
-                                enum: ["attributeProvider"],
-                            },
-                            attributeProviderId: { type: "string" },
+                    required: ["type", "claims"],
+                },
+                {
+                    type: "object",
+                    properties: {
+                        type: {
+                            type: "string",
+                            enum: ["attributeProvider"],
                         },
-                        required: ["type", "attributeProviderId"],
+                        attributeProviderId: { type: "string" },
                     },
-                    {
-                        type: "object",
-                        properties: {
-                            type: {
-                                type: "string",
-                                enum: ["webhook"],
-                            },
-                            webhook: {
-                                type: "object",
-                                properties: {
-                                    url: { type: "string" },
-                                    auth: { type: "object" },
-                                },
-                                required: ["url"],
-                            },
+                    required: ["type", "attributeProviderId"],
+                },
+                {
+                    type: "object",
+                    properties: {
+                        type: {
+                            type: "string",
+                            enum: ["webhook"],
                         },
-                        required: ["type", "webhook"],
+                        webhook: {
+                            type: "object",
+                            properties: {
+                                url: { type: "string" },
+                                auth: { type: "object" },
+                            },
+                            required: ["url"],
+                        },
                     },
-                ],
-            },
+                    required: ["type", "webhook"],
+                },
+            ],
         },
         example: {
             citizen: {

--- a/apps/client/src/app/utils/schemas.json
+++ b/apps/client/src/app/utils/schemas.json
@@ -1,7 +1,9 @@
 [
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/GrafanaConfigDto.schema.json",
-    "fileMatch": ["a://b/GrafanaConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/GrafanaConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/GrafanaConfigDto.schema.json",
@@ -24,13 +26,18 @@
           "example": "loki"
         }
       },
-      "required": ["tempoUid", "lokiUid"],
+      "required": [
+        "tempoUid",
+        "lokiUid"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FrontendConfigResponseDto.schema.json",
-    "fileMatch": ["a://b/FrontendConfigResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/FrontendConfigResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FrontendConfigResponseDto.schema.json",
@@ -46,13 +53,17 @@
           ]
         }
       },
-      "required": ["grafana"],
+      "required": [
+        "grafana"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RoleDto.schema.json",
-    "fileMatch": ["a://b/RoleDto*.schema.json"],
+    "fileMatch": [
+      "a://b/RoleDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RoleDto.schema.json",
@@ -75,13 +86,17 @@
           "example": "issuance:manage"
         }
       },
-      "required": ["role"],
+      "required": [
+        "role"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientCredentialsDto.schema.json",
-    "fileMatch": ["a://b/ClientCredentialsDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ClientCredentialsDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientCredentialsDto.schema.json",
@@ -99,13 +114,18 @@
           "type": "string"
         }
       },
-      "required": ["client_id", "client_secret"],
+      "required": [
+        "client_id",
+        "client_secret"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TokenResponse.schema.json",
-    "fileMatch": ["a://b/TokenResponse*.schema.json"],
+    "fileMatch": [
+      "a://b/TokenResponse*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TokenResponse.schema.json",
@@ -125,13 +145,19 @@
           "type": "number"
         }
       },
-      "required": ["access_token", "token_type", "expires_in"],
+      "required": [
+        "access_token",
+        "token_type",
+        "expires_in"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ImportTenantDto.schema.json",
-    "fileMatch": ["a://b/ImportTenantDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ImportTenantDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ImportTenantDto.schema.json",
@@ -147,13 +173,17 @@
           "description": "The description of the tenant."
         }
       },
-      "required": ["name"],
+      "required": [
+        "name"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SessionStorageConfig.schema.json",
-    "fileMatch": ["a://b/SessionStorageConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/SessionStorageConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SessionStorageConfig.schema.json",
@@ -169,7 +199,10 @@
         "cleanupMode": {
           "type": "string",
           "description": "Cleanup mode: 'full' deletes everything, 'anonymize' keeps metadata but removes PII.",
-          "enum": ["full", "anonymize"],
+          "enum": [
+            "full",
+            "anonymize"
+          ],
           "default": "full"
         }
       },
@@ -178,7 +211,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListConfig.schema.json",
-    "fileMatch": ["a://b/StatusListConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/StatusListConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListConfig.schema.json",
@@ -194,7 +229,12 @@
         "bits": {
           "type": "number",
           "description": "Bits per status entry: 1 (valid/revoked), 2 (with suspended), 4/8 (extended). If not set, uses global STATUS_BITS.",
-          "enum": [1, 2, 4, 8],
+          "enum": [
+            1,
+            2,
+            4,
+            8
+          ],
           "default": 1
         },
         "ttl": {
@@ -219,7 +259,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TenantEntity.schema.json",
-    "fileMatch": ["a://b/TenantEntity*.schema.json"],
+    "fileMatch": [
+      "a://b/TenantEntity*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TenantEntity.schema.json",
@@ -270,13 +312,20 @@
           }
         }
       },
-      "required": ["id", "name", "status", "clients"],
+      "required": [
+        "id",
+        "name",
+        "status",
+        "clients"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientEntity.schema.json",
-    "fileMatch": ["a://b/ClientEntity*.schema.json"],
+    "fileMatch": [
+      "a://b/ClientEntity*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientEntity.schema.json",
@@ -286,7 +335,10 @@
         "allowedPresentationConfigs": {
           "nullable": true,
           "description": "List of presentation config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": ["age-verification", "kyc-basic"],
+          "example": [
+            "age-verification",
+            "kyc-basic"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -295,7 +347,10 @@
         "allowedIssuanceConfigs": {
           "nullable": true,
           "description": "List of issuance config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": ["pid", "mdl"],
+          "example": [
+            "pid",
+            "mdl"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -343,13 +398,18 @@
           ]
         }
       },
-      "required": ["clientId", "roles"],
+      "required": [
+        "clientId",
+        "roles"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateTenantDto.schema.json",
-    "fileMatch": ["a://b/CreateTenantDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CreateTenantDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateTenantDto.schema.json",
@@ -403,13 +463,18 @@
           }
         }
       },
-      "required": ["id", "name"],
+      "required": [
+        "id",
+        "name"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateTenantDto.schema.json",
-    "fileMatch": ["a://b/UpdateTenantDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateTenantDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateTenantDto.schema.json",
@@ -464,7 +529,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuditLogResponseDto.schema.json",
-    "fileMatch": ["a://b/AuditLogResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/AuditLogResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuditLogResponseDto.schema.json",
@@ -478,7 +545,6 @@
           "type": "string"
         },
         "actionType": {
-          "type": "string",
           "enum": [
             "tenant_created",
             "tenant_updated",
@@ -498,11 +564,16 @@
             "attribute_provider_created",
             "attribute_provider_updated",
             "attribute_provider_deleted"
-          ]
+          ],
+          "type": "string"
         },
         "actorType": {
-          "type": "string",
-          "enum": ["user", "client", "system"]
+          "enum": [
+            "user",
+            "client",
+            "system"
+          ],
+          "type": "string"
         },
         "actorId": {
           "type": "string"
@@ -532,13 +603,21 @@
           "type": "string"
         }
       },
-      "required": ["id", "tenantId", "actionType", "actorType", "timestamp"],
+      "required": [
+        "id",
+        "tenantId",
+        "actionType",
+        "actorType",
+        "timestamp"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientSecretResponseDto.schema.json",
-    "fileMatch": ["a://b/ClientSecretResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ClientSecretResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientSecretResponseDto.schema.json",
@@ -549,13 +628,17 @@
           "type": "string"
         }
       },
-      "required": ["secret"],
+      "required": [
+        "secret"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateClientDto.schema.json",
-    "fileMatch": ["a://b/UpdateClientDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateClientDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateClientDto.schema.json",
@@ -565,7 +648,10 @@
         "allowedPresentationConfigs": {
           "nullable": true,
           "description": "List of presentation config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": ["age-verification", "kyc-basic"],
+          "example": [
+            "age-verification",
+            "kyc-basic"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -574,7 +660,10 @@
         "allowedIssuanceConfigs": {
           "nullable": true,
           "description": "List of issuance config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": ["pid", "mdl"],
+          "example": [
+            "pid",
+            "mdl"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -602,13 +691,17 @@
           }
         }
       },
-      "required": ["roles"],
+      "required": [
+        "roles"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateClientDto.schema.json",
-    "fileMatch": ["a://b/CreateClientDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CreateClientDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateClientDto.schema.json",
@@ -618,7 +711,10 @@
         "allowedPresentationConfigs": {
           "nullable": true,
           "description": "List of presentation config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": ["age-verification", "kyc-basic"],
+          "example": [
+            "age-verification",
+            "kyc-basic"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -627,7 +723,10 @@
         "allowedIssuanceConfigs": {
           "nullable": true,
           "description": "List of issuance config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": ["pid", "mdl"],
+          "example": [
+            "pid",
+            "mdl"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -663,13 +762,18 @@
           }
         }
       },
-      "required": ["clientId", "roles"],
+      "required": [
+        "clientId",
+        "roles"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListImportDto.schema.json",
-    "fileMatch": ["a://b/StatusListImportDto*.schema.json"],
+    "fileMatch": [
+      "a://b/StatusListImportDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListImportDto.schema.json",
@@ -698,19 +802,28 @@
           "example": 10000
         },
         "bits": {
-          "type": "number",
           "description": "Bits per status value. If not provided, uses tenant or global defaults.",
-          "enum": [1, 2, 4, 8],
+          "enum": [
+            1,
+            2,
+            4,
+            8
+          ],
+          "type": "number",
           "example": 1
         }
       },
-      "required": ["id"],
+      "required": [
+        "id"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListAggregationDto.schema.json",
-    "fileMatch": ["a://b/StatusListAggregationDto*.schema.json"],
+    "fileMatch": [
+      "a://b/StatusListAggregationDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListAggregationDto.schema.json",
@@ -729,13 +842,17 @@
           }
         }
       },
-      "required": ["status_lists"],
+      "required": [
+        "status_lists"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateStatusListConfigDto.schema.json",
-    "fileMatch": ["a://b/UpdateStatusListConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateStatusListConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateStatusListConfigDto.schema.json",
@@ -750,10 +867,15 @@
           "example": 10000
         },
         "bits": {
-          "type": "number",
           "nullable": true,
           "description": "Bits per status entry. Set to null to reset to global default.",
-          "enum": [1, 2, 4, 8]
+          "enum": [
+            1,
+            2,
+            4,
+            8
+          ],
+          "type": "number"
         },
         "ttl": {
           "type": "number",
@@ -778,7 +900,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListResponseDto.schema.json",
-    "fileMatch": ["a://b/StatusListResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/StatusListResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListResponseDto.schema.json",
@@ -808,9 +932,14 @@
           "example": "my-status-list-keychain"
         },
         "bits": {
-          "type": "number",
           "description": "Bits per status value",
-          "enum": [1, 2, 4, 8],
+          "enum": [
+            1,
+            2,
+            4,
+            8
+          ],
+          "type": "number",
           "example": 1
         },
         "capacity": {
@@ -862,7 +991,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateStatusListDto.schema.json",
-    "fileMatch": ["a://b/CreateStatusListDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CreateStatusListDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateStatusListDto.schema.json",
@@ -880,9 +1011,14 @@
           "example": "my-status-list-keychain"
         },
         "bits": {
-          "type": "number",
           "description": "Bits per status value. More bits allow more status states. Defaults to tenant configuration.",
-          "enum": [1, 2, 4, 8],
+          "enum": [
+            1,
+            2,
+            4,
+            8
+          ],
+          "type": "number",
           "example": 1
         },
         "capacity": {
@@ -897,7 +1033,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateStatusListDto.schema.json",
-    "fileMatch": ["a://b/UpdateStatusListDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateStatusListDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateStatusListDto.schema.json",
@@ -922,7 +1060,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthorizeQueries.schema.json",
-    "fileMatch": ["a://b/AuthorizeQueries*.schema.json"],
+    "fileMatch": [
+      "a://b/AuthorizeQueries*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthorizeQueries.schema.json",
@@ -975,7 +1115,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/OfferRequestDto.schema.json",
-    "fileMatch": ["a://b/OfferRequestDto*.schema.json"],
+    "fileMatch": [
+      "a://b/OfferRequestDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/OfferRequestDto.schema.json",
@@ -983,7 +1125,10 @@
       "type": "object",
       "properties": {
         "response_type": {
-          "enum": ["uri", "dc-api"],
+          "enum": [
+            "uri",
+            "dc-api"
+          ],
           "type": "string",
           "examples": [
             {
@@ -995,64 +1140,79 @@
         "credentialClaims": {
           "type": "object",
           "description": "Credential claims configuration per credential. Keys must match credentialConfigurationIds.",
-          "properties": {
-            "additionalProperties": {
-              "oneOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "type": {
-                      "type": "string",
-                      "enum": ["inline"]
-                    },
-                    "claims": {
-                      "type": "object",
-                      "additionalProperties": true
-                    }
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "inline"
+                    ]
                   },
-                  "required": ["type", "claims"],
-                  "additionalProperties": false
+                  "claims": {
+                    "type": "object",
+                    "additionalProperties": true
+                  }
                 },
-                {
-                  "type": "object",
-                  "properties": {
-                    "type": {
-                      "type": "string",
-                      "enum": ["attributeProvider"]
-                    },
-                    "attributeProviderId": {
-                      "type": "string"
-                    }
+                "required": [
+                  "type",
+                  "claims"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "attributeProvider"
+                    ]
                   },
-                  "required": ["type", "attributeProviderId"],
-                  "additionalProperties": false
+                  "attributeProviderId": {
+                    "type": "string"
+                  }
                 },
-                {
-                  "type": "object",
-                  "properties": {
-                    "type": {
-                      "type": "string",
-                      "enum": ["webhook"]
-                    },
-                    "webhook": {
-                      "type": "object",
-                      "properties": {
-                        "url": {
-                          "type": "string"
-                        },
-                        "auth": {
-                          "type": "object"
-                        }
+                "required": [
+                  "type",
+                  "attributeProviderId"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "webhook"
+                    ]
+                  },
+                  "webhook": {
+                    "type": "object",
+                    "properties": {
+                      "url": {
+                        "type": "string"
                       },
-                      "required": ["url"],
-                      "additionalProperties": false
-                    }
-                  },
-                  "required": ["type", "webhook"],
-                  "additionalProperties": false
-                }
-              ]
-            }
+                      "auth": {
+                        "type": "object"
+                      }
+                    },
+                    "required": [
+                      "url"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "type",
+                  "webhook"
+                ],
+                "additionalProperties": false
+              }
+            ]
           },
           "example": {
             "citizen": {
@@ -1062,12 +1222,14 @@
                 "family_name": "Doe"
               }
             }
-          },
-          "additionalProperties": false
+          }
         },
         "flow": {
           "description": "The flow type for the offer request.",
-          "enum": ["authorization_code", "pre_authorized_code"],
+          "enum": [
+            "authorization_code",
+            "pre_authorized_code"
+          ],
           "type": "string"
         },
         "tx_code": {
@@ -1094,13 +1256,19 @@
           "description": "ID of the webhook endpoint to notify about the status of the issuance process."
         }
       },
-      "required": ["response_type", "flow", "credentialConfigurationIds"],
+      "required": [
+        "response_type",
+        "flow",
+        "credentialConfigurationIds"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebHookAuthConfigNone.schema.json",
-    "fileMatch": ["a://b/WebHookAuthConfigNone*.schema.json"],
+    "fileMatch": [
+      "a://b/WebHookAuthConfigNone*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebHookAuthConfigNone.schema.json",
@@ -1110,16 +1278,22 @@
         "type": {
           "type": "string",
           "description": "The type of authentication used for the webhook.",
-          "enum": ["none"]
+          "enum": [
+            "none"
+          ]
         }
       },
-      "required": ["type"],
+      "required": [
+        "type"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ApiKeyConfig.schema.json",
-    "fileMatch": ["a://b/ApiKeyConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/ApiKeyConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ApiKeyConfig.schema.json",
@@ -1135,13 +1309,18 @@
           "description": "The value of the API key to be sent in the header."
         }
       },
-      "required": ["headerName", "value"],
+      "required": [
+        "headerName",
+        "value"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebHookAuthConfigHeader.schema.json",
-    "fileMatch": ["a://b/WebHookAuthConfigHeader*.schema.json"],
+    "fileMatch": [
+      "a://b/WebHookAuthConfigHeader*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebHookAuthConfigHeader.schema.json",
@@ -1151,7 +1330,9 @@
         "type": {
           "type": "string",
           "description": "The type of authentication used for the webhook.",
-          "enum": ["apiKey"]
+          "enum": [
+            "apiKey"
+          ]
         },
         "config": {
           "description": "Configuration for API key authentication.\nThis is required if the type is 'apiKey'.",
@@ -1162,13 +1343,18 @@
           ]
         }
       },
-      "required": ["type", "config"],
+      "required": [
+        "type",
+        "config"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebhookConfig.schema.json",
-    "fileMatch": ["a://b/WebhookConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/WebhookConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebhookConfig.schema.json",
@@ -1198,13 +1384,18 @@
           "description": "The URL to which the webhook will send notifications."
         }
       },
-      "required": ["auth", "url"],
+      "required": [
+        "auth",
+        "url"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TransactionData.schema.json",
-    "fileMatch": ["a://b/TransactionData*.schema.json"],
+    "fileMatch": [
+      "a://b/TransactionData*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TransactionData.schema.json",
@@ -1221,13 +1412,18 @@
           }
         }
       },
-      "required": ["type", "credential_ids"],
+      "required": [
+        "type",
+        "credential_ids"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Session.schema.json",
-    "fileMatch": ["a://b/Session*.schema.json"],
+    "fileMatch": [
+      "a://b/Session*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Session.schema.json",
@@ -1236,7 +1432,13 @@
       "properties": {
         "status": {
           "description": "Status of the session.",
-          "enum": ["active", "fetched", "completed", "expired", "failed"],
+          "enum": [
+            "active",
+            "fetched",
+            "completed",
+            "expired",
+            "failed"
+          ],
           "type": "string"
         },
         "id": {
@@ -1425,7 +1627,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PaginatedSessionResponseDto.schema.json",
-    "fileMatch": ["a://b/PaginatedSessionResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/PaginatedSessionResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PaginatedSessionResponseDto.schema.json",
@@ -1456,13 +1660,21 @@
           "description": "Total number of pages"
         }
       },
-      "required": ["items", "total", "page", "pageSize", "totalPages"],
+      "required": [
+        "items",
+        "total",
+        "page",
+        "pageSize",
+        "totalPages"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SessionLogEntryResponseDto.schema.json",
-    "fileMatch": ["a://b/SessionLogEntryResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/SessionLogEntryResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SessionLogEntryResponseDto.schema.json",
@@ -1485,7 +1697,11 @@
         "level": {
           "type": "string",
           "description": "Log level",
-          "enum": ["info", "warn", "error"]
+          "enum": [
+            "info",
+            "warn",
+            "error"
+          ]
         },
         "stage": {
           "type": "string",
@@ -1500,13 +1716,21 @@
           "description": "Additional structured detail"
         }
       },
-      "required": ["id", "sessionId", "timestamp", "level", "message"],
+      "required": [
+        "id",
+        "sessionId",
+        "timestamp",
+        "level",
+        "message"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusUpdateDto.schema.json",
-    "fileMatch": ["a://b/StatusUpdateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/StatusUpdateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusUpdateDto.schema.json",
@@ -1526,13 +1750,18 @@
           "description": "The status of the credential\n0 = valid, 1 = revoked, 2 = suspended"
         }
       },
-      "required": ["sessionId", "status"],
+      "required": [
+        "sessionId",
+        "status"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateSessionConfigDto.schema.json",
-    "fileMatch": ["a://b/UpdateSessionConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateSessionConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateSessionConfigDto.schema.json",
@@ -1548,7 +1777,10 @@
         },
         "cleanupMode": {
           "description": "Cleanup mode: 'full' deletes everything, 'anonymize' keeps metadata but removes PII.",
-          "enum": ["full", "anonymize"],
+          "enum": [
+            "full",
+            "anonymize"
+          ],
           "type": "string",
           "default": "full"
         }
@@ -1558,7 +1790,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ManagedUserDto.schema.json",
-    "fileMatch": ["a://b/ManagedUserDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ManagedUserDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ManagedUserDto.schema.json",
@@ -1607,13 +1841,20 @@
           "description": "One-time temporary password returned only on user creation."
         }
       },
-      "required": ["id", "username", "enabled", "roles"],
+      "required": [
+        "id",
+        "username",
+        "enabled",
+        "roles"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateUserDto.schema.json",
-    "fileMatch": ["a://b/CreateUserDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CreateUserDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateUserDto.schema.json",
@@ -1655,13 +1896,18 @@
           "example": true
         }
       },
-      "required": ["username", "roles"],
+      "required": [
+        "username",
+        "roles"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateUserDto.schema.json",
-    "fileMatch": ["a://b/UpdateUserDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateUserDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateUserDto.schema.json",
@@ -1713,7 +1959,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodNone.schema.json",
-    "fileMatch": ["a://b/AuthenticationMethodNone*.schema.json"],
+    "fileMatch": [
+      "a://b/AuthenticationMethodNone*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodNone.schema.json",
@@ -1722,16 +1970,22 @@
       "properties": {
         "method": {
           "type": "string",
-          "enum": ["none"]
+          "enum": [
+            "none"
+          ]
         }
       },
-      "required": ["method"],
+      "required": [
+        "method"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationUrlConfig.schema.json",
-    "fileMatch": ["a://b/AuthenticationUrlConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/AuthenticationUrlConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationUrlConfig.schema.json",
@@ -1751,13 +2005,17 @@
           ]
         }
       },
-      "required": ["url"],
+      "required": [
+        "url"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodAuth.schema.json",
-    "fileMatch": ["a://b/AuthenticationMethodAuth*.schema.json"],
+    "fileMatch": [
+      "a://b/AuthenticationMethodAuth*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodAuth.schema.json",
@@ -1766,19 +2024,26 @@
       "properties": {
         "method": {
           "type": "string",
-          "enum": ["auth"]
+          "enum": [
+            "auth"
+          ]
         },
         "config": {
           "$ref": "./AuthenticationUrlConfig.schema.json"
         }
       },
-      "required": ["method", "config"],
+      "required": [
+        "method",
+        "config"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationDuringIssuanceConfig.schema.json",
-    "fileMatch": ["a://b/PresentationDuringIssuanceConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/PresentationDuringIssuanceConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationDuringIssuanceConfig.schema.json",
@@ -1790,13 +2055,17 @@
           "description": "Link to the presentation configuration that is relevant for the issuance process"
         }
       },
-      "required": ["type"],
+      "required": [
+        "type"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodPresentation.schema.json",
-    "fileMatch": ["a://b/AuthenticationMethodPresentation*.schema.json"],
+    "fileMatch": [
+      "a://b/AuthenticationMethodPresentation*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodPresentation.schema.json",
@@ -1805,19 +2074,26 @@
       "properties": {
         "method": {
           "type": "string",
-          "enum": ["presentationDuringIssuance"]
+          "enum": [
+            "presentationDuringIssuance"
+          ]
         },
         "config": {
           "$ref": "./PresentationDuringIssuanceConfig.schema.json"
         }
       },
-      "required": ["method", "config"],
+      "required": [
+        "method",
+        "config"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpstreamOidcConfig.schema.json",
-    "fileMatch": ["a://b/UpstreamOidcConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/UpstreamOidcConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpstreamOidcConfig.schema.json",
@@ -1841,20 +2117,28 @@
         },
         "scopes": {
           "description": "Scopes to request from the upstream provider",
-          "default": ["openid", "profile"],
+          "default": [
+            "openid",
+            "profile"
+          ],
           "type": "array",
           "items": {
             "type": "string"
           }
         }
       },
-      "required": ["issuer", "clientId"],
+      "required": [
+        "issuer",
+        "clientId"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenConfig.schema.json",
-    "fileMatch": ["a://b/ChainedAsTokenConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/ChainedAsTokenConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenConfig.schema.json",
@@ -1877,7 +2161,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsConfig.schema.json",
-    "fileMatch": ["a://b/ChainedAsConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/ChainedAsConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsConfig.schema.json",
@@ -1911,13 +2197,17 @@
           "default": true
         }
       },
-      "required": ["enabled"],
+      "required": [
+        "enabled"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FederationTrustAnchorConfig.schema.json",
-    "fileMatch": ["a://b/FederationTrustAnchorConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/FederationTrustAnchorConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FederationTrustAnchorConfig.schema.json",
@@ -1935,13 +2225,18 @@
           "example": "https://ta.example.org/.well-known/openid-federation"
         }
       },
-      "required": ["entityId", "entityConfigurationUri"],
+      "required": [
+        "entityId",
+        "entityConfigurationUri"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FederationConfig.schema.json",
-    "fileMatch": ["a://b/FederationConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/FederationConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FederationConfig.schema.json",
@@ -1949,13 +2244,20 @@
       "type": "object",
       "properties": {
         "role": {
-          "enum": ["trust_anchor", "intermediate", "leaf"],
+          "enum": [
+            "trust_anchor",
+            "intermediate",
+            "leaf"
+          ],
           "type": "string",
           "description": "Role this tenant plays in the OpenID Federation topology.",
           "default": "leaf"
         },
         "mode": {
-          "enum": ["federation-only", "hybrid"],
+          "enum": [
+            "federation-only",
+            "hybrid"
+          ],
           "type": "string",
           "description": "Trust decision strategy when both LoTE trust lists and OpenID Federation are configured.",
           "default": "hybrid"
@@ -1983,13 +2285,17 @@
           }
         }
       },
-      "required": ["trustAnchors"],
+      "required": [
+        "trustAnchors"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayLogo.schema.json",
-    "fileMatch": ["a://b/DisplayLogo*.schema.json"],
+    "fileMatch": [
+      "a://b/DisplayLogo*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayLogo.schema.json",
@@ -2003,13 +2309,17 @@
           "type": "string"
         }
       },
-      "required": ["uri"],
+      "required": [
+        "uri"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayInfo.schema.json",
-    "fileMatch": ["a://b/DisplayInfo*.schema.json"],
+    "fileMatch": [
+      "a://b/DisplayInfo*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayInfo.schema.json",
@@ -2031,7 +2341,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuanceConfig.schema.json",
-    "fileMatch": ["a://b/IssuanceConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/IssuanceConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuanceConfig.schema.json",
@@ -2144,13 +2456,20 @@
           "description": "The timestamp when the VP request was last updated."
         }
       },
-      "required": ["tenant", "display", "createdAt", "updatedAt"],
+      "required": [
+        "tenant",
+        "display",
+        "createdAt",
+        "updatedAt"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuanceDto.schema.json",
-    "fileMatch": ["a://b/IssuanceDto*.schema.json"],
+    "fileMatch": [
+      "a://b/IssuanceDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuanceDto.schema.json",
@@ -2245,13 +2564,17 @@
           }
         }
       },
-      "required": ["display"],
+      "required": [
+        "display"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClaimsQuery.schema.json",
-    "fileMatch": ["a://b/ClaimsQuery*.schema.json"],
+    "fileMatch": [
+      "a://b/ClaimsQuery*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClaimsQuery.schema.json",
@@ -2274,13 +2597,17 @@
           }
         }
       },
-      "required": ["path"],
+      "required": [
+        "path"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustedAuthorityQuery.schema.json",
-    "fileMatch": ["a://b/TrustedAuthorityQuery*.schema.json"],
+    "fileMatch": [
+      "a://b/TrustedAuthorityQuery*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustedAuthorityQuery.schema.json",
@@ -2289,7 +2616,10 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["etsi_tl", "openid_federation"]
+          "enum": [
+            "etsi_tl",
+            "openid_federation"
+          ]
         },
         "values": {
           "type": "array",
@@ -2298,13 +2628,18 @@
           }
         }
       },
-      "required": ["type", "values"],
+      "required": [
+        "type",
+        "values"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialQuery.schema.json",
-    "fileMatch": ["a://b/CredentialQuery*.schema.json"],
+    "fileMatch": [
+      "a://b/CredentialQuery*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialQuery.schema.json",
@@ -2336,13 +2671,19 @@
           }
         }
       },
-      "required": ["id", "format", "meta"],
+      "required": [
+        "id",
+        "format",
+        "meta"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialSetQuery.schema.json",
-    "fileMatch": ["a://b/CredentialSetQuery*.schema.json"],
+    "fileMatch": [
+      "a://b/CredentialSetQuery*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialSetQuery.schema.json",
@@ -2362,13 +2703,17 @@
           "type": "boolean"
         }
       },
-      "required": ["options"],
+      "required": [
+        "options"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PolicyCredential.schema.json",
-    "fileMatch": ["a://b/PolicyCredential*.schema.json"],
+    "fileMatch": [
+      "a://b/PolicyCredential*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PolicyCredential.schema.json",
@@ -2394,13 +2739,17 @@
           }
         }
       },
-      "required": ["credentials"],
+      "required": [
+        "credentials"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AttestationBasedPolicy.schema.json",
-    "fileMatch": ["a://b/AttestationBasedPolicy*.schema.json"],
+    "fileMatch": [
+      "a://b/AttestationBasedPolicy*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AttestationBasedPolicy.schema.json",
@@ -2409,7 +2758,9 @@
       "properties": {
         "policy": {
           "type": "string",
-          "enum": ["attestationBased"]
+          "enum": [
+            "attestationBased"
+          ]
         },
         "values": {
           "type": "array",
@@ -2418,13 +2769,18 @@
           }
         }
       },
-      "required": ["policy", "values"],
+      "required": [
+        "policy",
+        "values"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/NoneTrustPolicy.schema.json",
-    "fileMatch": ["a://b/NoneTrustPolicy*.schema.json"],
+    "fileMatch": [
+      "a://b/NoneTrustPolicy*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/NoneTrustPolicy.schema.json",
@@ -2433,16 +2789,22 @@
       "properties": {
         "policy": {
           "type": "string",
-          "enum": ["none"]
+          "enum": [
+            "none"
+          ]
         }
       },
-      "required": ["policy"],
+      "required": [
+        "policy"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AllowListPolicy.schema.json",
-    "fileMatch": ["a://b/AllowListPolicy*.schema.json"],
+    "fileMatch": [
+      "a://b/AllowListPolicy*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AllowListPolicy.schema.json",
@@ -2451,7 +2813,9 @@
       "properties": {
         "policy": {
           "type": "string",
-          "enum": ["allowList"]
+          "enum": [
+            "allowList"
+          ]
         },
         "values": {
           "type": "array",
@@ -2460,13 +2824,18 @@
           }
         }
       },
-      "required": ["policy", "values"],
+      "required": [
+        "policy",
+        "values"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RootOfTrustPolicy.schema.json",
-    "fileMatch": ["a://b/RootOfTrustPolicy*.schema.json"],
+    "fileMatch": [
+      "a://b/RootOfTrustPolicy*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RootOfTrustPolicy.schema.json",
@@ -2475,19 +2844,26 @@
       "properties": {
         "policy": {
           "type": "string",
-          "enum": ["rootOfTrust"]
+          "enum": [
+            "rootOfTrust"
+          ]
         },
         "values": {
           "type": "string"
         }
       },
-      "required": ["policy", "values"],
+      "required": [
+        "policy",
+        "values"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/VCT.schema.json",
-    "fileMatch": ["a://b/VCT*.schema.json"],
+    "fileMatch": [
+      "a://b/VCT*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/VCT.schema.json",
@@ -2521,7 +2897,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IaeActionOpenid4vpPresentation.schema.json",
-    "fileMatch": ["a://b/IaeActionOpenid4vpPresentation*.schema.json"],
+    "fileMatch": [
+      "a://b/IaeActionOpenid4vpPresentation*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IaeActionOpenid4vpPresentation.schema.json",
@@ -2529,7 +2907,9 @@
       "type": "object",
       "properties": {
         "type": {
-          "enum": ["openid4vp_presentation"],
+          "enum": [
+            "openid4vp_presentation"
+          ],
           "type": "string",
           "description": "Action type discriminator",
           "example": "openid4vp_presentation"
@@ -2545,13 +2925,18 @@
           "example": "pid-presentation-config"
         }
       },
-      "required": ["type", "presentationConfigId"],
+      "required": [
+        "type",
+        "presentationConfigId"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IaeActionRedirectToWeb.schema.json",
-    "fileMatch": ["a://b/IaeActionRedirectToWeb*.schema.json"],
+    "fileMatch": [
+      "a://b/IaeActionRedirectToWeb*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IaeActionRedirectToWeb.schema.json",
@@ -2559,7 +2944,9 @@
       "type": "object",
       "properties": {
         "type": {
-          "enum": ["redirect_to_web"],
+          "enum": [
+            "redirect_to_web"
+          ],
           "type": "string",
           "description": "Action type discriminator",
           "example": "redirect_to_web"
@@ -2587,13 +2974,18 @@
           "example": "Please complete the identity verification form"
         }
       },
-      "required": ["type", "url"],
+      "required": [
+        "type",
+        "url"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebhookEndpointEntity.schema.json",
-    "fileMatch": ["a://b/WebhookEndpointEntity*.schema.json"],
+    "fileMatch": [
+      "a://b/WebhookEndpointEntity*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebhookEndpointEntity.schema.json",
@@ -2631,13 +3023,22 @@
           "type": "string"
         }
       },
-      "required": ["id", "auth", "tenantId", "tenant", "name", "url"],
+      "required": [
+        "id",
+        "auth",
+        "tenantId",
+        "tenant",
+        "name",
+        "url"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaUriEntry.schema.json",
-    "fileMatch": ["a://b/SchemaUriEntry*.schema.json"],
+    "fileMatch": [
+      "a://b/SchemaUriEntry*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaUriEntry.schema.json",
@@ -2664,13 +3065,17 @@
           "additionalProperties": true
         }
       },
-      "required": ["meta"],
+      "required": [
+        "meta"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustAuthorityEntry.schema.json",
-    "fileMatch": ["a://b/TrustAuthorityEntry*.schema.json"],
+    "fileMatch": [
+      "a://b/TrustAuthorityEntry*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustAuthorityEntry.schema.json",
@@ -2682,7 +3087,11 @@
           "description": "Trust list ID to resolve from the database. When set, frameworkType, value, and verificationMethod are derived automatically."
         },
         "frameworkType": {
-          "enum": ["aki", "etsi_tl", "openid_federation"],
+          "enum": [
+            "aki",
+            "etsi_tl",
+            "openid_federation"
+          ],
           "type": "string",
           "description": "Trust framework type (ignored when trustListId is set)"
         },
@@ -2705,7 +3114,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetaConfig.schema.json",
-    "fileMatch": ["a://b/SchemaMetaConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/SchemaMetaConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetaConfig.schema.json",
@@ -2738,7 +3149,12 @@
           "description": "Attestation Level of Security"
         },
         "bindingType": {
-          "enum": ["claim", "key", "biometric", "none"],
+          "enum": [
+            "claim",
+            "key",
+            "biometric",
+            "none"
+          ],
           "type": "string",
           "description": "Cryptographic binding type"
         },
@@ -2762,7 +3178,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EmbeddedDisclosurePolicy.schema.json",
-    "fileMatch": ["a://b/EmbeddedDisclosurePolicy*.schema.json"],
+    "fileMatch": [
+      "a://b/EmbeddedDisclosurePolicy*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EmbeddedDisclosurePolicy.schema.json",
@@ -2773,13 +3191,17 @@
           "type": "string"
         }
       },
-      "required": ["policy"],
+      "required": [
+        "policy"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyAttestationsRequired.schema.json",
-    "fileMatch": ["a://b/KeyAttestationsRequired*.schema.json"],
+    "fileMatch": [
+      "a://b/KeyAttestationsRequired*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyAttestationsRequired.schema.json",
@@ -2788,7 +3210,10 @@
       "properties": {
         "key_storage": {
           "description": "List of required key storage types (e.g., iso_18045_high, iso_18045_moderate)",
-          "example": ["iso_18045_high", "iso_18045_moderate"],
+          "example": [
+            "iso_18045_high",
+            "iso_18045_moderate"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -2796,7 +3221,10 @@
         },
         "user_authentication": {
           "description": "List of required user authentication types (e.g., iso_18045_high, iso_18045_moderate)",
-          "example": ["iso_18045_high", "iso_18045_moderate"],
+          "example": [
+            "iso_18045_high",
+            "iso_18045_moderate"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -2808,7 +3236,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayImage.schema.json",
-    "fileMatch": ["a://b/DisplayImage*.schema.json"],
+    "fileMatch": [
+      "a://b/DisplayImage*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayImage.schema.json",
@@ -2819,13 +3249,17 @@
           "type": "string"
         }
       },
-      "required": ["uri"],
+      "required": [
+        "uri"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Display.schema.json",
-    "fileMatch": ["a://b/Display*.schema.json"],
+    "fileMatch": [
+      "a://b/Display*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Display.schema.json",
@@ -2854,13 +3288,19 @@
           "$ref": "./DisplayImage.schema.json"
         }
       },
-      "required": ["name", "description", "locale"],
+      "required": [
+        "name",
+        "description",
+        "locale"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerMetadataCredentialConfig.schema.json",
-    "fileMatch": ["a://b/IssuerMetadataCredentialConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/IssuerMetadataCredentialConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerMetadataCredentialConfig.schema.json",
@@ -2877,7 +3317,10 @@
         },
         "format": {
           "type": "string",
-          "enum": ["mso_mdoc", "dc+sd-jwt"]
+          "enum": [
+            "mso_mdoc",
+            "dc+sd-jwt"
+          ]
         },
         "display": {
           "type": "array",
@@ -2893,13 +3336,18 @@
           "description": "Document type for mDOC credentials (e.g., \"org.iso.18013.5.1.mDL\").\nOnly applicable when format is \"mso_mdoc\"."
         }
       },
-      "required": ["format", "display"],
+      "required": [
+        "format",
+        "display"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FieldDisplayDto.schema.json",
-    "fileMatch": ["a://b/FieldDisplayDto*.schema.json"],
+    "fileMatch": [
+      "a://b/FieldDisplayDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FieldDisplayDto.schema.json",
@@ -2922,13 +3370,18 @@
           "example": "Primary first name"
         }
       },
-      "required": ["locale", "name"],
+      "required": [
+        "locale",
+        "name"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClaimFieldDefinitionDto.schema.json",
-    "fileMatch": ["a://b/ClaimFieldDefinitionDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ClaimFieldDefinitionDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClaimFieldDefinitionDto.schema.json",
@@ -2938,7 +3391,10 @@
         "path": {
           "type": "array",
           "description": "Path to claim value",
-          "example": ["address", "locality"],
+          "example": [
+            "address",
+            "locality"
+          ],
           "items": {
             "oneOf": [
               {
@@ -2954,8 +3410,16 @@
           }
         },
         "type": {
+          "enum": [
+            "string",
+            "number",
+            "integer",
+            "boolean",
+            "object",
+            "array",
+            "date"
+          ],
           "type": "string",
-          "enum": ["string", "number", "integer", "boolean", "object", "array", "date"],
           "description": "Claim value type"
         },
         "defaultValue": {
@@ -3007,13 +3471,18 @@
           "description": "Additional JSON schema constraints for this field"
         }
       },
-      "required": ["path", "type"],
+      "required": [
+        "path",
+        "type"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AttributeProviderEntity.schema.json",
-    "fileMatch": ["a://b/AttributeProviderEntity*.schema.json"],
+    "fileMatch": [
+      "a://b/AttributeProviderEntity*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AttributeProviderEntity.schema.json",
@@ -3050,13 +3519,22 @@
           "type": "string"
         }
       },
-      "required": ["auth", "id", "tenantId", "tenant", "name", "url"],
+      "required": [
+        "auth",
+        "id",
+        "tenantId",
+        "tenant",
+        "name",
+        "url"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainEntity.schema.json",
-    "fileMatch": ["a://b/KeyChainEntity*.schema.json"],
+    "fileMatch": [
+      "a://b/KeyChainEntity*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainEntity.schema.json",
@@ -3086,12 +3564,21 @@
         "usageType": {
           "type": "string",
           "description": "The purpose/role of this key chain in the system.",
-          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"]
+          "enum": [
+            "access",
+            "attestation",
+            "trustList",
+            "statusList",
+            "encrypt"
+          ]
         },
         "usage": {
           "type": "string",
           "description": "The usage type of the keys (sign or encrypt).",
-          "enum": ["sign", "encrypt"]
+          "enum": [
+            "sign",
+            "encrypt"
+          ]
         },
         "kmsProvider": {
           "type": "string",
@@ -3171,7 +3658,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfig.schema.json",
-    "fileMatch": ["a://b/CredentialConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/CredentialConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfig.schema.json",
@@ -3236,7 +3725,6 @@
               "$ref": "./RootOfTrustPolicy.schema.json"
             }
           ],
-          "type": "object",
           "allOf": [
             {
               "$ref": "./EmbeddedDisclosurePolicy.schema.json"
@@ -3302,20 +3790,31 @@
         "sdJwtTrustFormat": {
           "nullable": true,
           "description": "For SD-JWT credentials: determines whether to include certificate chain (x5c)\nor use federation-based trust (iss claim).\nDefault: \"x5c\" (federation must be explicitly selected)",
-          "enum": ["x5c", "federation"],
+          "enum": [
+            "x5c",
+            "federation"
+          ],
           "type": "string"
         },
         "lifeTime": {
           "type": "number"
         }
       },
-      "required": ["id", "tenant", "config", "configVersion", "fields"],
+      "required": [
+        "id",
+        "tenant",
+        "config",
+        "configVersion",
+        "fields"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfigCreate.schema.json",
-    "fileMatch": ["a://b/CredentialConfigCreate*.schema.json"],
+    "fileMatch": [
+      "a://b/CredentialConfigCreate*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfigCreate.schema.json",
@@ -3380,7 +3879,6 @@
               "$ref": "./RootOfTrustPolicy.schema.json"
             }
           ],
-          "type": "object",
           "allOf": [
             {
               "$ref": "./EmbeddedDisclosurePolicy.schema.json"
@@ -3429,20 +3927,30 @@
         "sdJwtTrustFormat": {
           "nullable": true,
           "description": "For SD-JWT credentials: determines whether to include certificate chain (x5c)\nor use federation-based trust (iss claim).\nDefault: \"x5c\" (federation must be explicitly selected)",
-          "enum": ["x5c", "federation"],
+          "enum": [
+            "x5c",
+            "federation"
+          ],
           "type": "string"
         },
         "lifeTime": {
           "type": "number"
         }
       },
-      "required": ["id", "config", "configVersion", "fields"],
+      "required": [
+        "id",
+        "config",
+        "configVersion",
+        "fields"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfigUpdate.schema.json",
-    "fileMatch": ["a://b/CredentialConfigUpdate*.schema.json"],
+    "fileMatch": [
+      "a://b/CredentialConfigUpdate*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfigUpdate.schema.json",
@@ -3507,7 +4015,6 @@
               "$ref": "./RootOfTrustPolicy.schema.json"
             }
           ],
-          "type": "object",
           "allOf": [
             {
               "$ref": "./EmbeddedDisclosurePolicy.schema.json"
@@ -3556,7 +4063,10 @@
         "sdJwtTrustFormat": {
           "nullable": true,
           "description": "For SD-JWT credentials: determines whether to include certificate chain (x5c)\nor use federation-based trust (iss claim).\nDefault: \"x5c\" (federation must be explicitly selected)",
-          "enum": ["x5c", "federation"],
+          "enum": [
+            "x5c",
+            "federation"
+          ],
           "type": "string"
         },
         "lifeTime": {
@@ -3568,7 +4078,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SignSchemaMetaConfigDto.schema.json",
-    "fileMatch": ["a://b/SignSchemaMetaConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/SignSchemaMetaConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SignSchemaMetaConfigDto.schema.json",
@@ -3592,13 +4104,17 @@
           "description": "ID of the credential config to link back after submission. When provided, schemaMeta.id on the credential config is updated with the reserved attestation ID."
         }
       },
-      "required": ["config"],
+      "required": [
+        "config"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SignVersionSchemaMetaConfigDto.schema.json",
-    "fileMatch": ["a://b/SignVersionSchemaMetaConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/SignVersionSchemaMetaConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SignVersionSchemaMetaConfigDto.schema.json",
@@ -3618,13 +4134,17 @@
           "description": "ID of the key chain to use for signing. Defaults to the tenant's default key chain."
         }
       },
-      "required": ["config"],
+      "required": [
+        "config"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/VocabularyEntryDto.schema.json",
-    "fileMatch": ["a://b/VocabularyEntryDto*.schema.json"],
+    "fileMatch": [
+      "a://b/VocabularyEntryDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/VocabularyEntryDto.schema.json",
@@ -3640,22 +4160,31 @@
           "description": "Display label for UI rendering."
         },
         "status": {
+          "enum": [
+            "active",
+            "deprecated"
+          ],
           "type": "string",
-          "description": "Vocabulary lifecycle status.",
-          "enum": ["active", "deprecated"]
+          "description": "Vocabulary lifecycle status."
         },
         "replacedBy": {
           "type": "string",
           "description": "Replacement code when status is deprecated."
         }
       },
-      "required": ["code", "label", "status"],
+      "required": [
+        "code",
+        "label",
+        "status"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetadataVocabulariesDto.schema.json",
-    "fileMatch": ["a://b/SchemaMetadataVocabulariesDto*.schema.json"],
+    "fileMatch": [
+      "a://b/SchemaMetadataVocabulariesDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetadataVocabulariesDto.schema.json",
@@ -3681,13 +4210,19 @@
           }
         }
       },
-      "required": ["version", "categories", "tags"],
+      "required": [
+        "version",
+        "categories",
+        "tags"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/MetadataSchemaDto.schema.json",
-    "fileMatch": ["a://b/MetadataSchemaDto*.schema.json"],
+    "fileMatch": [
+      "a://b/MetadataSchemaDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/MetadataSchemaDto.schema.json",
@@ -3699,9 +4234,12 @@
           "description": "Unique identifier for this schema entry"
         },
         "formatIdentifier": {
+          "enum": [
+            "dc+sd-jwt",
+            "mso_mdoc"
+          ],
           "type": "string",
-          "description": "The credential format identifier",
-          "enum": ["dc+sd-jwt", "mso_mdoc"]
+          "description": "The credential format identifier"
         },
         "uri": {
           "type": "string",
@@ -3717,13 +4255,18 @@
           "description": "Subresource Integrity hash for the schema"
         }
       },
-      "required": ["id", "formatIdentifier"],
+      "required": [
+        "id",
+        "formatIdentifier"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustAuthorityDto.schema.json",
-    "fileMatch": ["a://b/TrustAuthorityDto*.schema.json"],
+    "fileMatch": [
+      "a://b/TrustAuthorityDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustAuthorityDto.schema.json",
@@ -3737,7 +4280,9 @@
         "frameworkType": {
           "type": "string",
           "description": "Type of trust framework",
-          "enum": ["etsi_tl"]
+          "enum": [
+            "etsi_tl"
+          ]
         },
         "value": {
           "type": "string",
@@ -3749,13 +4294,19 @@
           "additionalProperties": true
         }
       },
-      "required": ["id", "frameworkType", "value"],
+      "required": [
+        "id",
+        "frameworkType",
+        "value"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AccessCertificateRefDto.schema.json",
-    "fileMatch": ["a://b/AccessCertificateRefDto*.schema.json"],
+    "fileMatch": [
+      "a://b/AccessCertificateRefDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AccessCertificateRefDto.schema.json",
@@ -3778,13 +4329,21 @@
           "type": "string"
         }
       },
-      "required": ["id", "relyingPartyId", "certificate", "revoked", "createdAt"],
+      "required": [
+        "id",
+        "relyingPartyId",
+        "certificate",
+        "revoked",
+        "createdAt"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetadataResponseDto.schema.json",
-    "fileMatch": ["a://b/SchemaMetadataResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/SchemaMetadataResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetadataResponseDto.schema.json",
@@ -3808,27 +4367,35 @@
           "description": "Subresource Integrity hash for the rulebook URI"
         },
         "attestationLoS": {
-          "type": "string",
-          "description": "Level of security (LoS) of this attestation",
           "enum": [
             "iso_18045_high",
             "iso_18045_moderate",
             "iso_18045_enhanced-basic",
             "iso_18045_basic"
-          ]
+          ],
+          "type": "string",
+          "description": "Level of security (LoS) of this attestation"
         },
         "bindingType": {
+          "enum": [
+            "claim",
+            "key",
+            "biometric",
+            "none"
+          ],
           "type": "string",
-          "description": "Required binding type between attestation and holder",
-          "enum": ["claim", "key", "biometric", "none"]
+          "description": "Required binding type between attestation and holder"
         },
         "supportedFormats": {
           "type": "array",
-          "description": "Credential formats in which this attestation is available",
           "items": {
             "type": "string",
-            "enum": ["dc+sd-jwt", "mso_mdoc"]
-          }
+            "enum": [
+              "dc+sd-jwt",
+              "mso_mdoc"
+            ]
+          },
+          "description": "Credential formats in which this attestation is available"
         },
         "schemaURIs": {
           "description": "Format-specific schema URIs for this schema metadata",
@@ -3845,9 +4412,17 @@
           }
         },
         "category": {
+          "enum": [
+            "identity",
+            "health",
+            "finance",
+            "education",
+            "mobility",
+            "employment",
+            "other"
+          ],
           "type": "string",
-          "description": "Domain category for filtering",
-          "enum": ["identity", "health", "finance", "education", "mobility", "employment", "other"]
+          "description": "Domain category for filtering"
         },
         "tags": {
           "description": "Free-form tags for filtering and search",
@@ -3921,7 +4496,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateSchemaMetadataDto.schema.json",
-    "fileMatch": ["a://b/UpdateSchemaMetadataDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateSchemaMetadataDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateSchemaMetadataDto.schema.json",
@@ -3929,13 +4506,20 @@
       "type": "object",
       "properties": {
         "category": {
+          "enum": [
+            "identity",
+            "health",
+            "finance",
+            "education",
+            "mobility",
+            "employment",
+            "other"
+          ],
           "type": "string",
-          "description": "Domain category for filtering",
-          "enum": ["identity", "health", "finance", "education", "mobility", "employment", "other"]
+          "description": "Domain category for filtering"
         },
         "tags": {
           "type": "array",
-          "description": "Predefined tags for filtering and search",
           "items": {
             "type": "string",
             "enum": [
@@ -3950,7 +4534,8 @@
               "employment",
               "mobility"
             ]
-          }
+          },
+          "description": "Predefined tags for filtering and search"
         }
       },
       "additionalProperties": false
@@ -3958,7 +4543,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeprecateSchemaMetadataDto.schema.json",
-    "fileMatch": ["a://b/DeprecateSchemaMetadataDto*.schema.json"],
+    "fileMatch": [
+      "a://b/DeprecateSchemaMetadataDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeprecateSchemaMetadataDto.schema.json",
@@ -3978,13 +4565,17 @@
           "description": "The version that supersedes this one"
         }
       },
-      "required": ["deprecated"],
+      "required": [
+        "deprecated"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateAttributeProviderDto.schema.json",
-    "fileMatch": ["a://b/CreateAttributeProviderDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CreateAttributeProviderDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateAttributeProviderDto.schema.json",
@@ -4015,13 +4606,20 @@
           "type": "string"
         }
       },
-      "required": ["auth", "id", "name", "url"],
+      "required": [
+        "auth",
+        "id",
+        "name",
+        "url"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateAttributeProviderDto.schema.json",
-    "fileMatch": ["a://b/UpdateAttributeProviderDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateAttributeProviderDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateAttributeProviderDto.schema.json",
@@ -4057,7 +4655,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateWebhookEndpointDto.schema.json",
-    "fileMatch": ["a://b/CreateWebhookEndpointDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CreateWebhookEndpointDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateWebhookEndpointDto.schema.json",
@@ -4089,13 +4689,20 @@
           "type": "string"
         }
       },
-      "required": ["id", "auth", "name", "url"],
+      "required": [
+        "id",
+        "auth",
+        "name",
+        "url"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateWebhookEndpointDto.schema.json",
-    "fileMatch": ["a://b/UpdateWebhookEndpointDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateWebhookEndpointDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateWebhookEndpointDto.schema.json",
@@ -4132,7 +4739,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListEntityInfo.schema.json",
-    "fileMatch": ["a://b/TrustListEntityInfo*.schema.json"],
+    "fileMatch": [
+      "a://b/TrustListEntityInfo*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListEntityInfo.schema.json",
@@ -4164,13 +4773,17 @@
           "type": "string"
         }
       },
-      "required": ["name"],
+      "required": [
+        "name"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InternalTrustListEntity.schema.json",
-    "fileMatch": ["a://b/InternalTrustListEntity*.schema.json"],
+    "fileMatch": [
+      "a://b/InternalTrustListEntity*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InternalTrustListEntity.schema.json",
@@ -4179,7 +4792,9 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["internal"]
+          "enum": [
+            "internal"
+          ]
         },
         "issuerKeyChainId": {
           "type": "string"
@@ -4191,13 +4806,20 @@
           "$ref": "./TrustListEntityInfo.schema.json"
         }
       },
-      "required": ["type", "issuerKeyChainId", "revocationKeyChainId", "info"],
+      "required": [
+        "type",
+        "issuerKeyChainId",
+        "revocationKeyChainId",
+        "info"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExternalTrustListEntity.schema.json",
-    "fileMatch": ["a://b/ExternalTrustListEntity*.schema.json"],
+    "fileMatch": [
+      "a://b/ExternalTrustListEntity*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExternalTrustListEntity.schema.json",
@@ -4206,7 +4828,9 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["external"]
+          "enum": [
+            "external"
+          ]
         },
         "issuerCertPem": {
           "type": "string"
@@ -4218,13 +4842,20 @@
           "$ref": "./TrustListEntityInfo.schema.json"
         }
       },
-      "required": ["type", "issuerCertPem", "revocationCertPem", "info"],
+      "required": [
+        "type",
+        "issuerCertPem",
+        "revocationCertPem",
+        "info"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListCreateDto.schema.json",
-    "fileMatch": ["a://b/TrustListCreateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/TrustListCreateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListCreateDto.schema.json",
@@ -4265,13 +4896,17 @@
           "type": "string"
         }
       },
-      "required": ["entities"],
+      "required": [
+        "entities"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustList.schema.json",
-    "fileMatch": ["a://b/TrustList*.schema.json"],
+    "fileMatch": [
+      "a://b/TrustList*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustList.schema.json",
@@ -4347,7 +4982,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListVersion.schema.json",
-    "fileMatch": ["a://b/TrustListVersion*.schema.json"],
+    "fileMatch": [
+      "a://b/TrustListVersion*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListVersion.schema.json",
@@ -4402,7 +5039,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DCQL.schema.json",
-    "fileMatch": ["a://b/DCQL*.schema.json"],
+    "fileMatch": [
+      "a://b/DCQL*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DCQL.schema.json",
@@ -4422,13 +5061,17 @@
           }
         }
       },
-      "required": ["credentials"],
+      "required": [
+        "credentials"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificatePurpose.schema.json",
-    "fileMatch": ["a://b/RegistrationCertificatePurpose*.schema.json"],
+    "fileMatch": [
+      "a://b/RegistrationCertificatePurpose*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificatePurpose.schema.json",
@@ -4442,13 +5085,18 @@
           "type": "string"
         }
       },
-      "required": ["lang", "content"],
+      "required": [
+        "lang",
+        "content"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateBody.schema.json",
-    "fileMatch": ["a://b/RegistrationCertificateBody*.schema.json"],
+    "fileMatch": [
+      "a://b/RegistrationCertificateBody*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateBody.schema.json",
@@ -4488,7 +5136,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateRequest.schema.json",
-    "fileMatch": ["a://b/RegistrationCertificateRequest*.schema.json"],
+    "fileMatch": [
+      "a://b/RegistrationCertificateRequest*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateRequest.schema.json",
@@ -4517,7 +5167,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationAttachment.schema.json",
-    "fileMatch": ["a://b/PresentationAttachment*.schema.json"],
+    "fileMatch": [
+      "a://b/PresentationAttachment*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationAttachment.schema.json",
@@ -4537,13 +5189,18 @@
           }
         }
       },
-      "required": ["format", "data"],
+      "required": [
+        "format",
+        "data"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfig.schema.json",
-    "fileMatch": ["a://b/PresentationConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/PresentationConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfig.schema.json",
@@ -4643,13 +5300,21 @@
           "description": "Optional ID of the access certificate to use for signing the presentation request.\nIf not provided, the default access certificate for the tenant will be used.\n\nNote: This is intentionally NOT a TypeORM relationship because CertEntity uses\na composite primary key (id + tenantId), and SQLite cannot create foreign keys\nthat reference only part of a composite primary key. The relationship is handled\nat the application level in the service layer."
         }
       },
-      "required": ["id", "tenant", "dcql_query", "createdAt", "updatedAt"],
+      "required": [
+        "id",
+        "tenant",
+        "dcql_query",
+        "createdAt",
+        "updatedAt"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ResolveIssuerMetadataDto.schema.json",
-    "fileMatch": ["a://b/ResolveIssuerMetadataDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ResolveIssuerMetadataDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ResolveIssuerMetadataDto.schema.json",
@@ -4663,13 +5328,17 @@
           "example": "https://issuer.example.com/issuers/tenant-a"
         }
       },
-      "required": ["issuerUrl"],
+      "required": [
+        "issuerUrl"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ResolveSchemaMetadataDto.schema.json",
-    "fileMatch": ["a://b/ResolveSchemaMetadataDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ResolveSchemaMetadataDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ResolveSchemaMetadataDto.schema.json",
@@ -4683,13 +5352,17 @@
           "example": "https://registrar.example.com/schema-metadata/5c0d7dbb-ef2e-448b-b84f-b8103575947b"
         }
       },
-      "required": ["schemaMetadataUrl"],
+      "required": [
+        "schemaMetadataUrl"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfigCreateDto.schema.json",
-    "fileMatch": ["a://b/PresentationConfigCreateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/PresentationConfigCreateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfigCreateDto.schema.json",
@@ -4763,13 +5436,18 @@
           "description": "Optional ID of the access certificate to use for signing the presentation request.\nIf not provided, the default access certificate for the tenant will be used.\n\nNote: This is intentionally NOT a TypeORM relationship because CertEntity uses\na composite primary key (id + tenantId), and SQLite cannot create foreign keys\nthat reference only part of a composite primary key. The relationship is handled\nat the application level in the service layer."
         }
       },
-      "required": ["id", "dcql_query"],
+      "required": [
+        "id",
+        "dcql_query"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfigUpdateDto.schema.json",
-    "fileMatch": ["a://b/PresentationConfigUpdateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/PresentationConfigUpdateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfigUpdateDto.schema.json",
@@ -4848,7 +5526,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateDefaults.schema.json",
-    "fileMatch": ["a://b/RegistrationCertificateDefaults*.schema.json"],
+    "fileMatch": [
+      "a://b/RegistrationCertificateDefaults*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateDefaults.schema.json",
@@ -4871,7 +5551,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrarConfigResponseDto.schema.json",
-    "fileMatch": ["a://b/RegistrarConfigResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/RegistrarConfigResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrarConfigResponseDto.schema.json",
@@ -4919,13 +5601,21 @@
           "example": true
         }
       },
-      "required": ["registrarUrl", "oidcUrl", "clientId", "username", "hasPassword"],
+      "required": [
+        "registrarUrl",
+        "oidcUrl",
+        "clientId",
+        "username",
+        "hasPassword"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateRegistrarConfigDto.schema.json",
-    "fileMatch": ["a://b/CreateRegistrarConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CreateRegistrarConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateRegistrarConfigDto.schema.json",
@@ -4972,13 +5662,21 @@
           ]
         }
       },
-      "required": ["registrarUrl", "oidcUrl", "clientId", "username", "password"],
+      "required": [
+        "registrarUrl",
+        "oidcUrl",
+        "clientId",
+        "username",
+        "password"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateRegistrarConfigDto.schema.json",
-    "fileMatch": ["a://b/UpdateRegistrarConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateRegistrarConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateRegistrarConfigDto.schema.json",
@@ -5030,7 +5728,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateAccessCertificateDto.schema.json",
-    "fileMatch": ["a://b/CreateAccessCertificateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CreateAccessCertificateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateAccessCertificateDto.schema.json",
@@ -5043,13 +5743,17 @@
           "example": "my-signing-key"
         }
       },
-      "required": ["keyId"],
+      "required": [
+        "keyId"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeferredCredentialRequestDto.schema.json",
-    "fileMatch": ["a://b/DeferredCredentialRequestDto*.schema.json"],
+    "fileMatch": [
+      "a://b/DeferredCredentialRequestDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeferredCredentialRequestDto.schema.json",
@@ -5062,13 +5766,17 @@
           "example": "8xLOxBtZp8"
         }
       },
-      "required": ["transaction_id"],
+      "required": [
+        "transaction_id"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/NotificationRequestDto.schema.json",
-    "fileMatch": ["a://b/NotificationRequestDto*.schema.json"],
+    "fileMatch": [
+      "a://b/NotificationRequestDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/NotificationRequestDto.schema.json",
@@ -5079,16 +5787,26 @@
           "type": "string"
         },
         "event": {
-          "type": "object"
+          "type": "string",
+          "enum": [
+            "credential_accepted",
+            "credential_failure",
+            "credential_deleted"
+          ]
         }
       },
-      "required": ["notification_id", "event"],
+      "required": [
+        "notification_id",
+        "event"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Object.schema.json",
-    "fileMatch": ["a://b/Object*.schema.json"],
+    "fileMatch": [
+      "a://b/Object*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Object.schema.json",
@@ -5100,7 +5818,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ParResponseDto.schema.json",
-    "fileMatch": ["a://b/ParResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ParResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ParResponseDto.schema.json",
@@ -5116,13 +5836,18 @@
           "description": "The expiration time for the request URI in seconds."
         }
       },
-      "required": ["request_uri", "expires_in"],
+      "required": [
+        "request_uri",
+        "expires_in"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationRequestDto.schema.json",
-    "fileMatch": ["a://b/InteractiveAuthorizationRequestDto*.schema.json"],
+    "fileMatch": [
+      "a://b/InteractiveAuthorizationRequestDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationRequestDto.schema.json",
@@ -5195,7 +5920,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationCodeResponseDto.schema.json",
-    "fileMatch": ["a://b/InteractiveAuthorizationCodeResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/InteractiveAuthorizationCodeResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationCodeResponseDto.schema.json",
@@ -5213,13 +5940,18 @@
           "example": "auth-code-123"
         }
       },
-      "required": ["status", "code"],
+      "required": [
+        "status",
+        "code"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationErrorResponseDto.schema.json",
-    "fileMatch": ["a://b/InteractiveAuthorizationErrorResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/InteractiveAuthorizationErrorResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationErrorResponseDto.schema.json",
@@ -5237,13 +5969,17 @@
           "example": "Missing required parameter: interaction_types_supported"
         }
       },
-      "required": ["error"],
+      "required": [
+        "error"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsParResponseDto.schema.json",
-    "fileMatch": ["a://b/ChainedAsParResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ChainedAsParResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsParResponseDto.schema.json",
@@ -5261,13 +5997,18 @@
           "example": 600
         }
       },
-      "required": ["request_uri", "expires_in"],
+      "required": [
+        "request_uri",
+        "expires_in"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsErrorResponseDto.schema.json",
-    "fileMatch": ["a://b/ChainedAsErrorResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ChainedAsErrorResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsErrorResponseDto.schema.json",
@@ -5284,13 +6025,17 @@
           "description": "Human-readable error description"
         }
       },
-      "required": ["error"],
+      "required": [
+        "error"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenRequestDto.schema.json",
-    "fileMatch": ["a://b/ChainedAsTokenRequestDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ChainedAsTokenRequestDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenRequestDto.schema.json",
@@ -5323,13 +6068,17 @@
           "description": "PKCE code verifier"
         }
       },
-      "required": ["grant_type"],
+      "required": [
+        "grant_type"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenResponseDto.schema.json",
-    "fileMatch": ["a://b/ChainedAsTokenResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ChainedAsTokenResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenResponseDto.schema.json",
@@ -5374,13 +6123,19 @@
           "description": "Refresh token (issued when refresh tokens are enabled)"
         }
       },
-      "required": ["access_token", "token_type", "expires_in"],
+      "required": [
+        "access_token",
+        "token_type",
+        "expires_in"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/OfferResponse.schema.json",
-    "fileMatch": ["a://b/OfferResponse*.schema.json"],
+    "fileMatch": [
+      "a://b/OfferResponse*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/OfferResponse.schema.json",
@@ -5398,13 +6153,18 @@
           "type": "string"
         }
       },
-      "required": ["uri", "session"],
+      "required": [
+        "uri",
+        "session"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CompleteDeferredDto.schema.json",
-    "fileMatch": ["a://b/CompleteDeferredDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CompleteDeferredDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CompleteDeferredDto.schema.json",
@@ -5421,13 +6181,17 @@
           }
         }
       },
-      "required": ["claims"],
+      "required": [
+        "claims"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeferredOperationResponse.schema.json",
-    "fileMatch": ["a://b/DeferredOperationResponse*.schema.json"],
+    "fileMatch": [
+      "a://b/DeferredOperationResponse*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeferredOperationResponse.schema.json",
@@ -5440,7 +6204,13 @@
         },
         "status": {
           "description": "The new status of the transaction",
-          "enum": ["pending", "ready", "retrieved", "expired", "failed"],
+          "enum": [
+            "pending",
+            "ready",
+            "retrieved",
+            "expired",
+            "failed"
+          ],
           "type": "string"
         },
         "message": {
@@ -5448,13 +6218,18 @@
           "description": "Optional message"
         }
       },
-      "required": ["transactionId", "status"],
+      "required": [
+        "transactionId",
+        "status"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FailDeferredDto.schema.json",
-    "fileMatch": ["a://b/FailDeferredDto*.schema.json"],
+    "fileMatch": [
+      "a://b/FailDeferredDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FailDeferredDto.schema.json",
@@ -5472,7 +6247,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EC_Public.schema.json",
-    "fileMatch": ["a://b/EC_Public*.schema.json"],
+    "fileMatch": [
+      "a://b/EC_Public*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EC_Public.schema.json",
@@ -5496,13 +6273,20 @@
           "description": "The y coordinate of the EC public key."
         }
       },
-      "required": ["kty", "crv", "x", "y"],
+      "required": [
+        "kty",
+        "crv",
+        "x",
+        "y"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/JwksResponseDto.schema.json",
-    "fileMatch": ["a://b/JwksResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/JwksResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/JwksResponseDto.schema.json",
@@ -5517,13 +6301,17 @@
           }
         }
       },
-      "required": ["keys"],
+      "required": [
+        "keys"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthorizationResponse.schema.json",
-    "fileMatch": ["a://b/AuthorizationResponse*.schema.json"],
+    "fileMatch": [
+      "a://b/AuthorizationResponse*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthorizationResponse.schema.json",
@@ -5559,7 +6347,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProviderCapabilitiesDto.schema.json",
-    "fileMatch": ["a://b/KmsProviderCapabilitiesDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KmsProviderCapabilitiesDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProviderCapabilitiesDto.schema.json",
@@ -5583,7 +6373,9 @@
         },
         "supportedAlgs": {
           "description": "Signing algorithms supported by the provider.",
-          "example": ["ES256"],
+          "example": [
+            "ES256"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -5595,13 +6387,21 @@
           "example": "ES256"
         }
       },
-      "required": ["canImport", "canCreate", "canDelete", "supportedAlgs", "defaultAlg"],
+      "required": [
+        "canImport",
+        "canCreate",
+        "canDelete",
+        "supportedAlgs",
+        "defaultAlg"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProviderInfoDto.schema.json",
-    "fileMatch": ["a://b/KmsProviderInfoDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KmsProviderInfoDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProviderInfoDto.schema.json",
@@ -5632,13 +6432,19 @@
           ]
         }
       },
-      "required": ["name", "type", "capabilities"],
+      "required": [
+        "name",
+        "type",
+        "capabilities"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProvidersResponseDto.schema.json",
-    "fileMatch": ["a://b/KmsProvidersResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KmsProvidersResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProvidersResponseDto.schema.json",
@@ -5658,13 +6464,18 @@
           "example": "db"
         }
       },
-      "required": ["providers", "default"],
+      "required": [
+        "providers",
+        "default"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CertificateInfoDto.schema.json",
-    "fileMatch": ["a://b/CertificateInfoDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CertificateInfoDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CertificateInfoDto.schema.json",
@@ -5698,13 +6509,17 @@
           "description": "Serial number."
         }
       },
-      "required": ["pem"],
+      "required": [
+        "pem"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PublicKeyInfoDto.schema.json",
-    "fileMatch": ["a://b/PublicKeyInfoDto*.schema.json"],
+    "fileMatch": [
+      "a://b/PublicKeyInfoDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PublicKeyInfoDto.schema.json",
@@ -5731,13 +6546,17 @@
           "example": "P-256"
         }
       },
-      "required": ["kty"],
+      "required": [
+        "kty"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyResponseDto.schema.json",
-    "fileMatch": ["a://b/RotationPolicyResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/RotationPolicyResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyResponseDto.schema.json",
@@ -5762,13 +6581,17 @@
           "description": "Next scheduled rotation date."
         }
       },
-      "required": ["enabled"],
+      "required": [
+        "enabled"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainResponseDto.schema.json",
-    "fileMatch": ["a://b/KeyChainResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KeyChainResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainResponseDto.schema.json",
@@ -5780,12 +6603,21 @@
           "description": "Unique identifier for the key chain."
         },
         "usageType": {
-          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"],
+          "enum": [
+            "access",
+            "attestation",
+            "trustList",
+            "statusList",
+            "encrypt"
+          ],
           "type": "string",
           "description": "Usage type of the key chain."
         },
         "type": {
-          "enum": ["standalone", "internalChain"],
+          "enum": [
+            "standalone",
+            "internalChain"
+          ],
           "type": "string",
           "description": "Type of key chain (standalone or internalChain)."
         },
@@ -5876,7 +6708,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExportEcJwk.schema.json",
-    "fileMatch": ["a://b/ExportEcJwk*.schema.json"],
+    "fileMatch": [
+      "a://b/ExportEcJwk*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExportEcJwk.schema.json",
@@ -5915,13 +6749,21 @@
           "description": "Key ID"
         }
       },
-      "required": ["kty", "crv", "x", "y", "d"],
+      "required": [
+        "kty",
+        "crv",
+        "x",
+        "y",
+        "d"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExportRotationPolicyDto.schema.json",
-    "fileMatch": ["a://b/ExportRotationPolicyDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ExportRotationPolicyDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExportRotationPolicyDto.schema.json",
@@ -5941,13 +6783,17 @@
           "description": "Certificate validity in days."
         }
       },
-      "required": ["enabled"],
+      "required": [
+        "enabled"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainExportDto.schema.json",
-    "fileMatch": ["a://b/KeyChainExportDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KeyChainExportDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainExportDto.schema.json",
@@ -5963,7 +6809,13 @@
           "description": "Human-readable description."
         },
         "usageType": {
-          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"],
+          "enum": [
+            "access",
+            "attestation",
+            "trustList",
+            "statusList",
+            "encrypt"
+          ],
           "type": "string",
           "description": "Usage type for this key chain."
         },
@@ -5995,13 +6847,19 @@
           ]
         }
       },
-      "required": ["id", "usageType", "key"],
+      "required": [
+        "id",
+        "usageType",
+        "key"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyCreateDto.schema.json",
-    "fileMatch": ["a://b/RotationPolicyCreateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/RotationPolicyCreateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyCreateDto.schema.json",
@@ -6028,13 +6886,17 @@
           "example": 365
         }
       },
-      "required": ["enabled"],
+      "required": [
+        "enabled"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainCreateDto.schema.json",
-    "fileMatch": ["a://b/KeyChainCreateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KeyChainCreateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainCreateDto.schema.json",
@@ -6042,13 +6904,22 @@
       "type": "object",
       "properties": {
         "usageType": {
-          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"],
+          "enum": [
+            "access",
+            "attestation",
+            "trustList",
+            "statusList",
+            "encrypt"
+          ],
           "type": "string",
           "description": "Usage type determines the purpose of this key chain (access, attestation, etc.).",
           "example": "attestation"
         },
         "type": {
-          "enum": ["standalone", "internalChain"],
+          "enum": [
+            "standalone",
+            "internalChain"
+          ],
           "type": "string",
           "description": "Type of key chain to create.",
           "example": "internalChain"
@@ -6072,13 +6943,18 @@
           ]
         }
       },
-      "required": ["usageType", "type"],
+      "required": [
+        "usageType",
+        "type"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EcJwk.schema.json",
-    "fileMatch": ["a://b/EcJwk*.schema.json"],
+    "fileMatch": [
+      "a://b/EcJwk*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EcJwk.schema.json",
@@ -6107,13 +6983,21 @@
           "type": "string"
         }
       },
-      "required": ["kty", "x", "y", "crv", "d"],
+      "required": [
+        "kty",
+        "x",
+        "y",
+        "crv",
+        "d"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyImportDto.schema.json",
-    "fileMatch": ["a://b/RotationPolicyImportDto*.schema.json"],
+    "fileMatch": [
+      "a://b/RotationPolicyImportDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyImportDto.schema.json",
@@ -6140,13 +7024,17 @@
           "example": 365
         }
       },
-      "required": ["enabled"],
+      "required": [
+        "enabled"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainImportDto.schema.json",
-    "fileMatch": ["a://b/KeyChainImportDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KeyChainImportDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainImportDto.schema.json",
@@ -6170,7 +7058,13 @@
           "description": "Human-readable description."
         },
         "usageType": {
-          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"],
+          "enum": [
+            "access",
+            "attestation",
+            "trustList",
+            "statusList",
+            "encrypt"
+          ],
           "type": "string",
           "description": "Usage type for this key chain."
         },
@@ -6194,13 +7088,18 @@
           ]
         }
       },
-      "required": ["key", "usageType"],
+      "required": [
+        "key",
+        "usageType"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyUpdateDto.schema.json",
-    "fileMatch": ["a://b/RotationPolicyUpdateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/RotationPolicyUpdateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyUpdateDto.schema.json",
@@ -6229,7 +7128,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainUpdateDto.schema.json",
-    "fileMatch": ["a://b/KeyChainUpdateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KeyChainUpdateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainUpdateDto.schema.json",
@@ -6258,7 +7159,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationRequest.schema.json",
-    "fileMatch": ["a://b/PresentationRequest*.schema.json"],
+    "fileMatch": [
+      "a://b/PresentationRequest*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationRequest.schema.json",
@@ -6268,7 +7171,10 @@
         "response_type": {
           "type": "string",
           "description": "The type of response expected from the presentation request.",
-          "enum": ["uri", "dc-api"]
+          "enum": [
+            "uri",
+            "dc-api"
+          ]
         },
         "requestId": {
           "type": "string",
@@ -6295,13 +7201,18 @@
           }
         }
       },
-      "required": ["response_type", "requestId"],
+      "required": [
+        "response_type",
+        "requestId"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FileUploadDto.schema.json",
-    "fileMatch": ["a://b/FileUploadDto*.schema.json"],
+    "fileMatch": [
+      "a://b/FileUploadDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FileUploadDto.schema.json",
@@ -6313,7 +7224,9 @@
           "format": "binary"
         }
       },
-      "required": ["file"],
+      "required": [
+        "file"
+      ],
       "additionalProperties": false
     }
   }

--- a/apps/client/src/app/utils/schemas.json
+++ b/apps/client/src/app/utils/schemas.json
@@ -1,9 +1,7 @@
 [
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/GrafanaConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/GrafanaConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/GrafanaConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/GrafanaConfigDto.schema.json",
@@ -26,18 +24,13 @@
           "example": "loki"
         }
       },
-      "required": [
-        "tempoUid",
-        "lokiUid"
-      ],
+      "required": ["tempoUid", "lokiUid"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FrontendConfigResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/FrontendConfigResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/FrontendConfigResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FrontendConfigResponseDto.schema.json",
@@ -53,17 +46,13 @@
           ]
         }
       },
-      "required": [
-        "grafana"
-      ],
+      "required": ["grafana"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RoleDto.schema.json",
-    "fileMatch": [
-      "a://b/RoleDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/RoleDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RoleDto.schema.json",
@@ -86,17 +75,13 @@
           "example": "issuance:manage"
         }
       },
-      "required": [
-        "role"
-      ],
+      "required": ["role"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientCredentialsDto.schema.json",
-    "fileMatch": [
-      "a://b/ClientCredentialsDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ClientCredentialsDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientCredentialsDto.schema.json",
@@ -114,18 +99,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "client_id",
-        "client_secret"
-      ],
+      "required": ["client_id", "client_secret"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TokenResponse.schema.json",
-    "fileMatch": [
-      "a://b/TokenResponse*.schema.json"
-    ],
+    "fileMatch": ["a://b/TokenResponse*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TokenResponse.schema.json",
@@ -145,19 +125,13 @@
           "type": "number"
         }
       },
-      "required": [
-        "access_token",
-        "token_type",
-        "expires_in"
-      ],
+      "required": ["access_token", "token_type", "expires_in"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ImportTenantDto.schema.json",
-    "fileMatch": [
-      "a://b/ImportTenantDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ImportTenantDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ImportTenantDto.schema.json",
@@ -173,17 +147,13 @@
           "description": "The description of the tenant."
         }
       },
-      "required": [
-        "name"
-      ],
+      "required": ["name"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SessionStorageConfig.schema.json",
-    "fileMatch": [
-      "a://b/SessionStorageConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/SessionStorageConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SessionStorageConfig.schema.json",
@@ -199,10 +169,7 @@
         "cleanupMode": {
           "type": "string",
           "description": "Cleanup mode: 'full' deletes everything, 'anonymize' keeps metadata but removes PII.",
-          "enum": [
-            "full",
-            "anonymize"
-          ],
+          "enum": ["full", "anonymize"],
           "default": "full"
         }
       },
@@ -211,9 +178,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListConfig.schema.json",
-    "fileMatch": [
-      "a://b/StatusListConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/StatusListConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListConfig.schema.json",
@@ -229,12 +194,7 @@
         "bits": {
           "type": "number",
           "description": "Bits per status entry: 1 (valid/revoked), 2 (with suspended), 4/8 (extended). If not set, uses global STATUS_BITS.",
-          "enum": [
-            1,
-            2,
-            4,
-            8
-          ],
+          "enum": [1, 2, 4, 8],
           "default": 1
         },
         "ttl": {
@@ -259,9 +219,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TenantEntity.schema.json",
-    "fileMatch": [
-      "a://b/TenantEntity*.schema.json"
-    ],
+    "fileMatch": ["a://b/TenantEntity*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TenantEntity.schema.json",
@@ -312,20 +270,13 @@
           }
         }
       },
-      "required": [
-        "id",
-        "name",
-        "status",
-        "clients"
-      ],
+      "required": ["id", "name", "status", "clients"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientEntity.schema.json",
-    "fileMatch": [
-      "a://b/ClientEntity*.schema.json"
-    ],
+    "fileMatch": ["a://b/ClientEntity*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientEntity.schema.json",
@@ -335,10 +286,7 @@
         "allowedPresentationConfigs": {
           "nullable": true,
           "description": "List of presentation config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": [
-            "age-verification",
-            "kyc-basic"
-          ],
+          "example": ["age-verification", "kyc-basic"],
           "type": "array",
           "items": {
             "type": "string"
@@ -347,10 +295,7 @@
         "allowedIssuanceConfigs": {
           "nullable": true,
           "description": "List of issuance config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": [
-            "pid",
-            "mdl"
-          ],
+          "example": ["pid", "mdl"],
           "type": "array",
           "items": {
             "type": "string"
@@ -398,18 +343,13 @@
           ]
         }
       },
-      "required": [
-        "clientId",
-        "roles"
-      ],
+      "required": ["clientId", "roles"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateTenantDto.schema.json",
-    "fileMatch": [
-      "a://b/CreateTenantDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CreateTenantDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateTenantDto.schema.json",
@@ -463,18 +403,13 @@
           }
         }
       },
-      "required": [
-        "id",
-        "name"
-      ],
+      "required": ["id", "name"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateTenantDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateTenantDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateTenantDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateTenantDto.schema.json",
@@ -529,9 +464,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuditLogResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/AuditLogResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/AuditLogResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuditLogResponseDto.schema.json",
@@ -568,11 +501,7 @@
           "type": "string"
         },
         "actorType": {
-          "enum": [
-            "user",
-            "client",
-            "system"
-          ],
+          "enum": ["user", "client", "system"],
           "type": "string"
         },
         "actorId": {
@@ -603,21 +532,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "id",
-        "tenantId",
-        "actionType",
-        "actorType",
-        "timestamp"
-      ],
+      "required": ["id", "tenantId", "actionType", "actorType", "timestamp"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientSecretResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/ClientSecretResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ClientSecretResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientSecretResponseDto.schema.json",
@@ -628,17 +549,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "secret"
-      ],
+      "required": ["secret"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateClientDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateClientDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateClientDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateClientDto.schema.json",
@@ -648,10 +565,7 @@
         "allowedPresentationConfigs": {
           "nullable": true,
           "description": "List of presentation config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": [
-            "age-verification",
-            "kyc-basic"
-          ],
+          "example": ["age-verification", "kyc-basic"],
           "type": "array",
           "items": {
             "type": "string"
@@ -660,10 +574,7 @@
         "allowedIssuanceConfigs": {
           "nullable": true,
           "description": "List of issuance config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": [
-            "pid",
-            "mdl"
-          ],
+          "example": ["pid", "mdl"],
           "type": "array",
           "items": {
             "type": "string"
@@ -691,17 +602,13 @@
           }
         }
       },
-      "required": [
-        "roles"
-      ],
+      "required": ["roles"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateClientDto.schema.json",
-    "fileMatch": [
-      "a://b/CreateClientDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CreateClientDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateClientDto.schema.json",
@@ -711,10 +618,7 @@
         "allowedPresentationConfigs": {
           "nullable": true,
           "description": "List of presentation config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": [
-            "age-verification",
-            "kyc-basic"
-          ],
+          "example": ["age-verification", "kyc-basic"],
           "type": "array",
           "items": {
             "type": "string"
@@ -723,10 +627,7 @@
         "allowedIssuanceConfigs": {
           "nullable": true,
           "description": "List of issuance config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": [
-            "pid",
-            "mdl"
-          ],
+          "example": ["pid", "mdl"],
           "type": "array",
           "items": {
             "type": "string"
@@ -762,18 +663,13 @@
           }
         }
       },
-      "required": [
-        "clientId",
-        "roles"
-      ],
+      "required": ["clientId", "roles"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListImportDto.schema.json",
-    "fileMatch": [
-      "a://b/StatusListImportDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/StatusListImportDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListImportDto.schema.json",
@@ -803,27 +699,18 @@
         },
         "bits": {
           "description": "Bits per status value. If not provided, uses tenant or global defaults.",
-          "enum": [
-            1,
-            2,
-            4,
-            8
-          ],
+          "enum": [1, 2, 4, 8],
           "type": "number",
           "example": 1
         }
       },
-      "required": [
-        "id"
-      ],
+      "required": ["id"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListAggregationDto.schema.json",
-    "fileMatch": [
-      "a://b/StatusListAggregationDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/StatusListAggregationDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListAggregationDto.schema.json",
@@ -842,17 +729,13 @@
           }
         }
       },
-      "required": [
-        "status_lists"
-      ],
+      "required": ["status_lists"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateStatusListConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateStatusListConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateStatusListConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateStatusListConfigDto.schema.json",
@@ -869,12 +752,7 @@
         "bits": {
           "nullable": true,
           "description": "Bits per status entry. Set to null to reset to global default.",
-          "enum": [
-            1,
-            2,
-            4,
-            8
-          ],
+          "enum": [1, 2, 4, 8],
           "type": "number"
         },
         "ttl": {
@@ -900,9 +778,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/StatusListResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/StatusListResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListResponseDto.schema.json",
@@ -933,12 +809,7 @@
         },
         "bits": {
           "description": "Bits per status value",
-          "enum": [
-            1,
-            2,
-            4,
-            8
-          ],
+          "enum": [1, 2, 4, 8],
           "type": "number",
           "example": 1
         },
@@ -991,9 +862,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateStatusListDto.schema.json",
-    "fileMatch": [
-      "a://b/CreateStatusListDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CreateStatusListDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateStatusListDto.schema.json",
@@ -1012,12 +881,7 @@
         },
         "bits": {
           "description": "Bits per status value. More bits allow more status states. Defaults to tenant configuration.",
-          "enum": [
-            1,
-            2,
-            4,
-            8
-          ],
+          "enum": [1, 2, 4, 8],
           "type": "number",
           "example": 1
         },
@@ -1033,9 +897,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateStatusListDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateStatusListDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateStatusListDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateStatusListDto.schema.json",
@@ -1060,9 +922,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthorizeQueries.schema.json",
-    "fileMatch": [
-      "a://b/AuthorizeQueries*.schema.json"
-    ],
+    "fileMatch": ["a://b/AuthorizeQueries*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthorizeQueries.schema.json",
@@ -1115,9 +975,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/OfferRequestDto.schema.json",
-    "fileMatch": [
-      "a://b/OfferRequestDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/OfferRequestDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/OfferRequestDto.schema.json",
@@ -1125,10 +983,7 @@
       "type": "object",
       "properties": {
         "response_type": {
-          "enum": [
-            "uri",
-            "dc-api"
-          ],
+          "enum": ["uri", "dc-api"],
           "type": "string",
           "examples": [
             {
@@ -1147,19 +1002,14 @@
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "inline"
-                    ]
+                    "enum": ["inline"]
                   },
                   "claims": {
                     "type": "object",
                     "additionalProperties": true
                   }
                 },
-                "required": [
-                  "type",
-                  "claims"
-                ],
+                "required": ["type", "claims"],
                 "additionalProperties": false
               },
               {
@@ -1167,18 +1017,13 @@
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "attributeProvider"
-                    ]
+                    "enum": ["attributeProvider"]
                   },
                   "attributeProviderId": {
                     "type": "string"
                   }
                 },
-                "required": [
-                  "type",
-                  "attributeProviderId"
-                ],
+                "required": ["type", "attributeProviderId"],
                 "additionalProperties": false
               },
               {
@@ -1186,9 +1031,7 @@
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "webhook"
-                    ]
+                    "enum": ["webhook"]
                   },
                   "webhook": {
                     "type": "object",
@@ -1200,16 +1043,11 @@
                         "type": "object"
                       }
                     },
-                    "required": [
-                      "url"
-                    ],
+                    "required": ["url"],
                     "additionalProperties": false
                   }
                 },
-                "required": [
-                  "type",
-                  "webhook"
-                ],
+                "required": ["type", "webhook"],
                 "additionalProperties": false
               }
             ]
@@ -1226,10 +1064,7 @@
         },
         "flow": {
           "description": "The flow type for the offer request.",
-          "enum": [
-            "authorization_code",
-            "pre_authorized_code"
-          ],
+          "enum": ["authorization_code", "pre_authorized_code"],
           "type": "string"
         },
         "tx_code": {
@@ -1256,19 +1091,13 @@
           "description": "ID of the webhook endpoint to notify about the status of the issuance process."
         }
       },
-      "required": [
-        "response_type",
-        "flow",
-        "credentialConfigurationIds"
-      ],
+      "required": ["response_type", "flow", "credentialConfigurationIds"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebHookAuthConfigNone.schema.json",
-    "fileMatch": [
-      "a://b/WebHookAuthConfigNone*.schema.json"
-    ],
+    "fileMatch": ["a://b/WebHookAuthConfigNone*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebHookAuthConfigNone.schema.json",
@@ -1278,22 +1107,16 @@
         "type": {
           "type": "string",
           "description": "The type of authentication used for the webhook.",
-          "enum": [
-            "none"
-          ]
+          "enum": ["none"]
         }
       },
-      "required": [
-        "type"
-      ],
+      "required": ["type"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ApiKeyConfig.schema.json",
-    "fileMatch": [
-      "a://b/ApiKeyConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/ApiKeyConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ApiKeyConfig.schema.json",
@@ -1309,18 +1132,13 @@
           "description": "The value of the API key to be sent in the header."
         }
       },
-      "required": [
-        "headerName",
-        "value"
-      ],
+      "required": ["headerName", "value"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebHookAuthConfigHeader.schema.json",
-    "fileMatch": [
-      "a://b/WebHookAuthConfigHeader*.schema.json"
-    ],
+    "fileMatch": ["a://b/WebHookAuthConfigHeader*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebHookAuthConfigHeader.schema.json",
@@ -1330,9 +1148,7 @@
         "type": {
           "type": "string",
           "description": "The type of authentication used for the webhook.",
-          "enum": [
-            "apiKey"
-          ]
+          "enum": ["apiKey"]
         },
         "config": {
           "description": "Configuration for API key authentication.\nThis is required if the type is 'apiKey'.",
@@ -1343,18 +1159,13 @@
           ]
         }
       },
-      "required": [
-        "type",
-        "config"
-      ],
+      "required": ["type", "config"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebhookConfig.schema.json",
-    "fileMatch": [
-      "a://b/WebhookConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/WebhookConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebhookConfig.schema.json",
@@ -1384,18 +1195,13 @@
           "description": "The URL to which the webhook will send notifications."
         }
       },
-      "required": [
-        "auth",
-        "url"
-      ],
+      "required": ["auth", "url"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TransactionData.schema.json",
-    "fileMatch": [
-      "a://b/TransactionData*.schema.json"
-    ],
+    "fileMatch": ["a://b/TransactionData*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TransactionData.schema.json",
@@ -1412,18 +1218,13 @@
           }
         }
       },
-      "required": [
-        "type",
-        "credential_ids"
-      ],
+      "required": ["type", "credential_ids"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Session.schema.json",
-    "fileMatch": [
-      "a://b/Session*.schema.json"
-    ],
+    "fileMatch": ["a://b/Session*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Session.schema.json",
@@ -1432,13 +1233,7 @@
       "properties": {
         "status": {
           "description": "Status of the session.",
-          "enum": [
-            "active",
-            "fetched",
-            "completed",
-            "expired",
-            "failed"
-          ],
+          "enum": ["active", "fetched", "completed", "expired", "failed"],
           "type": "string"
         },
         "id": {
@@ -1627,9 +1422,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PaginatedSessionResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/PaginatedSessionResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/PaginatedSessionResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PaginatedSessionResponseDto.schema.json",
@@ -1660,21 +1453,13 @@
           "description": "Total number of pages"
         }
       },
-      "required": [
-        "items",
-        "total",
-        "page",
-        "pageSize",
-        "totalPages"
-      ],
+      "required": ["items", "total", "page", "pageSize", "totalPages"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SessionLogEntryResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/SessionLogEntryResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/SessionLogEntryResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SessionLogEntryResponseDto.schema.json",
@@ -1697,11 +1482,7 @@
         "level": {
           "type": "string",
           "description": "Log level",
-          "enum": [
-            "info",
-            "warn",
-            "error"
-          ]
+          "enum": ["info", "warn", "error"]
         },
         "stage": {
           "type": "string",
@@ -1716,21 +1497,13 @@
           "description": "Additional structured detail"
         }
       },
-      "required": [
-        "id",
-        "sessionId",
-        "timestamp",
-        "level",
-        "message"
-      ],
+      "required": ["id", "sessionId", "timestamp", "level", "message"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusUpdateDto.schema.json",
-    "fileMatch": [
-      "a://b/StatusUpdateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/StatusUpdateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusUpdateDto.schema.json",
@@ -1750,18 +1523,13 @@
           "description": "The status of the credential\n0 = valid, 1 = revoked, 2 = suspended"
         }
       },
-      "required": [
-        "sessionId",
-        "status"
-      ],
+      "required": ["sessionId", "status"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateSessionConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateSessionConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateSessionConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateSessionConfigDto.schema.json",
@@ -1777,10 +1545,7 @@
         },
         "cleanupMode": {
           "description": "Cleanup mode: 'full' deletes everything, 'anonymize' keeps metadata but removes PII.",
-          "enum": [
-            "full",
-            "anonymize"
-          ],
+          "enum": ["full", "anonymize"],
           "type": "string",
           "default": "full"
         }
@@ -1790,9 +1555,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ManagedUserDto.schema.json",
-    "fileMatch": [
-      "a://b/ManagedUserDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ManagedUserDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ManagedUserDto.schema.json",
@@ -1841,20 +1604,13 @@
           "description": "One-time temporary password returned only on user creation."
         }
       },
-      "required": [
-        "id",
-        "username",
-        "enabled",
-        "roles"
-      ],
+      "required": ["id", "username", "enabled", "roles"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateUserDto.schema.json",
-    "fileMatch": [
-      "a://b/CreateUserDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CreateUserDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateUserDto.schema.json",
@@ -1896,18 +1652,13 @@
           "example": true
         }
       },
-      "required": [
-        "username",
-        "roles"
-      ],
+      "required": ["username", "roles"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateUserDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateUserDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateUserDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateUserDto.schema.json",
@@ -1959,9 +1710,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodNone.schema.json",
-    "fileMatch": [
-      "a://b/AuthenticationMethodNone*.schema.json"
-    ],
+    "fileMatch": ["a://b/AuthenticationMethodNone*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodNone.schema.json",
@@ -1970,22 +1719,16 @@
       "properties": {
         "method": {
           "type": "string",
-          "enum": [
-            "none"
-          ]
+          "enum": ["none"]
         }
       },
-      "required": [
-        "method"
-      ],
+      "required": ["method"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationUrlConfig.schema.json",
-    "fileMatch": [
-      "a://b/AuthenticationUrlConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/AuthenticationUrlConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationUrlConfig.schema.json",
@@ -2005,17 +1748,13 @@
           ]
         }
       },
-      "required": [
-        "url"
-      ],
+      "required": ["url"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodAuth.schema.json",
-    "fileMatch": [
-      "a://b/AuthenticationMethodAuth*.schema.json"
-    ],
+    "fileMatch": ["a://b/AuthenticationMethodAuth*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodAuth.schema.json",
@@ -2024,26 +1763,19 @@
       "properties": {
         "method": {
           "type": "string",
-          "enum": [
-            "auth"
-          ]
+          "enum": ["auth"]
         },
         "config": {
           "$ref": "./AuthenticationUrlConfig.schema.json"
         }
       },
-      "required": [
-        "method",
-        "config"
-      ],
+      "required": ["method", "config"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationDuringIssuanceConfig.schema.json",
-    "fileMatch": [
-      "a://b/PresentationDuringIssuanceConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/PresentationDuringIssuanceConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationDuringIssuanceConfig.schema.json",
@@ -2055,17 +1787,13 @@
           "description": "Link to the presentation configuration that is relevant for the issuance process"
         }
       },
-      "required": [
-        "type"
-      ],
+      "required": ["type"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodPresentation.schema.json",
-    "fileMatch": [
-      "a://b/AuthenticationMethodPresentation*.schema.json"
-    ],
+    "fileMatch": ["a://b/AuthenticationMethodPresentation*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodPresentation.schema.json",
@@ -2074,26 +1802,19 @@
       "properties": {
         "method": {
           "type": "string",
-          "enum": [
-            "presentationDuringIssuance"
-          ]
+          "enum": ["presentationDuringIssuance"]
         },
         "config": {
           "$ref": "./PresentationDuringIssuanceConfig.schema.json"
         }
       },
-      "required": [
-        "method",
-        "config"
-      ],
+      "required": ["method", "config"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpstreamOidcConfig.schema.json",
-    "fileMatch": [
-      "a://b/UpstreamOidcConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpstreamOidcConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpstreamOidcConfig.schema.json",
@@ -2117,28 +1838,20 @@
         },
         "scopes": {
           "description": "Scopes to request from the upstream provider",
-          "default": [
-            "openid",
-            "profile"
-          ],
+          "default": ["openid", "profile"],
           "type": "array",
           "items": {
             "type": "string"
           }
         }
       },
-      "required": [
-        "issuer",
-        "clientId"
-      ],
+      "required": ["issuer", "clientId"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenConfig.schema.json",
-    "fileMatch": [
-      "a://b/ChainedAsTokenConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/ChainedAsTokenConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenConfig.schema.json",
@@ -2161,9 +1874,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsConfig.schema.json",
-    "fileMatch": [
-      "a://b/ChainedAsConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/ChainedAsConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsConfig.schema.json",
@@ -2197,17 +1908,13 @@
           "default": true
         }
       },
-      "required": [
-        "enabled"
-      ],
+      "required": ["enabled"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FederationTrustAnchorConfig.schema.json",
-    "fileMatch": [
-      "a://b/FederationTrustAnchorConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/FederationTrustAnchorConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FederationTrustAnchorConfig.schema.json",
@@ -2225,18 +1932,13 @@
           "example": "https://ta.example.org/.well-known/openid-federation"
         }
       },
-      "required": [
-        "entityId",
-        "entityConfigurationUri"
-      ],
+      "required": ["entityId", "entityConfigurationUri"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FederationConfig.schema.json",
-    "fileMatch": [
-      "a://b/FederationConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/FederationConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FederationConfig.schema.json",
@@ -2244,20 +1946,13 @@
       "type": "object",
       "properties": {
         "role": {
-          "enum": [
-            "trust_anchor",
-            "intermediate",
-            "leaf"
-          ],
+          "enum": ["trust_anchor", "intermediate", "leaf"],
           "type": "string",
           "description": "Role this tenant plays in the OpenID Federation topology.",
           "default": "leaf"
         },
         "mode": {
-          "enum": [
-            "federation-only",
-            "hybrid"
-          ],
+          "enum": ["federation-only", "hybrid"],
           "type": "string",
           "description": "Trust decision strategy when both LoTE trust lists and OpenID Federation are configured.",
           "default": "hybrid"
@@ -2285,17 +1980,13 @@
           }
         }
       },
-      "required": [
-        "trustAnchors"
-      ],
+      "required": ["trustAnchors"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayLogo.schema.json",
-    "fileMatch": [
-      "a://b/DisplayLogo*.schema.json"
-    ],
+    "fileMatch": ["a://b/DisplayLogo*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayLogo.schema.json",
@@ -2309,17 +2000,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "uri"
-      ],
+      "required": ["uri"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayInfo.schema.json",
-    "fileMatch": [
-      "a://b/DisplayInfo*.schema.json"
-    ],
+    "fileMatch": ["a://b/DisplayInfo*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayInfo.schema.json",
@@ -2341,9 +2028,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuanceConfig.schema.json",
-    "fileMatch": [
-      "a://b/IssuanceConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/IssuanceConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuanceConfig.schema.json",
@@ -2456,20 +2141,13 @@
           "description": "The timestamp when the VP request was last updated."
         }
       },
-      "required": [
-        "tenant",
-        "display",
-        "createdAt",
-        "updatedAt"
-      ],
+      "required": ["tenant", "display", "createdAt", "updatedAt"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuanceDto.schema.json",
-    "fileMatch": [
-      "a://b/IssuanceDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/IssuanceDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuanceDto.schema.json",
@@ -2564,17 +2242,13 @@
           }
         }
       },
-      "required": [
-        "display"
-      ],
+      "required": ["display"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClaimsQuery.schema.json",
-    "fileMatch": [
-      "a://b/ClaimsQuery*.schema.json"
-    ],
+    "fileMatch": ["a://b/ClaimsQuery*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClaimsQuery.schema.json",
@@ -2597,17 +2271,13 @@
           }
         }
       },
-      "required": [
-        "path"
-      ],
+      "required": ["path"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustedAuthorityQuery.schema.json",
-    "fileMatch": [
-      "a://b/TrustedAuthorityQuery*.schema.json"
-    ],
+    "fileMatch": ["a://b/TrustedAuthorityQuery*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustedAuthorityQuery.schema.json",
@@ -2616,10 +2286,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": [
-            "etsi_tl",
-            "openid_federation"
-          ]
+          "enum": ["etsi_tl", "openid_federation"]
         },
         "values": {
           "type": "array",
@@ -2628,18 +2295,13 @@
           }
         }
       },
-      "required": [
-        "type",
-        "values"
-      ],
+      "required": ["type", "values"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialQuery.schema.json",
-    "fileMatch": [
-      "a://b/CredentialQuery*.schema.json"
-    ],
+    "fileMatch": ["a://b/CredentialQuery*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialQuery.schema.json",
@@ -2671,19 +2333,13 @@
           }
         }
       },
-      "required": [
-        "id",
-        "format",
-        "meta"
-      ],
+      "required": ["id", "format", "meta"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialSetQuery.schema.json",
-    "fileMatch": [
-      "a://b/CredentialSetQuery*.schema.json"
-    ],
+    "fileMatch": ["a://b/CredentialSetQuery*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialSetQuery.schema.json",
@@ -2703,17 +2359,13 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "options"
-      ],
+      "required": ["options"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PolicyCredential.schema.json",
-    "fileMatch": [
-      "a://b/PolicyCredential*.schema.json"
-    ],
+    "fileMatch": ["a://b/PolicyCredential*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PolicyCredential.schema.json",
@@ -2739,17 +2391,13 @@
           }
         }
       },
-      "required": [
-        "credentials"
-      ],
+      "required": ["credentials"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AttestationBasedPolicy.schema.json",
-    "fileMatch": [
-      "a://b/AttestationBasedPolicy*.schema.json"
-    ],
+    "fileMatch": ["a://b/AttestationBasedPolicy*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AttestationBasedPolicy.schema.json",
@@ -2758,9 +2406,7 @@
       "properties": {
         "policy": {
           "type": "string",
-          "enum": [
-            "attestationBased"
-          ]
+          "enum": ["attestationBased"]
         },
         "values": {
           "type": "array",
@@ -2769,18 +2415,13 @@
           }
         }
       },
-      "required": [
-        "policy",
-        "values"
-      ],
+      "required": ["policy", "values"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/NoneTrustPolicy.schema.json",
-    "fileMatch": [
-      "a://b/NoneTrustPolicy*.schema.json"
-    ],
+    "fileMatch": ["a://b/NoneTrustPolicy*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/NoneTrustPolicy.schema.json",
@@ -2789,22 +2430,16 @@
       "properties": {
         "policy": {
           "type": "string",
-          "enum": [
-            "none"
-          ]
+          "enum": ["none"]
         }
       },
-      "required": [
-        "policy"
-      ],
+      "required": ["policy"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AllowListPolicy.schema.json",
-    "fileMatch": [
-      "a://b/AllowListPolicy*.schema.json"
-    ],
+    "fileMatch": ["a://b/AllowListPolicy*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AllowListPolicy.schema.json",
@@ -2813,9 +2448,7 @@
       "properties": {
         "policy": {
           "type": "string",
-          "enum": [
-            "allowList"
-          ]
+          "enum": ["allowList"]
         },
         "values": {
           "type": "array",
@@ -2824,18 +2457,13 @@
           }
         }
       },
-      "required": [
-        "policy",
-        "values"
-      ],
+      "required": ["policy", "values"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RootOfTrustPolicy.schema.json",
-    "fileMatch": [
-      "a://b/RootOfTrustPolicy*.schema.json"
-    ],
+    "fileMatch": ["a://b/RootOfTrustPolicy*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RootOfTrustPolicy.schema.json",
@@ -2844,26 +2472,19 @@
       "properties": {
         "policy": {
           "type": "string",
-          "enum": [
-            "rootOfTrust"
-          ]
+          "enum": ["rootOfTrust"]
         },
         "values": {
           "type": "string"
         }
       },
-      "required": [
-        "policy",
-        "values"
-      ],
+      "required": ["policy", "values"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/VCT.schema.json",
-    "fileMatch": [
-      "a://b/VCT*.schema.json"
-    ],
+    "fileMatch": ["a://b/VCT*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/VCT.schema.json",
@@ -2897,9 +2518,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IaeActionOpenid4vpPresentation.schema.json",
-    "fileMatch": [
-      "a://b/IaeActionOpenid4vpPresentation*.schema.json"
-    ],
+    "fileMatch": ["a://b/IaeActionOpenid4vpPresentation*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IaeActionOpenid4vpPresentation.schema.json",
@@ -2907,9 +2526,7 @@
       "type": "object",
       "properties": {
         "type": {
-          "enum": [
-            "openid4vp_presentation"
-          ],
+          "enum": ["openid4vp_presentation"],
           "type": "string",
           "description": "Action type discriminator",
           "example": "openid4vp_presentation"
@@ -2925,18 +2542,13 @@
           "example": "pid-presentation-config"
         }
       },
-      "required": [
-        "type",
-        "presentationConfigId"
-      ],
+      "required": ["type", "presentationConfigId"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IaeActionRedirectToWeb.schema.json",
-    "fileMatch": [
-      "a://b/IaeActionRedirectToWeb*.schema.json"
-    ],
+    "fileMatch": ["a://b/IaeActionRedirectToWeb*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IaeActionRedirectToWeb.schema.json",
@@ -2944,9 +2556,7 @@
       "type": "object",
       "properties": {
         "type": {
-          "enum": [
-            "redirect_to_web"
-          ],
+          "enum": ["redirect_to_web"],
           "type": "string",
           "description": "Action type discriminator",
           "example": "redirect_to_web"
@@ -2974,18 +2584,13 @@
           "example": "Please complete the identity verification form"
         }
       },
-      "required": [
-        "type",
-        "url"
-      ],
+      "required": ["type", "url"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebhookEndpointEntity.schema.json",
-    "fileMatch": [
-      "a://b/WebhookEndpointEntity*.schema.json"
-    ],
+    "fileMatch": ["a://b/WebhookEndpointEntity*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebhookEndpointEntity.schema.json",
@@ -3023,22 +2628,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "id",
-        "auth",
-        "tenantId",
-        "tenant",
-        "name",
-        "url"
-      ],
+      "required": ["id", "auth", "tenantId", "tenant", "name", "url"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaUriEntry.schema.json",
-    "fileMatch": [
-      "a://b/SchemaUriEntry*.schema.json"
-    ],
+    "fileMatch": ["a://b/SchemaUriEntry*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaUriEntry.schema.json",
@@ -3065,17 +2661,13 @@
           "additionalProperties": true
         }
       },
-      "required": [
-        "meta"
-      ],
+      "required": ["meta"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustAuthorityEntry.schema.json",
-    "fileMatch": [
-      "a://b/TrustAuthorityEntry*.schema.json"
-    ],
+    "fileMatch": ["a://b/TrustAuthorityEntry*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustAuthorityEntry.schema.json",
@@ -3087,11 +2679,7 @@
           "description": "Trust list ID to resolve from the database. When set, frameworkType, value, and verificationMethod are derived automatically."
         },
         "frameworkType": {
-          "enum": [
-            "aki",
-            "etsi_tl",
-            "openid_federation"
-          ],
+          "enum": ["aki", "etsi_tl", "openid_federation"],
           "type": "string",
           "description": "Trust framework type (ignored when trustListId is set)"
         },
@@ -3114,9 +2702,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetaConfig.schema.json",
-    "fileMatch": [
-      "a://b/SchemaMetaConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/SchemaMetaConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetaConfig.schema.json",
@@ -3149,12 +2735,7 @@
           "description": "Attestation Level of Security"
         },
         "bindingType": {
-          "enum": [
-            "claim",
-            "key",
-            "biometric",
-            "none"
-          ],
+          "enum": ["claim", "key", "biometric", "none"],
           "type": "string",
           "description": "Cryptographic binding type"
         },
@@ -3178,9 +2759,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EmbeddedDisclosurePolicy.schema.json",
-    "fileMatch": [
-      "a://b/EmbeddedDisclosurePolicy*.schema.json"
-    ],
+    "fileMatch": ["a://b/EmbeddedDisclosurePolicy*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EmbeddedDisclosurePolicy.schema.json",
@@ -3191,17 +2770,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "policy"
-      ],
+      "required": ["policy"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyAttestationsRequired.schema.json",
-    "fileMatch": [
-      "a://b/KeyAttestationsRequired*.schema.json"
-    ],
+    "fileMatch": ["a://b/KeyAttestationsRequired*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyAttestationsRequired.schema.json",
@@ -3210,10 +2785,7 @@
       "properties": {
         "key_storage": {
           "description": "List of required key storage types (e.g., iso_18045_high, iso_18045_moderate)",
-          "example": [
-            "iso_18045_high",
-            "iso_18045_moderate"
-          ],
+          "example": ["iso_18045_high", "iso_18045_moderate"],
           "type": "array",
           "items": {
             "type": "string"
@@ -3221,10 +2793,7 @@
         },
         "user_authentication": {
           "description": "List of required user authentication types (e.g., iso_18045_high, iso_18045_moderate)",
-          "example": [
-            "iso_18045_high",
-            "iso_18045_moderate"
-          ],
+          "example": ["iso_18045_high", "iso_18045_moderate"],
           "type": "array",
           "items": {
             "type": "string"
@@ -3236,9 +2805,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayImage.schema.json",
-    "fileMatch": [
-      "a://b/DisplayImage*.schema.json"
-    ],
+    "fileMatch": ["a://b/DisplayImage*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayImage.schema.json",
@@ -3249,17 +2816,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "uri"
-      ],
+      "required": ["uri"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Display.schema.json",
-    "fileMatch": [
-      "a://b/Display*.schema.json"
-    ],
+    "fileMatch": ["a://b/Display*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Display.schema.json",
@@ -3288,19 +2851,13 @@
           "$ref": "./DisplayImage.schema.json"
         }
       },
-      "required": [
-        "name",
-        "description",
-        "locale"
-      ],
+      "required": ["name", "description", "locale"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerMetadataCredentialConfig.schema.json",
-    "fileMatch": [
-      "a://b/IssuerMetadataCredentialConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/IssuerMetadataCredentialConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerMetadataCredentialConfig.schema.json",
@@ -3317,10 +2874,7 @@
         },
         "format": {
           "type": "string",
-          "enum": [
-            "mso_mdoc",
-            "dc+sd-jwt"
-          ]
+          "enum": ["mso_mdoc", "dc+sd-jwt"]
         },
         "display": {
           "type": "array",
@@ -3336,18 +2890,13 @@
           "description": "Document type for mDOC credentials (e.g., \"org.iso.18013.5.1.mDL\").\nOnly applicable when format is \"mso_mdoc\"."
         }
       },
-      "required": [
-        "format",
-        "display"
-      ],
+      "required": ["format", "display"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FieldDisplayDto.schema.json",
-    "fileMatch": [
-      "a://b/FieldDisplayDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/FieldDisplayDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FieldDisplayDto.schema.json",
@@ -3370,18 +2919,13 @@
           "example": "Primary first name"
         }
       },
-      "required": [
-        "locale",
-        "name"
-      ],
+      "required": ["locale", "name"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClaimFieldDefinitionDto.schema.json",
-    "fileMatch": [
-      "a://b/ClaimFieldDefinitionDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ClaimFieldDefinitionDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClaimFieldDefinitionDto.schema.json",
@@ -3391,10 +2935,7 @@
         "path": {
           "type": "array",
           "description": "Path to claim value",
-          "example": [
-            "address",
-            "locality"
-          ],
+          "example": ["address", "locality"],
           "items": {
             "oneOf": [
               {
@@ -3410,15 +2951,7 @@
           }
         },
         "type": {
-          "enum": [
-            "string",
-            "number",
-            "integer",
-            "boolean",
-            "object",
-            "array",
-            "date"
-          ],
+          "enum": ["string", "number", "integer", "boolean", "object", "array", "date"],
           "type": "string",
           "description": "Claim value type"
         },
@@ -3471,18 +3004,13 @@
           "description": "Additional JSON schema constraints for this field"
         }
       },
-      "required": [
-        "path",
-        "type"
-      ],
+      "required": ["path", "type"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AttributeProviderEntity.schema.json",
-    "fileMatch": [
-      "a://b/AttributeProviderEntity*.schema.json"
-    ],
+    "fileMatch": ["a://b/AttributeProviderEntity*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AttributeProviderEntity.schema.json",
@@ -3519,22 +3047,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "auth",
-        "id",
-        "tenantId",
-        "tenant",
-        "name",
-        "url"
-      ],
+      "required": ["auth", "id", "tenantId", "tenant", "name", "url"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainEntity.schema.json",
-    "fileMatch": [
-      "a://b/KeyChainEntity*.schema.json"
-    ],
+    "fileMatch": ["a://b/KeyChainEntity*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainEntity.schema.json",
@@ -3564,21 +3083,12 @@
         "usageType": {
           "type": "string",
           "description": "The purpose/role of this key chain in the system.",
-          "enum": [
-            "access",
-            "attestation",
-            "trustList",
-            "statusList",
-            "encrypt"
-          ]
+          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"]
         },
         "usage": {
           "type": "string",
           "description": "The usage type of the keys (sign or encrypt).",
-          "enum": [
-            "sign",
-            "encrypt"
-          ]
+          "enum": ["sign", "encrypt"]
         },
         "kmsProvider": {
           "type": "string",
@@ -3658,9 +3168,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfig.schema.json",
-    "fileMatch": [
-      "a://b/CredentialConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/CredentialConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfig.schema.json",
@@ -3790,31 +3298,20 @@
         "sdJwtTrustFormat": {
           "nullable": true,
           "description": "For SD-JWT credentials: determines whether to include certificate chain (x5c)\nor use federation-based trust (iss claim).\nDefault: \"x5c\" (federation must be explicitly selected)",
-          "enum": [
-            "x5c",
-            "federation"
-          ],
+          "enum": ["x5c", "federation"],
           "type": "string"
         },
         "lifeTime": {
           "type": "number"
         }
       },
-      "required": [
-        "id",
-        "tenant",
-        "config",
-        "configVersion",
-        "fields"
-      ],
+      "required": ["id", "tenant", "config", "configVersion", "fields"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfigCreate.schema.json",
-    "fileMatch": [
-      "a://b/CredentialConfigCreate*.schema.json"
-    ],
+    "fileMatch": ["a://b/CredentialConfigCreate*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfigCreate.schema.json",
@@ -3927,30 +3424,20 @@
         "sdJwtTrustFormat": {
           "nullable": true,
           "description": "For SD-JWT credentials: determines whether to include certificate chain (x5c)\nor use federation-based trust (iss claim).\nDefault: \"x5c\" (federation must be explicitly selected)",
-          "enum": [
-            "x5c",
-            "federation"
-          ],
+          "enum": ["x5c", "federation"],
           "type": "string"
         },
         "lifeTime": {
           "type": "number"
         }
       },
-      "required": [
-        "id",
-        "config",
-        "configVersion",
-        "fields"
-      ],
+      "required": ["id", "config", "configVersion", "fields"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfigUpdate.schema.json",
-    "fileMatch": [
-      "a://b/CredentialConfigUpdate*.schema.json"
-    ],
+    "fileMatch": ["a://b/CredentialConfigUpdate*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfigUpdate.schema.json",
@@ -4063,10 +3550,7 @@
         "sdJwtTrustFormat": {
           "nullable": true,
           "description": "For SD-JWT credentials: determines whether to include certificate chain (x5c)\nor use federation-based trust (iss claim).\nDefault: \"x5c\" (federation must be explicitly selected)",
-          "enum": [
-            "x5c",
-            "federation"
-          ],
+          "enum": ["x5c", "federation"],
           "type": "string"
         },
         "lifeTime": {
@@ -4078,9 +3562,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SignSchemaMetaConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/SignSchemaMetaConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/SignSchemaMetaConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SignSchemaMetaConfigDto.schema.json",
@@ -4104,17 +3586,13 @@
           "description": "ID of the credential config to link back after submission. When provided, schemaMeta.id on the credential config is updated with the reserved attestation ID."
         }
       },
-      "required": [
-        "config"
-      ],
+      "required": ["config"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SignVersionSchemaMetaConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/SignVersionSchemaMetaConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/SignVersionSchemaMetaConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SignVersionSchemaMetaConfigDto.schema.json",
@@ -4134,17 +3612,13 @@
           "description": "ID of the key chain to use for signing. Defaults to the tenant's default key chain."
         }
       },
-      "required": [
-        "config"
-      ],
+      "required": ["config"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/VocabularyEntryDto.schema.json",
-    "fileMatch": [
-      "a://b/VocabularyEntryDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/VocabularyEntryDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/VocabularyEntryDto.schema.json",
@@ -4160,10 +3634,7 @@
           "description": "Display label for UI rendering."
         },
         "status": {
-          "enum": [
-            "active",
-            "deprecated"
-          ],
+          "enum": ["active", "deprecated"],
           "type": "string",
           "description": "Vocabulary lifecycle status."
         },
@@ -4172,19 +3643,13 @@
           "description": "Replacement code when status is deprecated."
         }
       },
-      "required": [
-        "code",
-        "label",
-        "status"
-      ],
+      "required": ["code", "label", "status"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetadataVocabulariesDto.schema.json",
-    "fileMatch": [
-      "a://b/SchemaMetadataVocabulariesDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/SchemaMetadataVocabulariesDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetadataVocabulariesDto.schema.json",
@@ -4210,19 +3675,13 @@
           }
         }
       },
-      "required": [
-        "version",
-        "categories",
-        "tags"
-      ],
+      "required": ["version", "categories", "tags"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/MetadataSchemaDto.schema.json",
-    "fileMatch": [
-      "a://b/MetadataSchemaDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/MetadataSchemaDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/MetadataSchemaDto.schema.json",
@@ -4234,10 +3693,7 @@
           "description": "Unique identifier for this schema entry"
         },
         "formatIdentifier": {
-          "enum": [
-            "dc+sd-jwt",
-            "mso_mdoc"
-          ],
+          "enum": ["dc+sd-jwt", "mso_mdoc"],
           "type": "string",
           "description": "The credential format identifier"
         },
@@ -4255,18 +3711,13 @@
           "description": "Subresource Integrity hash for the schema"
         }
       },
-      "required": [
-        "id",
-        "formatIdentifier"
-      ],
+      "required": ["id", "formatIdentifier"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustAuthorityDto.schema.json",
-    "fileMatch": [
-      "a://b/TrustAuthorityDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/TrustAuthorityDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustAuthorityDto.schema.json",
@@ -4280,9 +3731,7 @@
         "frameworkType": {
           "type": "string",
           "description": "Type of trust framework",
-          "enum": [
-            "etsi_tl"
-          ]
+          "enum": ["etsi_tl"]
         },
         "value": {
           "type": "string",
@@ -4294,19 +3743,13 @@
           "additionalProperties": true
         }
       },
-      "required": [
-        "id",
-        "frameworkType",
-        "value"
-      ],
+      "required": ["id", "frameworkType", "value"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AccessCertificateRefDto.schema.json",
-    "fileMatch": [
-      "a://b/AccessCertificateRefDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/AccessCertificateRefDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AccessCertificateRefDto.schema.json",
@@ -4329,21 +3772,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "id",
-        "relyingPartyId",
-        "certificate",
-        "revoked",
-        "createdAt"
-      ],
+      "required": ["id", "relyingPartyId", "certificate", "revoked", "createdAt"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetadataResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/SchemaMetadataResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/SchemaMetadataResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetadataResponseDto.schema.json",
@@ -4377,12 +3812,7 @@
           "description": "Level of security (LoS) of this attestation"
         },
         "bindingType": {
-          "enum": [
-            "claim",
-            "key",
-            "biometric",
-            "none"
-          ],
+          "enum": ["claim", "key", "biometric", "none"],
           "type": "string",
           "description": "Required binding type between attestation and holder"
         },
@@ -4390,10 +3820,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "enum": [
-              "dc+sd-jwt",
-              "mso_mdoc"
-            ]
+            "enum": ["dc+sd-jwt", "mso_mdoc"]
           },
           "description": "Credential formats in which this attestation is available"
         },
@@ -4412,15 +3839,7 @@
           }
         },
         "category": {
-          "enum": [
-            "identity",
-            "health",
-            "finance",
-            "education",
-            "mobility",
-            "employment",
-            "other"
-          ],
+          "enum": ["identity", "health", "finance", "education", "mobility", "employment", "other"],
           "type": "string",
           "description": "Domain category for filtering"
         },
@@ -4496,9 +3915,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateSchemaMetadataDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateSchemaMetadataDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateSchemaMetadataDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateSchemaMetadataDto.schema.json",
@@ -4506,15 +3923,7 @@
       "type": "object",
       "properties": {
         "category": {
-          "enum": [
-            "identity",
-            "health",
-            "finance",
-            "education",
-            "mobility",
-            "employment",
-            "other"
-          ],
+          "enum": ["identity", "health", "finance", "education", "mobility", "employment", "other"],
           "type": "string",
           "description": "Domain category for filtering"
         },
@@ -4543,9 +3952,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeprecateSchemaMetadataDto.schema.json",
-    "fileMatch": [
-      "a://b/DeprecateSchemaMetadataDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/DeprecateSchemaMetadataDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeprecateSchemaMetadataDto.schema.json",
@@ -4565,17 +3972,13 @@
           "description": "The version that supersedes this one"
         }
       },
-      "required": [
-        "deprecated"
-      ],
+      "required": ["deprecated"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateAttributeProviderDto.schema.json",
-    "fileMatch": [
-      "a://b/CreateAttributeProviderDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CreateAttributeProviderDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateAttributeProviderDto.schema.json",
@@ -4606,20 +4009,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "auth",
-        "id",
-        "name",
-        "url"
-      ],
+      "required": ["auth", "id", "name", "url"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateAttributeProviderDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateAttributeProviderDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateAttributeProviderDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateAttributeProviderDto.schema.json",
@@ -4655,9 +4051,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateWebhookEndpointDto.schema.json",
-    "fileMatch": [
-      "a://b/CreateWebhookEndpointDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CreateWebhookEndpointDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateWebhookEndpointDto.schema.json",
@@ -4689,20 +4083,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "id",
-        "auth",
-        "name",
-        "url"
-      ],
+      "required": ["id", "auth", "name", "url"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateWebhookEndpointDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateWebhookEndpointDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateWebhookEndpointDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateWebhookEndpointDto.schema.json",
@@ -4739,9 +4126,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListEntityInfo.schema.json",
-    "fileMatch": [
-      "a://b/TrustListEntityInfo*.schema.json"
-    ],
+    "fileMatch": ["a://b/TrustListEntityInfo*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListEntityInfo.schema.json",
@@ -4773,17 +4158,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "name"
-      ],
+      "required": ["name"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InternalTrustListEntity.schema.json",
-    "fileMatch": [
-      "a://b/InternalTrustListEntity*.schema.json"
-    ],
+    "fileMatch": ["a://b/InternalTrustListEntity*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InternalTrustListEntity.schema.json",
@@ -4792,9 +4173,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": [
-            "internal"
-          ]
+          "enum": ["internal"]
         },
         "issuerKeyChainId": {
           "type": "string"
@@ -4806,20 +4185,13 @@
           "$ref": "./TrustListEntityInfo.schema.json"
         }
       },
-      "required": [
-        "type",
-        "issuerKeyChainId",
-        "revocationKeyChainId",
-        "info"
-      ],
+      "required": ["type", "issuerKeyChainId", "revocationKeyChainId", "info"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExternalTrustListEntity.schema.json",
-    "fileMatch": [
-      "a://b/ExternalTrustListEntity*.schema.json"
-    ],
+    "fileMatch": ["a://b/ExternalTrustListEntity*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExternalTrustListEntity.schema.json",
@@ -4828,9 +4200,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": [
-            "external"
-          ]
+          "enum": ["external"]
         },
         "issuerCertPem": {
           "type": "string"
@@ -4842,20 +4212,13 @@
           "$ref": "./TrustListEntityInfo.schema.json"
         }
       },
-      "required": [
-        "type",
-        "issuerCertPem",
-        "revocationCertPem",
-        "info"
-      ],
+      "required": ["type", "issuerCertPem", "revocationCertPem", "info"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListCreateDto.schema.json",
-    "fileMatch": [
-      "a://b/TrustListCreateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/TrustListCreateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListCreateDto.schema.json",
@@ -4896,17 +4259,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "entities"
-      ],
+      "required": ["entities"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustList.schema.json",
-    "fileMatch": [
-      "a://b/TrustList*.schema.json"
-    ],
+    "fileMatch": ["a://b/TrustList*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustList.schema.json",
@@ -4982,9 +4341,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListVersion.schema.json",
-    "fileMatch": [
-      "a://b/TrustListVersion*.schema.json"
-    ],
+    "fileMatch": ["a://b/TrustListVersion*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListVersion.schema.json",
@@ -5039,9 +4396,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DCQL.schema.json",
-    "fileMatch": [
-      "a://b/DCQL*.schema.json"
-    ],
+    "fileMatch": ["a://b/DCQL*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DCQL.schema.json",
@@ -5061,17 +4416,13 @@
           }
         }
       },
-      "required": [
-        "credentials"
-      ],
+      "required": ["credentials"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificatePurpose.schema.json",
-    "fileMatch": [
-      "a://b/RegistrationCertificatePurpose*.schema.json"
-    ],
+    "fileMatch": ["a://b/RegistrationCertificatePurpose*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificatePurpose.schema.json",
@@ -5085,18 +4436,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "lang",
-        "content"
-      ],
+      "required": ["lang", "content"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateBody.schema.json",
-    "fileMatch": [
-      "a://b/RegistrationCertificateBody*.schema.json"
-    ],
+    "fileMatch": ["a://b/RegistrationCertificateBody*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateBody.schema.json",
@@ -5136,9 +4482,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateRequest.schema.json",
-    "fileMatch": [
-      "a://b/RegistrationCertificateRequest*.schema.json"
-    ],
+    "fileMatch": ["a://b/RegistrationCertificateRequest*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateRequest.schema.json",
@@ -5167,9 +4511,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationAttachment.schema.json",
-    "fileMatch": [
-      "a://b/PresentationAttachment*.schema.json"
-    ],
+    "fileMatch": ["a://b/PresentationAttachment*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationAttachment.schema.json",
@@ -5189,18 +4531,13 @@
           }
         }
       },
-      "required": [
-        "format",
-        "data"
-      ],
+      "required": ["format", "data"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfig.schema.json",
-    "fileMatch": [
-      "a://b/PresentationConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/PresentationConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfig.schema.json",
@@ -5300,21 +4637,13 @@
           "description": "Optional ID of the access certificate to use for signing the presentation request.\nIf not provided, the default access certificate for the tenant will be used.\n\nNote: This is intentionally NOT a TypeORM relationship because CertEntity uses\na composite primary key (id + tenantId), and SQLite cannot create foreign keys\nthat reference only part of a composite primary key. The relationship is handled\nat the application level in the service layer."
         }
       },
-      "required": [
-        "id",
-        "tenant",
-        "dcql_query",
-        "createdAt",
-        "updatedAt"
-      ],
+      "required": ["id", "tenant", "dcql_query", "createdAt", "updatedAt"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ResolveIssuerMetadataDto.schema.json",
-    "fileMatch": [
-      "a://b/ResolveIssuerMetadataDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ResolveIssuerMetadataDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ResolveIssuerMetadataDto.schema.json",
@@ -5328,17 +4657,13 @@
           "example": "https://issuer.example.com/issuers/tenant-a"
         }
       },
-      "required": [
-        "issuerUrl"
-      ],
+      "required": ["issuerUrl"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ResolveSchemaMetadataDto.schema.json",
-    "fileMatch": [
-      "a://b/ResolveSchemaMetadataDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ResolveSchemaMetadataDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ResolveSchemaMetadataDto.schema.json",
@@ -5352,17 +4677,13 @@
           "example": "https://registrar.example.com/schema-metadata/5c0d7dbb-ef2e-448b-b84f-b8103575947b"
         }
       },
-      "required": [
-        "schemaMetadataUrl"
-      ],
+      "required": ["schemaMetadataUrl"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfigCreateDto.schema.json",
-    "fileMatch": [
-      "a://b/PresentationConfigCreateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/PresentationConfigCreateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfigCreateDto.schema.json",
@@ -5436,18 +4757,13 @@
           "description": "Optional ID of the access certificate to use for signing the presentation request.\nIf not provided, the default access certificate for the tenant will be used.\n\nNote: This is intentionally NOT a TypeORM relationship because CertEntity uses\na composite primary key (id + tenantId), and SQLite cannot create foreign keys\nthat reference only part of a composite primary key. The relationship is handled\nat the application level in the service layer."
         }
       },
-      "required": [
-        "id",
-        "dcql_query"
-      ],
+      "required": ["id", "dcql_query"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfigUpdateDto.schema.json",
-    "fileMatch": [
-      "a://b/PresentationConfigUpdateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/PresentationConfigUpdateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfigUpdateDto.schema.json",
@@ -5526,9 +4842,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateDefaults.schema.json",
-    "fileMatch": [
-      "a://b/RegistrationCertificateDefaults*.schema.json"
-    ],
+    "fileMatch": ["a://b/RegistrationCertificateDefaults*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateDefaults.schema.json",
@@ -5551,9 +4865,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrarConfigResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/RegistrarConfigResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/RegistrarConfigResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrarConfigResponseDto.schema.json",
@@ -5601,21 +4913,13 @@
           "example": true
         }
       },
-      "required": [
-        "registrarUrl",
-        "oidcUrl",
-        "clientId",
-        "username",
-        "hasPassword"
-      ],
+      "required": ["registrarUrl", "oidcUrl", "clientId", "username", "hasPassword"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateRegistrarConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/CreateRegistrarConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CreateRegistrarConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateRegistrarConfigDto.schema.json",
@@ -5662,21 +4966,13 @@
           ]
         }
       },
-      "required": [
-        "registrarUrl",
-        "oidcUrl",
-        "clientId",
-        "username",
-        "password"
-      ],
+      "required": ["registrarUrl", "oidcUrl", "clientId", "username", "password"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateRegistrarConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateRegistrarConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateRegistrarConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateRegistrarConfigDto.schema.json",
@@ -5728,9 +5024,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateAccessCertificateDto.schema.json",
-    "fileMatch": [
-      "a://b/CreateAccessCertificateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CreateAccessCertificateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateAccessCertificateDto.schema.json",
@@ -5743,17 +5037,13 @@
           "example": "my-signing-key"
         }
       },
-      "required": [
-        "keyId"
-      ],
+      "required": ["keyId"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeferredCredentialRequestDto.schema.json",
-    "fileMatch": [
-      "a://b/DeferredCredentialRequestDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/DeferredCredentialRequestDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeferredCredentialRequestDto.schema.json",
@@ -5766,17 +5056,13 @@
           "example": "8xLOxBtZp8"
         }
       },
-      "required": [
-        "transaction_id"
-      ],
+      "required": ["transaction_id"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/NotificationRequestDto.schema.json",
-    "fileMatch": [
-      "a://b/NotificationRequestDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/NotificationRequestDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/NotificationRequestDto.schema.json",
@@ -5788,25 +5074,16 @@
         },
         "event": {
           "type": "string",
-          "enum": [
-            "credential_accepted",
-            "credential_failure",
-            "credential_deleted"
-          ]
+          "enum": ["credential_accepted", "credential_failure", "credential_deleted"]
         }
       },
-      "required": [
-        "notification_id",
-        "event"
-      ],
+      "required": ["notification_id", "event"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Object.schema.json",
-    "fileMatch": [
-      "a://b/Object*.schema.json"
-    ],
+    "fileMatch": ["a://b/Object*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Object.schema.json",
@@ -5818,9 +5095,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ParResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/ParResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ParResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ParResponseDto.schema.json",
@@ -5836,18 +5111,13 @@
           "description": "The expiration time for the request URI in seconds."
         }
       },
-      "required": [
-        "request_uri",
-        "expires_in"
-      ],
+      "required": ["request_uri", "expires_in"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationRequestDto.schema.json",
-    "fileMatch": [
-      "a://b/InteractiveAuthorizationRequestDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/InteractiveAuthorizationRequestDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationRequestDto.schema.json",
@@ -5920,9 +5190,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationCodeResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/InteractiveAuthorizationCodeResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/InteractiveAuthorizationCodeResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationCodeResponseDto.schema.json",
@@ -5940,18 +5208,13 @@
           "example": "auth-code-123"
         }
       },
-      "required": [
-        "status",
-        "code"
-      ],
+      "required": ["status", "code"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationErrorResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/InteractiveAuthorizationErrorResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/InteractiveAuthorizationErrorResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationErrorResponseDto.schema.json",
@@ -5969,17 +5232,13 @@
           "example": "Missing required parameter: interaction_types_supported"
         }
       },
-      "required": [
-        "error"
-      ],
+      "required": ["error"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsParResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/ChainedAsParResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ChainedAsParResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsParResponseDto.schema.json",
@@ -5997,18 +5256,13 @@
           "example": 600
         }
       },
-      "required": [
-        "request_uri",
-        "expires_in"
-      ],
+      "required": ["request_uri", "expires_in"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsErrorResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/ChainedAsErrorResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ChainedAsErrorResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsErrorResponseDto.schema.json",
@@ -6025,17 +5279,13 @@
           "description": "Human-readable error description"
         }
       },
-      "required": [
-        "error"
-      ],
+      "required": ["error"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenRequestDto.schema.json",
-    "fileMatch": [
-      "a://b/ChainedAsTokenRequestDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ChainedAsTokenRequestDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenRequestDto.schema.json",
@@ -6068,17 +5318,13 @@
           "description": "PKCE code verifier"
         }
       },
-      "required": [
-        "grant_type"
-      ],
+      "required": ["grant_type"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/ChainedAsTokenResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ChainedAsTokenResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenResponseDto.schema.json",
@@ -6123,19 +5369,13 @@
           "description": "Refresh token (issued when refresh tokens are enabled)"
         }
       },
-      "required": [
-        "access_token",
-        "token_type",
-        "expires_in"
-      ],
+      "required": ["access_token", "token_type", "expires_in"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/OfferResponse.schema.json",
-    "fileMatch": [
-      "a://b/OfferResponse*.schema.json"
-    ],
+    "fileMatch": ["a://b/OfferResponse*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/OfferResponse.schema.json",
@@ -6153,18 +5393,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "uri",
-        "session"
-      ],
+      "required": ["uri", "session"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CompleteDeferredDto.schema.json",
-    "fileMatch": [
-      "a://b/CompleteDeferredDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CompleteDeferredDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CompleteDeferredDto.schema.json",
@@ -6181,17 +5416,13 @@
           }
         }
       },
-      "required": [
-        "claims"
-      ],
+      "required": ["claims"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeferredOperationResponse.schema.json",
-    "fileMatch": [
-      "a://b/DeferredOperationResponse*.schema.json"
-    ],
+    "fileMatch": ["a://b/DeferredOperationResponse*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeferredOperationResponse.schema.json",
@@ -6204,13 +5435,7 @@
         },
         "status": {
           "description": "The new status of the transaction",
-          "enum": [
-            "pending",
-            "ready",
-            "retrieved",
-            "expired",
-            "failed"
-          ],
+          "enum": ["pending", "ready", "retrieved", "expired", "failed"],
           "type": "string"
         },
         "message": {
@@ -6218,18 +5443,13 @@
           "description": "Optional message"
         }
       },
-      "required": [
-        "transactionId",
-        "status"
-      ],
+      "required": ["transactionId", "status"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FailDeferredDto.schema.json",
-    "fileMatch": [
-      "a://b/FailDeferredDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/FailDeferredDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FailDeferredDto.schema.json",
@@ -6247,9 +5467,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EC_Public.schema.json",
-    "fileMatch": [
-      "a://b/EC_Public*.schema.json"
-    ],
+    "fileMatch": ["a://b/EC_Public*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EC_Public.schema.json",
@@ -6273,20 +5491,13 @@
           "description": "The y coordinate of the EC public key."
         }
       },
-      "required": [
-        "kty",
-        "crv",
-        "x",
-        "y"
-      ],
+      "required": ["kty", "crv", "x", "y"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/JwksResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/JwksResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/JwksResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/JwksResponseDto.schema.json",
@@ -6301,17 +5512,13 @@
           }
         }
       },
-      "required": [
-        "keys"
-      ],
+      "required": ["keys"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthorizationResponse.schema.json",
-    "fileMatch": [
-      "a://b/AuthorizationResponse*.schema.json"
-    ],
+    "fileMatch": ["a://b/AuthorizationResponse*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthorizationResponse.schema.json",
@@ -6347,9 +5554,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProviderCapabilitiesDto.schema.json",
-    "fileMatch": [
-      "a://b/KmsProviderCapabilitiesDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KmsProviderCapabilitiesDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProviderCapabilitiesDto.schema.json",
@@ -6373,9 +5578,7 @@
         },
         "supportedAlgs": {
           "description": "Signing algorithms supported by the provider.",
-          "example": [
-            "ES256"
-          ],
+          "example": ["ES256"],
           "type": "array",
           "items": {
             "type": "string"
@@ -6387,21 +5590,13 @@
           "example": "ES256"
         }
       },
-      "required": [
-        "canImport",
-        "canCreate",
-        "canDelete",
-        "supportedAlgs",
-        "defaultAlg"
-      ],
+      "required": ["canImport", "canCreate", "canDelete", "supportedAlgs", "defaultAlg"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProviderInfoDto.schema.json",
-    "fileMatch": [
-      "a://b/KmsProviderInfoDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KmsProviderInfoDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProviderInfoDto.schema.json",
@@ -6432,19 +5627,13 @@
           ]
         }
       },
-      "required": [
-        "name",
-        "type",
-        "capabilities"
-      ],
+      "required": ["name", "type", "capabilities"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProvidersResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/KmsProvidersResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KmsProvidersResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProvidersResponseDto.schema.json",
@@ -6464,18 +5653,13 @@
           "example": "db"
         }
       },
-      "required": [
-        "providers",
-        "default"
-      ],
+      "required": ["providers", "default"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CertificateInfoDto.schema.json",
-    "fileMatch": [
-      "a://b/CertificateInfoDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CertificateInfoDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CertificateInfoDto.schema.json",
@@ -6509,17 +5693,13 @@
           "description": "Serial number."
         }
       },
-      "required": [
-        "pem"
-      ],
+      "required": ["pem"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PublicKeyInfoDto.schema.json",
-    "fileMatch": [
-      "a://b/PublicKeyInfoDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/PublicKeyInfoDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PublicKeyInfoDto.schema.json",
@@ -6546,17 +5726,13 @@
           "example": "P-256"
         }
       },
-      "required": [
-        "kty"
-      ],
+      "required": ["kty"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/RotationPolicyResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/RotationPolicyResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyResponseDto.schema.json",
@@ -6581,17 +5757,13 @@
           "description": "Next scheduled rotation date."
         }
       },
-      "required": [
-        "enabled"
-      ],
+      "required": ["enabled"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/KeyChainResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KeyChainResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainResponseDto.schema.json",
@@ -6603,21 +5775,12 @@
           "description": "Unique identifier for the key chain."
         },
         "usageType": {
-          "enum": [
-            "access",
-            "attestation",
-            "trustList",
-            "statusList",
-            "encrypt"
-          ],
+          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"],
           "type": "string",
           "description": "Usage type of the key chain."
         },
         "type": {
-          "enum": [
-            "standalone",
-            "internalChain"
-          ],
+          "enum": ["standalone", "internalChain"],
           "type": "string",
           "description": "Type of key chain (standalone or internalChain)."
         },
@@ -6708,9 +5871,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExportEcJwk.schema.json",
-    "fileMatch": [
-      "a://b/ExportEcJwk*.schema.json"
-    ],
+    "fileMatch": ["a://b/ExportEcJwk*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExportEcJwk.schema.json",
@@ -6749,21 +5910,13 @@
           "description": "Key ID"
         }
       },
-      "required": [
-        "kty",
-        "crv",
-        "x",
-        "y",
-        "d"
-      ],
+      "required": ["kty", "crv", "x", "y", "d"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExportRotationPolicyDto.schema.json",
-    "fileMatch": [
-      "a://b/ExportRotationPolicyDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ExportRotationPolicyDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExportRotationPolicyDto.schema.json",
@@ -6783,17 +5936,13 @@
           "description": "Certificate validity in days."
         }
       },
-      "required": [
-        "enabled"
-      ],
+      "required": ["enabled"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainExportDto.schema.json",
-    "fileMatch": [
-      "a://b/KeyChainExportDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KeyChainExportDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainExportDto.schema.json",
@@ -6809,13 +5958,7 @@
           "description": "Human-readable description."
         },
         "usageType": {
-          "enum": [
-            "access",
-            "attestation",
-            "trustList",
-            "statusList",
-            "encrypt"
-          ],
+          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"],
           "type": "string",
           "description": "Usage type for this key chain."
         },
@@ -6847,19 +5990,13 @@
           ]
         }
       },
-      "required": [
-        "id",
-        "usageType",
-        "key"
-      ],
+      "required": ["id", "usageType", "key"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyCreateDto.schema.json",
-    "fileMatch": [
-      "a://b/RotationPolicyCreateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/RotationPolicyCreateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyCreateDto.schema.json",
@@ -6886,17 +6023,13 @@
           "example": 365
         }
       },
-      "required": [
-        "enabled"
-      ],
+      "required": ["enabled"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainCreateDto.schema.json",
-    "fileMatch": [
-      "a://b/KeyChainCreateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KeyChainCreateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainCreateDto.schema.json",
@@ -6904,22 +6037,13 @@
       "type": "object",
       "properties": {
         "usageType": {
-          "enum": [
-            "access",
-            "attestation",
-            "trustList",
-            "statusList",
-            "encrypt"
-          ],
+          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"],
           "type": "string",
           "description": "Usage type determines the purpose of this key chain (access, attestation, etc.).",
           "example": "attestation"
         },
         "type": {
-          "enum": [
-            "standalone",
-            "internalChain"
-          ],
+          "enum": ["standalone", "internalChain"],
           "type": "string",
           "description": "Type of key chain to create.",
           "example": "internalChain"
@@ -6943,18 +6067,13 @@
           ]
         }
       },
-      "required": [
-        "usageType",
-        "type"
-      ],
+      "required": ["usageType", "type"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EcJwk.schema.json",
-    "fileMatch": [
-      "a://b/EcJwk*.schema.json"
-    ],
+    "fileMatch": ["a://b/EcJwk*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EcJwk.schema.json",
@@ -6983,21 +6102,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "kty",
-        "x",
-        "y",
-        "crv",
-        "d"
-      ],
+      "required": ["kty", "x", "y", "crv", "d"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyImportDto.schema.json",
-    "fileMatch": [
-      "a://b/RotationPolicyImportDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/RotationPolicyImportDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyImportDto.schema.json",
@@ -7024,17 +6135,13 @@
           "example": 365
         }
       },
-      "required": [
-        "enabled"
-      ],
+      "required": ["enabled"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainImportDto.schema.json",
-    "fileMatch": [
-      "a://b/KeyChainImportDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KeyChainImportDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainImportDto.schema.json",
@@ -7058,13 +6165,7 @@
           "description": "Human-readable description."
         },
         "usageType": {
-          "enum": [
-            "access",
-            "attestation",
-            "trustList",
-            "statusList",
-            "encrypt"
-          ],
+          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"],
           "type": "string",
           "description": "Usage type for this key chain."
         },
@@ -7088,18 +6189,13 @@
           ]
         }
       },
-      "required": [
-        "key",
-        "usageType"
-      ],
+      "required": ["key", "usageType"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyUpdateDto.schema.json",
-    "fileMatch": [
-      "a://b/RotationPolicyUpdateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/RotationPolicyUpdateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyUpdateDto.schema.json",
@@ -7128,9 +6224,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainUpdateDto.schema.json",
-    "fileMatch": [
-      "a://b/KeyChainUpdateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KeyChainUpdateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainUpdateDto.schema.json",
@@ -7159,9 +6253,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationRequest.schema.json",
-    "fileMatch": [
-      "a://b/PresentationRequest*.schema.json"
-    ],
+    "fileMatch": ["a://b/PresentationRequest*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationRequest.schema.json",
@@ -7171,10 +6263,7 @@
         "response_type": {
           "type": "string",
           "description": "The type of response expected from the presentation request.",
-          "enum": [
-            "uri",
-            "dc-api"
-          ]
+          "enum": ["uri", "dc-api"]
         },
         "requestId": {
           "type": "string",
@@ -7201,18 +6290,13 @@
           }
         }
       },
-      "required": [
-        "response_type",
-        "requestId"
-      ],
+      "required": ["response_type", "requestId"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FileUploadDto.schema.json",
-    "fileMatch": [
-      "a://b/FileUploadDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/FileUploadDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FileUploadDto.schema.json",
@@ -7224,9 +6308,7 @@
           "format": "binary"
         }
       },
-      "required": [
-        "file"
-      ],
+      "required": ["file"],
       "additionalProperties": false
     }
   }

--- a/docs/architecture/webhooks.md
+++ b/docs/architecture/webhooks.md
@@ -79,27 +79,34 @@ See [Attribute Providers](./attribute-providers.md).
 
 ---
 
-## Notification Webhook
+## Notification Webhook Endpoint
 
-The **notification webhook** receives the outcome of the issuance process (e.g., accepted or denied).  
-This confirms that the wallet has received and accepted the credential.
+The **notification webhook endpoint** is a standalone, reusable tenant resource
+that receives the outcome of the issuance process (e.g., accepted or denied).
+It is not embedded directly in the issuance request or credential configuration.
+
+Instead, reference the endpoint by ID using `webhookEndpointId` on the
+credential configuration or on an offer request.
+
+Example endpoint resource:
 
 ```json
 {
-    "notifyWebhook": {
-        "url": "http://localhost:8787/notify",
-        "auth": {
-            "type": "apiKey",
-            "config": {
-                "headerName": "x-api-key",
-                "value": "your-api-key"
-            }
-        }
+    "id": "notification",
+    "name": "Notification Webhook",
+    "description": "Receives credential issuance lifecycle events",
+    "url": "http://localhost:8787",
+    "auth": {
+        "type": "none"
     }
 }
 ```
 
-If no notification webhook is configured, you can fetch the session result by querying the `/session` endpoint with the `sessionId`.
+If you use authentication for the endpoint, the `auth` object follows the same
+webhook authentication model used by presentation webhooks.
+
+If no notification webhook endpoint is configured, you can fetch the session
+result by querying the `/session` endpoint with the `sessionId`.
 
 ---
 

--- a/docs/getting-started/issuance/attribute-provider.md
+++ b/docs/getting-started/issuance/attribute-provider.md
@@ -1,12 +1,12 @@
 # Attribute Providers
 
-Attribute Providers are external HTTPS endpoints that EUDIPLO calls during credential issuance to dynamically fetch claim values. They provide a centralized, reusable way to configure claims webhooks at the tenant level.
+Attribute Providers are external HTTPS endpoints that EUDIPLO calls during credential issuance to dynamically fetch claim values. They provide a centralized, reusable way to configure claim sources at the tenant level.
 
 ---
 
 ## Overview
 
-Instead of configuring webhook URLs and authentication directly on each credential configuration, you can:
+Instead of repeating claim source settings on each credential configuration, you can:
 
 1. Create an Attribute Provider with the endpoint URL and authentication settings
 2. Reference the Attribute Provider by ID in one or more credential configurations
@@ -131,9 +131,9 @@ Once created, reference the Attribute Provider in your credential configuration:
 
 ---
 
-## Webhook Request & Response
+## Request and Response
 
-When EUDIPLO calls your Attribute Provider endpoint, it sends a POST request with information about the issuance session.
+When EUDIPLO calls your Attribute Provider endpoint, it sends a POST request with issuance session context.
 
 ### Request Format
 

--- a/docs/getting-started/issuance/credential-configuration.md
+++ b/docs/getting-started/issuance/credential-configuration.md
@@ -1,7 +1,7 @@
 # Credential Configuration
 
-Credential configurations define the structure and properties of individual
-credentials. Each credential type has its own configuration file.
+Credential configurations define the structure and behavior of individual
+credentials. Each credential type has its own configuration.
 
 ---
 
@@ -39,7 +39,7 @@ For a complete configuration example, see the [Complete Configuration Example](#
 - `vct`: **OPTIONAL** -
   [VC Type Metadata](https://www.ietf.org/archive/id/draft-ietf-oauth-sd-jwt-vc-09.html#name-sd-jwt-vc-type-metadata)
   provided via the `/{tenantId}/credentials-metadata/vct/{id}` endpoint. This link will
-  automatically added into the credential.
+  be automatically added to the credential.
 - `keyChainId`: **OPTIONAL** - Unique identifier for the key chain used to sign the credential. If not provided, the key chain with `attestation` usage type will be used. See [Signing Key Chain](#signing-key-chain) for details.
 - `lifeTime`: **OPTIONAL** - Credential expiration time in seconds. If
   specified, credentials will include an `exp` claim calculated as
@@ -53,7 +53,9 @@ For a complete configuration example, see the [Complete Configuration Example](#
 - `fields`: **REQUIRED for v2** - Field definitions (`ClaimFieldDefinition[]`) that describe claim paths, data types, defaults, disclosure behavior, and optional display labels.
 - `attributeProviderId`: **OPTIONAL** - Reference to an Attribute Provider that fetches claims dynamically. See [Attribute Providers](attribute-provider.md) for details.
 - `webhookEndpointId`: **OPTIONAL** - Reference to a Webhook Endpoint for receiving notifications about the issuance process. See [Notification Webhook Endpoint](#notification-webhook-endpoint) for details.
-- `sdJwtTrustFormat`: **OPTIONAL (SD-JWT only)** - Controls trust signaling in issued SD-JWT credentials: - `x5c` (default): include X.509 chain in JWT header - `federation`: use federation issuer identity (`iss`) for trust resolution
+- `sdJwtTrustFormat`: **OPTIONAL (SD-JWT only)** - Controls trust signaling in issued SD-JWT credentials:
+    - `x5c` (default): include the X.509 chain in the JWT header
+    - `federation`: use federation issuer identity (`iss`) for trust resolution
 - `embeddedDisclosurePolicy`: **OPTIONAL** - Defines the embedded disclosure policy for the credential. See [Embedded Disclosure Policy](#embedded-disclosure-policy) for details.
 - `iaeActions`: **OPTIONAL** - Sequence of Interactive Authorization actions required before credential issuance. See [Interactive Authorization Actions](#interactive-authorization-actions) for details.
 
@@ -115,7 +117,7 @@ Static field defaults are useful for:
 - Fixed metadata (e.g., issuing country, issuing authority)
 - Development and testing scenarios
 
-### Claims Webhook
+### Attribute Provider
 
 For dynamic claim retrieval, configure an Attribute Provider that is called during issuance:
 
@@ -159,7 +161,7 @@ For more details about the webhook implementation and payload structure, see [No
 
 !!! Info
 
-    When a webhook endpoint is configured on credential config level, notifications will be sent to this endpoint instead of the one provided in the issuance config. It can also be overwritten via the credential offer.
+    When a webhook endpoint is configured on credential config level, notifications are sent to this endpoint by default. It can be overridden per issuance by setting `webhookEndpointId` on the credential offer request.
 
 ---
 

--- a/docs/getting-started/issuance/credential-configuration.md
+++ b/docs/getting-started/issuance/credential-configuration.md
@@ -52,7 +52,7 @@ For a complete configuration example, see the [Complete Configuration Example](#
   proof of possession. See [Cryptographic Key Binding](#cryptographic-key-binding) for details.
 - `fields`: **REQUIRED for v2** - Field definitions (`ClaimFieldDefinition[]`) that describe claim paths, data types, defaults, disclosure behavior, and optional display labels.
 - `attributeProviderId`: **OPTIONAL** - Reference to an Attribute Provider that fetches claims dynamically. See [Attribute Providers](attribute-provider.md) for details.
-- `webhookEndpointId`: **OPTIONAL** - Reference to a Webhook Endpoint for receiving notifications about the issuance process. See [Notification Webhook](#notification-webhook) for details.
+- `webhookEndpointId`: **OPTIONAL** - Reference to a Webhook Endpoint for receiving notifications about the issuance process. See [Notification Webhook Endpoint](#notification-webhook-endpoint) for details.
 - `sdJwtTrustFormat`: **OPTIONAL (SD-JWT only)** - Controls trust signaling in issued SD-JWT credentials: - `x5c` (default): include X.509 chain in JWT header - `federation`: use federation issuer identity (`iss`) for trust resolution
 - `embeddedDisclosurePolicy`: **OPTIONAL** - Defines the embedded disclosure policy for the credential. See [Embedded Disclosure Policy](#embedded-disclosure-policy) for details.
 - `iaeActions`: **OPTIONAL** - Sequence of Interactive Authorization actions required before credential issuance. See [Interactive Authorization Actions](#interactive-authorization-actions) for details.
@@ -71,7 +71,7 @@ In v2, claim content is configured through `fields[]`. Each entry describes a si
 
 !!! info "Claims Priority System"
 
-    EUDIPLO supports multiple ways to provide claims (configuration-level and offer-level), with a priority system that determines which claims are used. For a complete explanation of the claims priority order and when to use each method, see [Passing Claims](index.md#passing-claims) in the Issuance Overview.
+    EUDIPLO supports multiple ways to provide claims (configuration-level and offer-level), with a priority system that determines which claims are used. For a complete explanation of the claims priority order and when to use each method, see [Credential Offers](credential-offers.md#passing-claims).
 
 ### Static Defaults via `fields[]`
 
@@ -137,7 +137,7 @@ For detailed information about creating Attribute Providers, request/response fo
 
 ---
 
-## Notification Webhook
+## Notification Webhook Endpoint
 
 You can configure a webhook endpoint to receive notifications about the issuance process. This allows you to track the status of credential issuance and take appropriate actions.
 
@@ -149,13 +149,13 @@ Reference a pre-configured webhook endpoint by its ID:
 }
 ```
 
-The notification webhook will be called at various stages of the issuance process, such as:
+The notification webhook endpoint will be called at various stages of the issuance process, such as:
 
 - When a credential is successfully issued
 - When an issuance request fails
 - When a credential is accepted by the holder
 
-For more details about the webhook implementation and payload structure, see [Notification Webhook](../../architecture/webhooks.md#notification-webhook).
+For more details about the webhook implementation and payload structure, see [Notification Webhook Endpoint](../../architecture/webhooks.md#notification-webhook-endpoint).
 
 !!! Info
 

--- a/docs/getting-started/issuance/credential-offers.md
+++ b/docs/getting-started/issuance/credential-offers.md
@@ -1,17 +1,17 @@
 # Credential Offers
 
-Credential offers are the entry point into OID4VCI issuance. Your backend creates
-an offer via the API, EUDIPLO returns an offer URI, and that URI is then
-presented to the wallet as a QR code, deep link, or button.
+Credential offers start OID4VCI issuance. Your backend creates an offer via the
+API, EUDIPLO returns an offer URI, and you present that URI to the wallet
+(for example as a QR code or deep link).
 
-Use this page for the request shape and offer-specific behavior. For guidance on
-which issuance mode to choose, see the [Issuance Overview](index.md).
+This page covers request shape and offer behavior. For flow selection guidance,
+see the [Issuance Overview](index.md).
 
 ---
 
 ## Before You Create an Offer
 
-You typically need these resources in place first:
+Usually you create these resources first:
 
 1. A [Credential Configuration](credential-configuration.md)
 2. An [Issuance Configuration](issuance-configuration.md)
@@ -21,8 +21,7 @@ You typically need these resources in place first:
 
 ## Creating Credential Offers
 
-Via the [credential offer endpoint](../../api/openapi.md) you can create a
-credential offer that can be presented to the user.
+Use the [credential offer endpoint](../../api/openapi.md) to create the offer.
 
 When creating an offer, you can:
 
@@ -43,6 +42,12 @@ When creating an offer, you can:
 - `tx_code` - optional transaction code for pre-authorized flows
 - `tx_code_description` - optional prompt shown with the transaction code
 - `webhookEndpointId` - optional notification webhook endpoint ID
+
+!!! info "Notification webhook endpoint references"
+
+    `webhookEndpointId` references a standalone Webhook Endpoint resource. Create the endpoint first, then reference it by ID.
+
+    If both a credential configuration and an offer specify `webhookEndpointId`, the offer-level value is used for that session.
 
 ### Example: Pre-authorized Offer with Inline Claims
 
@@ -78,8 +83,8 @@ When creating an offer, you can:
 
 ## Single-Use Offers
 
-All credential offers are single-use and non-replayable. Once a wallet completes
-the issuance flow with a credential offer:
+Credential offers are single-use and non-replayable. Once a wallet completes
+issuance with an offer:
 
 - Token replay with the same authorization or pre-authorized code is rejected with an `invalid_grant` error
 - The offer is marked as consumed at the credential endpoint and cannot be used again after successful credential processing
@@ -172,7 +177,7 @@ Notes:
 - `credentialClaims` keys must be a subset of `credentialConfigurationIds`
 - values are resolved per credential configuration, not globally for the whole offer
 - if you want to override only one credential in a multi-credential offer, include only that credential in `credentialClaims`
-- for the full webhook shape, see [Attribute Providers](attribute-provider.md) and the [API documentation](../../api/openapi.md)
+- for the full webhook shape, see [Attribute Providers](attribute-provider.md), [Webhooks](../../architecture/webhooks.md), and the [API documentation](../../api/openapi.md)
 
 ### When to Use Each Method
 

--- a/docs/getting-started/issuance/credential-offers.md
+++ b/docs/getting-started/issuance/credential-offers.md
@@ -1,0 +1,184 @@
+# Credential Offers
+
+Credential offers are the entry point into OID4VCI issuance. Your backend creates
+an offer via the API, EUDIPLO returns an offer URI, and that URI is then
+presented to the wallet as a QR code, deep link, or button.
+
+Use this page for the request shape and offer-specific behavior. For guidance on
+which issuance mode to choose, see the [Issuance Overview](index.md).
+
+---
+
+## Before You Create an Offer
+
+You typically need these resources in place first:
+
+1. A [Credential Configuration](credential-configuration.md)
+2. An [Issuance Configuration](issuance-configuration.md)
+3. Optionally an [Attribute Provider](attribute-provider.md) if claims should be fetched dynamically
+
+---
+
+## Creating Credential Offers
+
+Via the [credential offer endpoint](../../api/openapi.md) you can create a
+credential offer that can be presented to the user.
+
+When creating an offer, you can:
+
+1. Define the flow with `flow`
+2. Select the credentials with `credentialConfigurationIds`
+3. Optionally select an external authorization server with `authorization_server`
+4. Optionally override claims with `credentialClaims`
+5. Optionally enable a transaction code with `tx_code` and `tx_code_description`
+6. Optionally configure notifications with `webhookEndpointId`
+
+### Common Request Fields
+
+- `response_type` - how the offer is returned to the caller
+- `flow` - `pre_authorized_code` or `authorization_code`
+- `credentialConfigurationIds` - list of credential configuration IDs to include in the offer
+- `authorization_server` - optional authorization server identifier for flows using an external AS
+- `credentialClaims` - optional per-credential claims source override
+- `tx_code` - optional transaction code for pre-authorized flows
+- `tx_code_description` - optional prompt shown with the transaction code
+- `webhookEndpointId` - optional notification webhook endpoint ID
+
+### Example: Pre-authorized Offer with Inline Claims
+
+```json
+{
+    "response_type": "uri",
+    "flow": "pre_authorized_code",
+    "credentialConfigurationIds": ["citizen"],
+    "credentialClaims": {
+        "citizen": {
+            "type": "inline",
+            "claims": {
+                "given_name": "John",
+                "family_name": "Doe"
+            }
+        }
+    }
+}
+```
+
+### Example: Authorization Code Offer with External AS
+
+```json
+{
+    "response_type": "uri",
+    "flow": "authorization_code",
+    "authorization_server": "https://keycloak.example.com/realms/myrealm",
+    "credentialConfigurationIds": ["employee_badge"]
+}
+```
+
+---
+
+## Single-Use Offers
+
+All credential offers are single-use and non-replayable. Once a wallet completes
+the issuance flow with a credential offer:
+
+- Token replay with the same authorization or pre-authorized code is rejected with an `invalid_grant` error
+- The offer is marked as consumed at the credential endpoint and cannot be used again after successful credential processing
+- The `consumedAt` timestamp records when the offer was first used
+
+Important considerations:
+
+- Create a new offer for each issuance request
+- Combine single-use enforcement with TTL-based cleanup so expired offers do not accumulate
+- Refresh tokens remain valid for follow-up operations on the issued credentials
+
+This prevents credential offer replay attacks where an intercepted offer could
+otherwise be reused.
+
+---
+
+## Passing Claims
+
+EUDIPLO provides multiple methods to pass claims during issuance. Claims are
+resolved in the following priority order:
+
+1. Offer-level claims via `credentialClaims`
+2. Configuration-level Attribute Provider via `attributeProviderId`
+3. Configuration-level static claims on the credential configuration
+
+!!! warning "Claims are not merged"
+
+    Higher priority sources completely override lower priority sources. If an offer-level webhook or Attribute Provider is used, lower-priority sources are not merged in.
+
+### Request Shape for `credentialClaims`
+
+`credentialClaims` must be an object keyed by credential configuration ID. Each
+key must also appear in `credentialConfigurationIds`.
+
+Each value selects the claims source for that credential:
+
+- `type: "inline"` - pass the claims directly in the request
+- `type: "attributeProvider"` - fetch claims from an existing Attribute Provider
+- `type: "webhook"` - fetch claims from an inline webhook definition for this offer only
+
+The most common way to override claims is the inline variant:
+
+```json
+{
+    "response_type": "uri",
+    "flow": "pre_authorized_code",
+    "credentialConfigurationIds": ["citizen"],
+    "credentialClaims": {
+        "citizen": {
+            "type": "inline",
+            "claims": {
+                "given_name": "John",
+                "family_name": "Doe"
+            }
+        }
+    }
+}
+```
+
+In this example:
+
+- `citizen` is the credential configuration ID
+- `claims` contains the actual credential claim values
+- the inline claims override any configuration-level Attribute Provider or static claims for `citizen`
+
+You can also override the source instead of embedding claims directly:
+
+```json
+{
+    "response_type": "uri",
+    "flow": "pre_authorized_code",
+    "credentialConfigurationIds": ["citizen", "employee_badge"],
+    "credentialClaims": {
+        "citizen": {
+            "type": "attributeProvider",
+            "attributeProviderId": "citizen-claims-provider"
+        },
+        "employee_badge": {
+            "type": "webhook",
+            "webhook": {
+                "url": "https://issuer.example.com/api/claims/employee-badge"
+            }
+        }
+    }
+}
+```
+
+Notes:
+
+- `credentialClaims` keys must be a subset of `credentialConfigurationIds`
+- values are resolved per credential configuration, not globally for the whole offer
+- if you want to override only one credential in a multi-credential offer, include only that credential in `credentialClaims`
+- for the full webhook shape, see [Attribute Providers](attribute-provider.md) and the [API documentation](../../api/openapi.md)
+
+### When to Use Each Method
+
+- Configuration-level static claims for fixed metadata used on every issuance
+- Configuration-level Attribute Providers for dynamic claims based on authentication context
+- Offer-level inline claims when claim values are already known at offer creation time
+- Offer-level webhook or Attribute Provider overrides when claim resolution should vary per offer
+
+For the broader claims model, see [Fetching Claims](credential-configuration.md#fetching-claims).

--- a/docs/getting-started/issuance/index.md
+++ b/docs/getting-started/issuance/index.md
@@ -1,6 +1,6 @@
 # Configuring Credential Issuance Flows
 
-The issuance system uses a **three-part configuration approach**:
+Issuance configuration is split into **three layers**:
 
 1. **Credential Configurations** - Define the structure, format, and metadata of
    individual credentials
@@ -13,7 +13,7 @@ The issuance system uses a **three-part configuration approach**:
 
 ## API Endpoints
 
-The system uses separate endpoints for each configuration layer:
+Each layer has its own API endpoints:
 
 ### Credential Configurations
 
@@ -43,9 +43,9 @@ format are documented in [Credential Offers](credential-offers.md).
 
 ## Credential Issuance Flow
 
-This flow describes how a backend service starts an issuance flow of an
-attestation. EUDIPLO creates the OID4VCI request and handles the protocol flow
-with the wallet. It also shows the interactions with [webhooks](../../architecture/webhooks.md) when they are configured.
+This flow shows how a backend service starts issuance. EUDIPLO creates the
+OID4VCI request, runs the protocol with the wallet, and optionally calls
+[webhooks](../../architecture/webhooks.md).
 
 ```mermaid
 sequenceDiagram
@@ -93,7 +93,8 @@ sequenceDiagram
     end
 ```
 
-The response with the credential offer link will also provide the session ID. It is included in the requests from the optional webhooks to identify the specific issuance flow. You can also use the id to query the issuance status at the API.
+The offer response also contains the session ID. EUDIPLO includes this ID in
+optional webhook calls, and you can use it to query issuance status via the API.
 
 ---
 
@@ -419,7 +420,7 @@ This issuance documentation is organized into the following sections:
   dedicated, reusable registrar-backed resource
 - **[Issuance Configuration](issuance-configuration.md)** - Understand how to
   create issuance configurations that group multiple credentials and define
-  issuance parameters such as authorization and webhooks
+  issuance parameters such as authorization, token behavior, and trust settings
 - **[Attribute Providers](attribute-provider.md)** - Configure reusable webhook
   endpoints for fetching claims dynamically during credential issuance
 

--- a/docs/getting-started/issuance/index.md
+++ b/docs/getting-started/issuance/index.md
@@ -33,35 +33,11 @@ Based on your passed access token, endpoints will be scoped to the tenant ID of 
 token. You also need the `issuance:manage` role to access these endpoints.
 The configurations are internally stored in a database.
 
-### Creating Credential Offers
+### Credential Offers
 
-Via the [credential offer endpoint](../../api/openapi.md) you can create a credential offer that can be presented to the user.
-When creating an offer, you can:
-
-1. **Define the flow** - Either go with the pre authorized flow or require user
-   authentication via the authorization code flow
-2. **Provide credentials** - Use `credentialConfigurationIds` to specify which
-   credentials to issue from the issuance configuration
-3. **Optionally override claims** - Use the `credentialClaims` parameter to provide
-   inline claims, webhook, or Attribute Provider reference for specific credentials
-4. **Optionally pass notification webhooks** - Use the `notifyWebhook` parameter to
-   get notified about issuance status changes
-
-### Single-Use Offers (Replay Prevention)
-
-All credential offers are **single-use and non-replayable**. Once a wallet completes the issuance flow with a credential offer:
-
-- Token replay with the same authorization or pre-authorized code is rejected with an `invalid_grant` error
-- The offer is marked as consumed at the credential endpoint and cannot be used again after successful credential processing
-- The `consumedAt` timestamp records when the offer was first used
-
-**Important Considerations:**
-
-- **Create a new offer for each issuance**: If a user needs credentials again, create a fresh credential offer via the API
-- **Offer expiration**: Combine single-use enforcement with TTL-based session cleanup (configured per-tenant) to ensure expired offers don't accumulate
-- **Refresh tokens**: Refresh tokens remain valid and can be used to obtain new access tokens for additional operations on the issued credentials
-
-This design prevents credential offer replay attacks where an attacker could reuse an intercepted offer to obtain credentials fraudulently.
+Creating a credential offer is the operational step that starts issuance. The
+full request model, examples, replay behavior, and `credentialClaims` override
+format are documented in [Credential Offers](credential-offers.md).
 
 ---
 
@@ -435,6 +411,7 @@ For detailed information on implementing deferred issuance, see the [Deferred Is
 
 This issuance documentation is organized into the following sections:
 
+- **[Credential Offers](credential-offers.md)** - Create offers, pass inline or dynamic claims, and understand replay prevention behavior
 - **[Credential Configuration](credential-configuration.md)** - Learn how to
   define individual credential types, their structure, claims, and display
   properties
@@ -460,31 +437,7 @@ For a quick start, follow these steps:
    [Schema Metadata](schema-metadata.md) guide
 4. **Create an issuance configuration** - Define the issuance configuration using
    the [Issuance Configuration](issuance-configuration.md) guide
-5. **Issue credentials** - Start the issuance flow by creating credential offers
+5. **Create a credential offer** - Start the issuance flow using the
+   [Credential Offers](credential-offers.md) guide
 
 ---
-
-## Passing Claims
-
-EUDIPLO provides multiple methods to pass claims (data) for credentials during issuance, with a clear priority system that determines which claims are used.
-
-### Priority Order
-
-Claims are resolved in the following priority order (highest to lowest):
-
-1. **Offer-level claims** - Inline claims, webhook, or Attribute Provider reference passed at offer time
-2. **Configuration-level Attribute Provider** - The `attributeProviderId` on the credential configuration
-3. **Configuration-level static claims** - Claims defined in the credential configuration
-
-!!! warning "Claims are not merged"
-
-    Higher priority sources completely override lower priority sources - claims are not merged. If an offer-level webhook is provided, the configuration-level Attribute Provider will not be called.
-
-For a detailed explanation of the claims priority system and how to configure each method, see the [Fetching Claims](credential-configuration.md#fetching-claims) section in the Credential Configuration documentation.
-
-### When to Use Each Method
-
-- **Configuration-level static claims** - Default values for all credentials of this type, fixed metadata (e.g., issuing country, authority)
-- **Configuration-level Attribute Provider** - Dynamic claims based on authentication context, personalized credentials requiring real-time data
-- **Offer-level inline claims** - Claims known at offer creation time, overriding specific values for individual issuances
-- **Offer-level webhook/Attribute Provider** - Custom data source per offer, testing different webhook endpoints

--- a/docs/getting-started/issuance/issuance-configuration.md
+++ b/docs/getting-started/issuance/issuance-configuration.md
@@ -1,6 +1,7 @@
 # Issuance Configuration
 
-Issuance configurations define the parameters and settings for the issuance of credentials. This includes details such as the supported credential types, issuance policies, and any specific requirements for the issuance process.
+Issuance configurations define runtime behavior for issuing credentials, such as
+authorization, token behavior, and trust-related requirements.
 
 ---
 

--- a/docs/getting-started/presentation/index.md
+++ b/docs/getting-started/presentation/index.md
@@ -102,7 +102,11 @@ Presentation flows create sessions that:
 
 ## Quick Start
 
-To manage presentation configurations, have a look at the [API Documentation](../../api/openapi.md) about the verifier. There you will find the endpoints to manage presentation configs and also to create presentation requests.
+Use the verifier section in the [API Documentation](../../api/openapi.md) to
+manage presentation configurations and create presentation requests.
+
+For request payloads, examples, and runtime override behavior, see
+[Presentation Requests](presentation-requests.md).
 
 ---
 
@@ -178,7 +182,7 @@ sequenceDiagram
     Wallet->>User: Request presentation consent
     User->>Wallet: Approve presentation
     Wallet->>EUDIPLO: Submit OpenID4VP presentation
-    EUDIPLO->>Backend: Claims webhook (verified claims)
+    EUDIPLO->>Backend: Attribute Provider call (verified claims context)
     Backend-->>EUDIPLO: Return issuance claims
     EUDIPLO-->>Wallet: Authorization Code
     Wallet->>EUDIPLO: Token Request

--- a/docs/getting-started/presentation/presentation-configuration.md
+++ b/docs/getting-started/presentation/presentation-configuration.md
@@ -4,6 +4,9 @@ This guide covers how to create, manage, and configure presentation requests in
 EUDIPLO. Presentation configurations define what credentials and claims should
 be requested from users.
 
+For creating request payloads and runtime overrides, see
+[Presentation Requests](presentation-requests.md).
+
 ---
 
 ## Configuration Structure
@@ -29,6 +32,14 @@ be requested from users.
 !!! Info
 
     If no webhook is configured, the presentation result can be fetched by querying the `/session` endpoint with the `sessionId`.
+
+!!! info "Request-time overrides"
+
+    When you create a presentation request (`/verifier/offer`), the request body can override configuration-level values:
+
+    - `webhook` in the request overrides `webhook` from the presentation configuration
+    - `redirectUri` in the request overrides `redirectUri` from the presentation configuration
+    - `transaction_data` in the request overrides `transaction_data` from the presentation configuration
 
 ### registrationCert Structure
 

--- a/docs/getting-started/presentation/presentation-requests.md
+++ b/docs/getting-started/presentation/presentation-requests.md
@@ -1,0 +1,93 @@
+# Presentation Requests
+
+Presentation requests are created with the `/verifier/offer` endpoint. Each
+request references a stored presentation configuration and can optionally
+override selected runtime values.
+
+Use this page for request payload shape and override behavior. For defining what
+to request (DCQL, webhook defaults, registration certificate), see
+[Presentation Configuration](presentation-configuration.md).
+
+---
+
+## Endpoint
+
+- `POST /verifier/offer`
+
+---
+
+## Request Fields
+
+| Field              | Required | Description                                                           |
+| ------------------ | -------- | --------------------------------------------------------------------- |
+| `response_type`    | Yes      | Response mode. Supported values: `uri`, `dc-api`.                     |
+| `requestId`        | Yes      | ID of the presentation configuration to use.                          |
+| `webhook`          | No       | Inline webhook override for this request.                             |
+| `redirectUri`      | No       | Redirect target after completion. Supports `{sessionId}` placeholder. |
+| `transaction_data` | No       | Transaction data override for this request.                           |
+
+---
+
+## Basic Example
+
+```json
+{
+    "response_type": "uri",
+    "requestId": "pid-verification"
+}
+```
+
+## Example with Runtime Overrides
+
+```json
+{
+    "response_type": "uri",
+    "requestId": "pid-verification",
+    "webhook": {
+        "url": "https://verifier.example.com/presentation-callback",
+        "auth": {
+            "type": "none"
+        }
+    },
+    "redirectUri": "https://verifier.example.com/callback?session={sessionId}",
+    "transaction_data": [
+        {
+            "type": "access_control",
+            "credential_ids": ["pid"],
+            "resource": "Building A"
+        }
+    ]
+}
+```
+
+---
+
+## Override Rules
+
+When a request provides runtime fields, they override the corresponding values
+from the presentation configuration for that session:
+
+- `webhook` overrides configuration `webhook`
+- `redirectUri` overrides configuration `redirectUri`
+- `transaction_data` overrides configuration `transaction_data`
+
+These values are not merged.
+
+---
+
+## Session and Result Retrieval
+
+If no webhook is configured, retrieve the result via the `/session` endpoint
+using the returned session identifier.
+
+For same-device redirect flows, use the `response_code` from the redirect URL to
+look up the completed session.
+
+---
+
+## Related Docs
+
+- [Credential Presentation Overview](index.md)
+- [Presentation Configuration](presentation-configuration.md)
+- [Transaction Data](transaction-data.md)
+- [Webhooks](../../architecture/webhooks.md#presentation-webhook)

--- a/docs/getting-started/presentation/transaction-data.md
+++ b/docs/getting-started/presentation/transaction-data.md
@@ -76,6 +76,8 @@ When creating a presentation request via the `/verifier/offer` endpoint, you can
 
     When `transaction_data` is provided in the request, it completely replaces any transaction data defined in the presentation configuration. The two are not merged.
 
+    The same request-time override model also applies to `webhook` and `redirectUri`. See [Presentation Configuration](presentation-configuration.md#request-time-overrides).
+
 ---
 
 ## Fields

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -120,6 +120,7 @@ nav:
           - Issuance Configuration: getting-started/issuance/issuance-configuration.md
         - Presentation:
           - Overview: getting-started/presentation/index.md
+          - Presentation Requests: getting-started/presentation/presentation-requests.md
           - Presentation Configuration: getting-started/presentation/presentation-configuration.md
           - Transaction Data: getting-started/presentation/transaction-data.md
       - Advanced:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -113,6 +113,7 @@ nav:
       - Flows:
         - Issuance:
           - Overview: getting-started/issuance/index.md
+          - Credential Offers: getting-started/issuance/credential-offers.md
           - Credential Configuration: getting-started/issuance/credential-configuration.md
           - Attribute Providers: getting-started/issuance/attribute-provider.md
           - Schema Metadata: getting-started/issuance/schema-metadata.md

--- a/packages/eudiplo-sdk-core/src/api/client/client.gen.ts
+++ b/packages/eudiplo-sdk-core/src/api/client/client.gen.ts
@@ -48,10 +48,7 @@ export const createClient = (config: Config = {}): Client => {
     };
 
     if (opts.security) {
-      await setAuthParams({
-        ...opts,
-        security: opts.security,
-      });
+      await setAuthParams(opts);
     }
 
     if (opts.requestValidator) {

--- a/packages/eudiplo-sdk-core/src/api/client/types.gen.ts
+++ b/packages/eudiplo-sdk-core/src/api/client/types.gen.ts
@@ -151,12 +151,13 @@ type MethodFn = <
 
 type SseFn = <
   TData = unknown,
-  TError = unknown,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _TError = unknown,
   ThrowOnError extends boolean = false,
   TResponseStyle extends ResponseStyle = 'fields',
 >(
   options: Omit<RequestOptions<never, TResponseStyle, ThrowOnError>, 'method'>,
-) => Promise<ServerSentEventsResult<TData, TError>>;
+) => Promise<ServerSentEventsResult<TData>>;
 
 type RequestFn = <
   TData = unknown,

--- a/packages/eudiplo-sdk-core/src/api/client/utils.gen.ts
+++ b/packages/eudiplo-sdk-core/src/api/client/utils.gen.ts
@@ -118,14 +118,12 @@ const checkForExistence = (
   return false;
 };
 
-export const setAuthParams = async ({
-  security,
-  ...options
-}: Pick<Required<RequestOptions>, 'security'> &
-  Pick<RequestOptions, 'auth' | 'query'> & {
+export async function setAuthParams(
+  options: Pick<RequestOptions, 'auth' | 'query' | 'security'> & {
     headers: Headers;
-  }) => {
-  for (const auth of security) {
+  },
+): Promise<void> {
+  for (const auth of options.security ?? []) {
     if (checkForExistence(options, auth.name)) {
       continue;
     }
@@ -154,7 +152,7 @@ export const setAuthParams = async ({
         break;
     }
   }
-};
+}
 
 export const buildUrl: Client['buildUrl'] = (options) =>
   getUrl({

--- a/packages/eudiplo-sdk-core/src/api/core/params.gen.ts
+++ b/packages/eudiplo-sdk-core/src/api/core/params.gen.ts
@@ -104,10 +104,10 @@ const stripEmptySlots = (params: Params) => {
 
 export const buildClientParams = (args: ReadonlyArray<unknown>, fields: FieldsConfig) => {
   const params: Params = {
-    body: {},
-    headers: {},
-    path: {},
-    query: {},
+    body: Object.create(null),
+    headers: Object.create(null),
+    path: Object.create(null),
+    query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);

--- a/packages/eudiplo-sdk-core/src/api/schemas.gen.ts
+++ b/packages/eudiplo-sdk-core/src/api/schemas.gen.ts
@@ -430,7 +430,6 @@ export const AuditLogResponseDtoSchema = {
             type: 'string'
         },
         actionType: {
-            type: 'string',
             enum: [
                 'tenant_created',
                 'tenant_updated',
@@ -450,15 +449,16 @@ export const AuditLogResponseDtoSchema = {
                 'attribute_provider_created',
                 'attribute_provider_updated',
                 'attribute_provider_deleted'
-            ]
+            ],
+            type: 'string'
         },
         actorType: {
-            type: 'string',
             enum: [
                 'user',
                 'client',
                 'system'
-            ]
+            ],
+            type: 'string'
         },
         actorId: {
             type: 'string'
@@ -651,7 +651,6 @@ export const StatusListImportDtoSchema = {
             example: 10000
         },
         bits: {
-            type: 'number',
             description: 'Bits per status value. If not provided, uses tenant or global defaults.',
             enum: [
                 1,
@@ -659,6 +658,7 @@ export const StatusListImportDtoSchema = {
                 4,
                 8
             ],
+            type: 'number',
             example: 1
         }
     },
@@ -698,7 +698,6 @@ export const UpdateStatusListConfigDtoSchema = {
             example: 10000
         },
         bits: {
-            type: 'number',
             nullable: true,
             description: 'Bits per status entry. Set to null to reset to global default.',
             enum: [
@@ -706,7 +705,8 @@ export const UpdateStatusListConfigDtoSchema = {
                 2,
                 4,
                 8
-            ]
+            ],
+            type: 'number'
         },
         ttl: {
             type: 'number',
@@ -754,7 +754,6 @@ export const StatusListResponseDtoSchema = {
             example: 'my-status-list-keychain'
         },
         bits: {
-            type: 'number',
             description: 'Bits per status value',
             enum: [
                 1,
@@ -762,6 +761,7 @@ export const StatusListResponseDtoSchema = {
                 4,
                 8
             ],
+            type: 'number',
             example: 1
         },
         capacity: {
@@ -824,7 +824,6 @@ export const CreateStatusListDtoSchema = {
             example: 'my-status-list-keychain'
         },
         bits: {
-            type: 'number',
             description: 'Bits per status value. More bits allow more status states. Defaults to tenant configuration.',
             enum: [
                 1,
@@ -832,6 +831,7 @@ export const CreateStatusListDtoSchema = {
                 4,
                 8
             ],
+            type: 'number',
             example: 1
         },
         capacity: {
@@ -926,77 +926,75 @@ export const OfferRequestDtoSchema = {
         credentialClaims: {
             type: 'object',
             description: 'Credential claims configuration per credential. Keys must match credentialConfigurationIds.',
-            properties: {
-                additionalProperties: {
-                    oneOf: [
-                        {
-                            type: 'object',
-                            properties: {
-                                type: {
-                                    type: 'string',
-                                    enum: [
-                                        'inline'
-                                    ]
-                                },
-                                claims: {
-                                    type: 'object',
-                                    additionalProperties: true
-                                }
+            additionalProperties: {
+                oneOf: [
+                    {
+                        type: 'object',
+                        properties: {
+                            type: {
+                                type: 'string',
+                                enum: [
+                                    'inline'
+                                ]
                             },
-                            required: [
-                                'type',
-                                'claims'
-                            ]
+                            claims: {
+                                type: 'object',
+                                additionalProperties: true
+                            }
                         },
-                        {
-                            type: 'object',
-                            properties: {
-                                type: {
-                                    type: 'string',
-                                    enum: [
-                                        'attributeProvider'
-                                    ]
-                                },
-                                attributeProviderId: {
-                                    type: 'string'
-                                }
+                        required: [
+                            'type',
+                            'claims'
+                        ]
+                    },
+                    {
+                        type: 'object',
+                        properties: {
+                            type: {
+                                type: 'string',
+                                enum: [
+                                    'attributeProvider'
+                                ]
                             },
-                            required: [
-                                'type',
-                                'attributeProviderId'
-                            ]
+                            attributeProviderId: {
+                                type: 'string'
+                            }
                         },
-                        {
-                            type: 'object',
-                            properties: {
-                                type: {
-                                    type: 'string',
-                                    enum: [
-                                        'webhook'
-                                    ]
-                                },
-                                webhook: {
-                                    type: 'object',
-                                    properties: {
-                                        url: {
-                                            type: 'string'
-                                        },
-                                        auth: {
-                                            type: 'object'
-                                        }
+                        required: [
+                            'type',
+                            'attributeProviderId'
+                        ]
+                    },
+                    {
+                        type: 'object',
+                        properties: {
+                            type: {
+                                type: 'string',
+                                enum: [
+                                    'webhook'
+                                ]
+                            },
+                            webhook: {
+                                type: 'object',
+                                properties: {
+                                    url: {
+                                        type: 'string'
                                     },
-                                    required: [
-                                        'url'
-                                    ]
-                                }
-                            },
-                            required: [
-                                'type',
-                                'webhook'
-                            ]
-                        }
-                    ]
-                }
+                                    auth: {
+                                        type: 'object'
+                                    }
+                                },
+                                required: [
+                                    'url'
+                                ]
+                            }
+                        },
+                        required: [
+                            'type',
+                            'webhook'
+                        ]
+                    }
+                ]
             },
             example: {
                 citizen: {
@@ -2744,7 +2742,6 @@ export const ClaimFieldDefinitionDtoSchema = {
             }
         },
         type: {
-            type: 'string',
             enum: [
                 'string',
                 'number',
@@ -2754,6 +2751,7 @@ export const ClaimFieldDefinitionDtoSchema = {
                 'array',
                 'date'
             ],
+            type: 'string',
             description: 'Claim value type'
         },
         defaultValue: {
@@ -3032,7 +3030,6 @@ export const CredentialConfigSchema = {
                     $ref: '#/components/schemas/RootOfTrustPolicy'
                 }
             ],
-            type: 'object',
             allOf: [
                 {
                     $ref: '#/components/schemas/EmbeddedDisclosurePolicy'
@@ -3178,7 +3175,6 @@ export const CredentialConfigCreateSchema = {
                     $ref: '#/components/schemas/RootOfTrustPolicy'
                 }
             ],
-            type: 'object',
             allOf: [
                 {
                     $ref: '#/components/schemas/EmbeddedDisclosurePolicy'
@@ -3306,7 +3302,6 @@ export const CredentialConfigUpdateSchema = {
                     $ref: '#/components/schemas/RootOfTrustPolicy'
                 }
             ],
-            type: 'object',
             allOf: [
                 {
                     $ref: '#/components/schemas/EmbeddedDisclosurePolicy'
@@ -3425,12 +3420,12 @@ export const VocabularyEntryDtoSchema = {
             description: 'Display label for UI rendering.'
         },
         status: {
-            type: 'string',
-            description: 'Vocabulary lifecycle status.',
             enum: [
                 'active',
                 'deprecated'
-            ]
+            ],
+            type: 'string',
+            description: 'Vocabulary lifecycle status.'
         },
         replacedBy: {
             type: 'string',
@@ -3481,12 +3476,12 @@ export const MetadataSchemaDtoSchema = {
             description: 'Unique identifier for this schema entry'
         },
         formatIdentifier: {
-            type: 'string',
-            description: 'The credential format identifier',
             enum: [
                 'dc+sd-jwt',
                 'mso_mdoc'
-            ]
+            ],
+            type: 'string',
+            description: 'The credential format identifier'
         },
         uri: {
             type: 'string',
@@ -3587,35 +3582,35 @@ export const SchemaMetadataResponseDtoSchema = {
             description: 'Subresource Integrity hash for the rulebook URI'
         },
         attestationLoS: {
-            type: 'string',
-            description: 'Level of security (LoS) of this attestation',
             enum: [
                 'iso_18045_high',
                 'iso_18045_moderate',
                 'iso_18045_enhanced-basic',
                 'iso_18045_basic'
-            ]
+            ],
+            type: 'string',
+            description: 'Level of security (LoS) of this attestation'
         },
         bindingType: {
-            type: 'string',
-            description: 'Required binding type between attestation and holder',
             enum: [
                 'claim',
                 'key',
                 'biometric',
                 'none'
-            ]
+            ],
+            type: 'string',
+            description: 'Required binding type between attestation and holder'
         },
         supportedFormats: {
             type: 'array',
-            description: 'Credential formats in which this attestation is available',
             items: {
                 type: 'string',
                 enum: [
                     'dc+sd-jwt',
                     'mso_mdoc'
                 ]
-            }
+            },
+            description: 'Credential formats in which this attestation is available'
         },
         schemaURIs: {
             description: 'Format-specific schema URIs for this schema metadata',
@@ -3632,8 +3627,6 @@ export const SchemaMetadataResponseDtoSchema = {
             }
         },
         category: {
-            type: 'string',
-            description: 'Domain category for filtering',
             enum: [
                 'identity',
                 'health',
@@ -3642,7 +3635,9 @@ export const SchemaMetadataResponseDtoSchema = {
                 'mobility',
                 'employment',
                 'other'
-            ]
+            ],
+            type: 'string',
+            description: 'Domain category for filtering'
         },
         tags: {
             description: 'Free-form tags for filtering and search',
@@ -3717,8 +3712,6 @@ export const UpdateSchemaMetadataDtoSchema = {
     type: 'object',
     properties: {
         category: {
-            type: 'string',
-            description: 'Domain category for filtering',
             enum: [
                 'identity',
                 'health',
@@ -3727,11 +3720,12 @@ export const UpdateSchemaMetadataDtoSchema = {
                 'mobility',
                 'employment',
                 'other'
-            ]
+            ],
+            type: 'string',
+            description: 'Domain category for filtering'
         },
         tags: {
             type: 'array',
-            description: 'Predefined tags for filtering and search',
             items: {
                 type: 'string',
                 enum: [
@@ -3746,7 +3740,8 @@ export const UpdateSchemaMetadataDtoSchema = {
                     'employment',
                     'mobility'
                 ]
-            }
+            },
+            description: 'Predefined tags for filtering and search'
         }
     }
 } as const;
@@ -4746,7 +4741,12 @@ export const NotificationRequestDtoSchema = {
             type: 'string'
         },
         event: {
-            type: 'object'
+            type: 'string',
+            enum: [
+                'credential_accepted',
+                'credential_failure',
+                'credential_deleted'
+            ]
         }
     },
     required: [

--- a/packages/eudiplo-sdk-core/src/api/types.gen.ts
+++ b/packages/eudiplo-sdk-core/src/api/types.gen.ts
@@ -431,7 +431,7 @@ export type OfferRequestDto = {
      * Credential claims configuration per credential. Keys must match credentialConfigurationIds.
      */
     credentialClaims?: {
-        additionalProperties?: {
+        [key: string]: {
             type: 'inline';
             claims: {
                 [key: string]: unknown;
@@ -2364,9 +2364,7 @@ export type DeferredCredentialRequestDto = {
 
 export type NotificationRequestDto = {
     notification_id: string;
-    event: {
-        [key: string]: unknown;
-    };
+    event: 'credential_accepted' | 'credential_failure' | 'credential_deleted';
 };
 
 export type Object = {

--- a/packages/eudiplo-sdk-core/src/client.ts
+++ b/packages/eudiplo-sdk-core/src/client.ts
@@ -319,17 +319,16 @@ export class EudiploClient {
 
     // Build credential claims if provided
     if (options.claims) {
-      body.credentialClaims = {
-        additionalProperties: undefined,
-      };
+      const credentialClaims: NonNullable<OfferRequestDto['credentialClaims']> = {};
       // For simplicity, we use inline claims
       for (const [configId, claims] of Object.entries(options.claims)) {
         // The API expects a specific structure
-        (body.credentialClaims as Record<string, unknown>)[configId] = {
+        credentialClaims[configId] = {
           type: 'inline',
           claims,
         };
       }
+      body.credentialClaims = credentialClaims;
     }
 
     const response = await credentialOfferControllerGetOffer({

--- a/schemas/AuditLogResponseDto.schema.json
+++ b/schemas/AuditLogResponseDto.schema.json
@@ -11,7 +11,6 @@
       "type": "string"
     },
     "actionType": {
-      "type": "string",
       "enum": [
         "tenant_created",
         "tenant_updated",
@@ -31,15 +30,16 @@
         "attribute_provider_created",
         "attribute_provider_updated",
         "attribute_provider_deleted"
-      ]
+      ],
+      "type": "string"
     },
     "actorType": {
-      "type": "string",
       "enum": [
         "user",
         "client",
         "system"
-      ]
+      ],
+      "type": "string"
     },
     "actorId": {
       "type": "string"

--- a/schemas/ClaimFieldDefinitionDto.schema.json
+++ b/schemas/ClaimFieldDefinitionDto.schema.json
@@ -26,7 +26,6 @@
       }
     },
     "type": {
-      "type": "string",
       "enum": [
         "string",
         "number",
@@ -36,6 +35,7 @@
         "array",
         "date"
       ],
+      "type": "string",
       "description": "Claim value type"
     },
     "defaultValue": {

--- a/schemas/CreateStatusListDto.schema.json
+++ b/schemas/CreateStatusListDto.schema.json
@@ -15,7 +15,6 @@
       "example": "my-status-list-keychain"
     },
     "bits": {
-      "type": "number",
       "description": "Bits per status value. More bits allow more status states. Defaults to tenant configuration.",
       "enum": [
         1,
@@ -23,6 +22,7 @@
         4,
         8
       ],
+      "type": "number",
       "example": 1
     },
     "capacity": {

--- a/schemas/CredentialConfig.schema.json
+++ b/schemas/CredentialConfig.schema.json
@@ -62,7 +62,6 @@
           "$ref": "./RootOfTrustPolicy.schema.json"
         }
       ],
-      "type": "object",
       "allOf": [
         {
           "$ref": "./EmbeddedDisclosurePolicy.schema.json"

--- a/schemas/CredentialConfigCreate.schema.json
+++ b/schemas/CredentialConfigCreate.schema.json
@@ -62,7 +62,6 @@
           "$ref": "./RootOfTrustPolicy.schema.json"
         }
       ],
-      "type": "object",
       "allOf": [
         {
           "$ref": "./EmbeddedDisclosurePolicy.schema.json"

--- a/schemas/CredentialConfigUpdate.schema.json
+++ b/schemas/CredentialConfigUpdate.schema.json
@@ -62,7 +62,6 @@
           "$ref": "./RootOfTrustPolicy.schema.json"
         }
       ],
-      "type": "object",
       "allOf": [
         {
           "$ref": "./EmbeddedDisclosurePolicy.schema.json"

--- a/schemas/MetadataSchemaDto.schema.json
+++ b/schemas/MetadataSchemaDto.schema.json
@@ -9,12 +9,12 @@
       "description": "Unique identifier for this schema entry"
     },
     "formatIdentifier": {
-      "type": "string",
-      "description": "The credential format identifier",
       "enum": [
         "dc+sd-jwt",
         "mso_mdoc"
-      ]
+      ],
+      "type": "string",
+      "description": "The credential format identifier"
     },
     "uri": {
       "type": "string",

--- a/schemas/NotificationRequestDto.schema.json
+++ b/schemas/NotificationRequestDto.schema.json
@@ -8,7 +8,12 @@
       "type": "string"
     },
     "event": {
-      "type": "object"
+      "type": "string",
+      "enum": [
+        "credential_accepted",
+        "credential_failure",
+        "credential_deleted"
+      ]
     }
   },
   "required": [

--- a/schemas/OfferRequestDto.schema.json
+++ b/schemas/OfferRequestDto.schema.json
@@ -20,81 +20,79 @@
     "credentialClaims": {
       "type": "object",
       "description": "Credential claims configuration per credential. Keys must match credentialConfigurationIds.",
-      "properties": {
-        "additionalProperties": {
-          "oneOf": [
-            {
-              "type": "object",
-              "properties": {
-                "type": {
-                  "type": "string",
-                  "enum": [
-                    "inline"
-                  ]
-                },
-                "claims": {
-                  "type": "object",
-                  "additionalProperties": true
-                }
+      "additionalProperties": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "inline"
+                ]
               },
-              "required": [
-                "type",
-                "claims"
-              ],
-              "additionalProperties": false
+              "claims": {
+                "type": "object",
+                "additionalProperties": true
+              }
             },
-            {
-              "type": "object",
-              "properties": {
-                "type": {
-                  "type": "string",
-                  "enum": [
-                    "attributeProvider"
-                  ]
-                },
-                "attributeProviderId": {
-                  "type": "string"
-                }
+            "required": [
+              "type",
+              "claims"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "attributeProvider"
+                ]
               },
-              "required": [
-                "type",
-                "attributeProviderId"
-              ],
-              "additionalProperties": false
+              "attributeProviderId": {
+                "type": "string"
+              }
             },
-            {
-              "type": "object",
-              "properties": {
-                "type": {
-                  "type": "string",
-                  "enum": [
-                    "webhook"
-                  ]
-                },
-                "webhook": {
-                  "type": "object",
-                  "properties": {
-                    "url": {
-                      "type": "string"
-                    },
-                    "auth": {
-                      "type": "object"
-                    }
+            "required": [
+              "type",
+              "attributeProviderId"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "webhook"
+                ]
+              },
+              "webhook": {
+                "type": "object",
+                "properties": {
+                  "url": {
+                    "type": "string"
                   },
-                  "required": [
-                    "url"
-                  ],
-                  "additionalProperties": false
-                }
-              },
-              "required": [
-                "type",
-                "webhook"
-              ],
-              "additionalProperties": false
-            }
-          ]
-        }
+                  "auth": {
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "url"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "type",
+              "webhook"
+            ],
+            "additionalProperties": false
+          }
+        ]
       },
       "example": {
         "citizen": {
@@ -104,8 +102,7 @@
             "family_name": "Doe"
           }
         }
-      },
-      "additionalProperties": false
+      }
     },
     "flow": {
       "description": "The flow type for the offer request.",

--- a/schemas/SchemaMetadataResponseDto.schema.json
+++ b/schemas/SchemaMetadataResponseDto.schema.json
@@ -21,35 +21,35 @@
       "description": "Subresource Integrity hash for the rulebook URI"
     },
     "attestationLoS": {
-      "type": "string",
-      "description": "Level of security (LoS) of this attestation",
       "enum": [
         "iso_18045_high",
         "iso_18045_moderate",
         "iso_18045_enhanced-basic",
         "iso_18045_basic"
-      ]
+      ],
+      "type": "string",
+      "description": "Level of security (LoS) of this attestation"
     },
     "bindingType": {
-      "type": "string",
-      "description": "Required binding type between attestation and holder",
       "enum": [
         "claim",
         "key",
         "biometric",
         "none"
-      ]
+      ],
+      "type": "string",
+      "description": "Required binding type between attestation and holder"
     },
     "supportedFormats": {
       "type": "array",
-      "description": "Credential formats in which this attestation is available",
       "items": {
         "type": "string",
         "enum": [
           "dc+sd-jwt",
           "mso_mdoc"
         ]
-      }
+      },
+      "description": "Credential formats in which this attestation is available"
     },
     "schemaURIs": {
       "description": "Format-specific schema URIs for this schema metadata",
@@ -66,8 +66,6 @@
       }
     },
     "category": {
-      "type": "string",
-      "description": "Domain category for filtering",
       "enum": [
         "identity",
         "health",
@@ -76,7 +74,9 @@
         "mobility",
         "employment",
         "other"
-      ]
+      ],
+      "type": "string",
+      "description": "Domain category for filtering"
     },
     "tags": {
       "description": "Free-form tags for filtering and search",

--- a/schemas/StatusListImportDto.schema.json
+++ b/schemas/StatusListImportDto.schema.json
@@ -26,7 +26,6 @@
       "example": 10000
     },
     "bits": {
-      "type": "number",
       "description": "Bits per status value. If not provided, uses tenant or global defaults.",
       "enum": [
         1,
@@ -34,6 +33,7 @@
         4,
         8
       ],
+      "type": "number",
       "example": 1
     }
   },

--- a/schemas/StatusListResponseDto.schema.json
+++ b/schemas/StatusListResponseDto.schema.json
@@ -27,7 +27,6 @@
       "example": "my-status-list-keychain"
     },
     "bits": {
-      "type": "number",
       "description": "Bits per status value",
       "enum": [
         1,
@@ -35,6 +34,7 @@
         4,
         8
       ],
+      "type": "number",
       "example": 1
     },
     "capacity": {

--- a/schemas/UpdateSchemaMetadataDto.schema.json
+++ b/schemas/UpdateSchemaMetadataDto.schema.json
@@ -5,8 +5,6 @@
   "type": "object",
   "properties": {
     "category": {
-      "type": "string",
-      "description": "Domain category for filtering",
       "enum": [
         "identity",
         "health",
@@ -15,11 +13,12 @@
         "mobility",
         "employment",
         "other"
-      ]
+      ],
+      "type": "string",
+      "description": "Domain category for filtering"
     },
     "tags": {
       "type": "array",
-      "description": "Predefined tags for filtering and search",
       "items": {
         "type": "string",
         "enum": [
@@ -34,7 +33,8 @@
           "employment",
           "mobility"
         ]
-      }
+      },
+      "description": "Predefined tags for filtering and search"
     }
   },
   "additionalProperties": false

--- a/schemas/UpdateStatusListConfigDto.schema.json
+++ b/schemas/UpdateStatusListConfigDto.schema.json
@@ -12,7 +12,6 @@
       "example": 10000
     },
     "bits": {
-      "type": "number",
       "nullable": true,
       "description": "Bits per status entry. Set to null to reset to global default.",
       "enum": [
@@ -20,7 +19,8 @@
         2,
         4,
         8
-      ]
+      ],
+      "type": "number"
     },
     "ttl": {
       "type": "number",

--- a/schemas/VocabularyEntryDto.schema.json
+++ b/schemas/VocabularyEntryDto.schema.json
@@ -13,12 +13,12 @@
       "description": "Display label for UI rendering."
     },
     "status": {
-      "type": "string",
-      "description": "Vocabulary lifecycle status.",
       "enum": [
         "active",
         "deprecated"
-      ]
+      ],
+      "type": "string",
+      "description": "Vocabulary lifecycle status."
     },
     "replacedBy": {
       "type": "string",


### PR DESCRIPTION
## Summary
This PR improves the getting-started documentation for issuance and presentation flows, and aligns generated API/client behavior for offer claim overrides.

### Docs improvements
- Adds dedicated **Credential Offers** guide:
  - request shape, examples, replay prevention, and `credentialClaims` usage
- Adds dedicated **Presentation Requests** guide:
  - `/verifier/offer` payload, examples, and runtime override behavior
- Refactors overview pages to focus on concepts/flow selection and link to dedicated request pages
- Aligns notification webhook docs with current model:
  - standalone webhook endpoint resource referenced by `webhookEndpointId`
- Improves cross-links and readability across issuance/presentation pages
- Updates MkDocs navigation to include the new pages

### OpenAPI / SDK alignment
- Fixes `OfferRequestDto` OpenAPI schema for `credentialClaims` to emit proper map semantics (`additionalProperties` at schema root)
- Updates SDK helper in `packages/eudiplo-sdk-core/src/client.ts` to construct `credentialClaims` as a record compatible with regenerated types
- Regenerates related schemas/client types in this branch

## Why
Users reported ambiguity around passing claim overrides in offer creation and confusion around notification webhook configuration. This PR makes the request model explicit and consistent with generated API definitions.

## Notes
- Branch includes formatting and regenerated artifacts related to the schema change.
- `pnpm run generate` in `packages/eudiplo-sdk-core` succeeds after the SDK helper update.