### PR TITLE
fix: include path in monaco editors baseUrl

### DIFF
--- a/apps/client/src/app/app.config.ts
+++ b/apps/client/src/app/app.config.ts
@@ -54,7 +54,7 @@ export const appConfig: ApplicationConfig = {
     importProvidersFrom(FlexLayoutModule),
     provideHttpClient(withInterceptors([authInterceptor]), withFetch()),
     provideMonacoEditor({
-      baseUrl: window.location.origin + '/assets/monaco/min/vs',
+      baseUrl: window.location.origin + window.location.pathname + '/assets/monaco/min/vs',
       onMonacoLoad,
       //monacoRequire: (window as any).monacoRequire,
       //requireConfig: { preferScriptTags: true }


### PR DESCRIPTION
## 📝 Description

When comping the baseUrl for the monaco editor, add the path (window.location.pathname), so assets can be found, even if the client is running at a subpath.

Fixes #761 

## 🔄 Type of Change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

## 🧪 Testing

- [X] Manual testing performed

## ✔️ Checklist

- [X] My code follows the code style of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## 📋 Additional Notes

I only tested this on my local deployment, where it fixes the issue for me.

One possible issue with this fix is that `window.location.pathname` could theoretically end in a filename (e.g. `/eudiplo-client/dashboard`).
This does not seem to be the case here, but in this case we would need something like: 
```
baseUrl: window.location.origin + window.location.pathname.substring(0, window.location.pathname.lastIndexOf('/')) + '/assets/monaco/min/vs',
```