### PR TITLE
fix: add migration files for better update

### DIFF
--- a/docs/architecture/federation.md
+++ b/docs/architecture/federation.md
@@ -453,5 +453,4 @@ await api.issuer.postIssuanceConfig(config);
 
 - [OpenID Federation 1.0](https://openid.net/specs/openid-federation-1_0.html)
 - [RFC 8414 OAuth 2.0 Authorization Server Metadata](https://tools.ietf.org/html/rfc8414)
-- EUDIPLO Architecture: [docs/architecture/](../architecture/)
-- Trust Validation: [docs/trust-model/](../trust-model/)
+- EUDIPLO Architecture: [docs/architecture/](../index.md)

--- a/docs/getting-started/issuance/credential-offers.md
+++ b/docs/getting-started/issuance/credential-offers.md
@@ -186,4 +186,4 @@ Notes:
 - Offer-level inline claims when claim values are already known at offer creation time
 - Offer-level webhook or Attribute Provider overrides when claim resolution should vary per offer
 
-For the broader claims model, see [Fetching Claims](credential-configuration.md#fetching-claims).
+For the broader claims model, see [Fetching Claims](../../architecture/webhooks.md#fetching-claims-attribute-providers).

--- a/docs/getting-started/issuance/issuance-configuration.md
+++ b/docs/getting-started/issuance/issuance-configuration.md
@@ -32,7 +32,7 @@ authorization, token behavior, and trust-related requirements.
 - `credentialRequestEncryption` (boolean, optional): Advertise support for encrypted credential requests (`credential_request_encryption`).
 - `credentialResponseEncryption` (boolean, optional): Advertise support for encrypted credential responses (`credential_response_encryption`).
 - `chainedAs` (object, optional): Chained Authorization Server configuration. See [Chained Authorization Server](#chained-authorization-server).
-- `federation` (object, optional): OpenID Federation trust configuration for auth-server/upstream trust evaluation. See [OpenID Federation](../../federation/README.md).
+- `federation` (object, optional): OpenID Federation trust configuration for auth-server/upstream trust evaluation. See [OpenID Federation](../../architecture/federation.md).
 - `display` (array of objects, required): The display information from the [OID4VCI spec](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-credential-issuer-metadata:~:text=2%20or%20greater.-,display,-%3A%20OPTIONAL.%20A%20non). To host images or logos, you can use the [storage](../../architecture/storage.md) system provided by EUDIPLO.
 
 ---

--- a/docs/getting-started/presentation/transaction-data.md
+++ b/docs/getting-started/presentation/transaction-data.md
@@ -76,7 +76,7 @@ When creating a presentation request via the `/verifier/offer` endpoint, you can
 
     When `transaction_data` is provided in the request, it completely replaces any transaction data defined in the presentation configuration. The two are not merged.
 
-    The same request-time override model also applies to `webhook` and `redirectUri`. See [Presentation Configuration](presentation-configuration.md#request-time-overrides).
+    The same request-time override model also applies to `webhook` and `redirectUri`. See [Presentation Configuration](presentation-configuration.md#configuration-fields).
 
 ---
 

--- a/docs/migration/4.x-to-5.0.md
+++ b/docs/migration/4.x-to-5.0.md
@@ -38,56 +38,141 @@ Credential configurations now use a **field-based model** (v2) instead of the le
 | mDOC Namespace       | `config.namespace` or `claimsByNamespace`                        | Per-field `namespace` property  |
 | Validation           | Top-level JSON `schema`                                          | Derived at runtime from fields  |
 
-### Database Migration
+### Manual File Migration
 
-The TypeORM migration `MigrateCredentialConfigToV2Fields` runs automatically on startup. It:
+!!! warning "No Automated Migration Available"
 
-1. Reads every row from `credential_config`
-2. Converts the v1 shape (`claims`, `disclosureFrame`, `schema`, `config.claimsMetadata`, `config.namespace`, `config.claimsByNamespace`) into the new `fields[]` array
-3. Writes `configVersion = 2` and the derived `fields[]`
-4. **Drops the columns** `claims`, `disclosureFrame`, and `schema`
+    EUDIPLO will not write to your config files or modify them during upgrade. You must manually convert each credential config file from the v1 shape to the v2 shape before upgrading to 5.0.
+    In the future, we will evaluate if writing to the config section is a good idea and how to do this safely without risking data loss or corruption.
 
-!!! danger "Irreversible schema change"
+For configs stored on disk in `assets/config/.../issuance/credentials/`, the file format must be migrated manually before you upgrade to 5.0. v5.0 only accepts the field-based model and rejects the legacy v1 shape on import.
 
-    The `down()` migration is not provided. Once you upgrade to 5.0 and the migration runs, the legacy columns are gone. Restore from your backup if you need to roll back.
+The mapping is straightforward:
 
-### File-Based Config Migration
+- `claims` becomes `fields[].defaultValue`
+- `disclosureFrame` becomes `fields[].disclosable`
+- `schema` is no longer stored in the config file; it is derived from `fields[]`
+- `config.claimsMetadata` becomes `fields[].display[]` and `fields[].mandatory`
+- `config.namespace` becomes `fields[].namespace` for mDOC entries
+- `config.claimsByNamespace` becomes one field entry per claim, each with the correct `namespace` and `defaultValue`
 
-For configs stored on disk in `assets/config/.../issuance/credentials/`, the file format must also be migrated. v5.0 **rejects** v1 JSON files on import — there is no runtime auto-conversion in the import path.
+#### Before (v1): Legacy Credential Config
 
-#### Step 1: Preview Changes (Dry-Run)
-
-```bash
-pnpm run migrate:configs:v2 -- --dry-run
+```json
+{
+    "id": "pid",
+    "config": {
+        "format": "mso_mdoc",
+        "docType": "eu.europa.ec.eudi.pid.1",
+        "namespace": "eu.europa.ec.eudi.pid.1",
+        "display": [{ "name": "PID", "locale": "en-US" }],
+        "claimsMetadata": [
+            {
+                "path": ["given_name"],
+                "mandatory": true,
+                "display": [{ "name": "Given Name", "locale": "en-US" }]
+            },
+            {
+                "path": ["family_name"],
+                "display": [{ "name": "Family Name", "locale": "en-US" }]
+            }
+        ]
+    },
+    "claims": {
+        "given_name": "John",
+        "family_name": "Doe"
+    },
+    "disclosureFrame": {
+        "_sd": ["given_name", "family_name"]
+    },
+    "schema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+            "given_name": { "type": "string" },
+            "family_name": { "type": "string" }
+        },
+        "required": ["given_name"]
+    }
+}
 ```
 
-Or for a specific directory:
+#### After (v2): Field-Based Credential Config
 
-```bash
-pnpm run migrate:configs:v2 -- --dry-run assets/config/demo/issuance/credentials
+```json
+{
+    "id": "pid",
+    "configVersion": 2,
+    "config": {
+        "format": "mso_mdoc",
+        "docType": "eu.europa.ec.eudi.pid.1",
+        "display": [{ "name": "PID", "locale": "en-US" }]
+    },
+    "fields": [
+        {
+            "path": ["given_name"],
+            "type": "string",
+            "defaultValue": "John",
+            "mandatory": true,
+            "disclosable": true,
+            "namespace": "eu.europa.ec.eudi.pid.1",
+            "display": [{ "name": "Given Name", "locale": "en-US" }]
+        },
+        {
+            "path": ["family_name"],
+            "type": "string",
+            "defaultValue": "Doe",
+            "disclosable": true,
+            "namespace": "eu.europa.ec.eudi.pid.1",
+            "display": [{ "name": "Family Name", "locale": "en-US" }]
+        }
+    ]
+}
 ```
 
-#### Step 2: Perform the Migration
+#### Step 1: Convert each config file
 
-```bash
-pnpm run migrate:configs:v2
-```
+Open every credential config JSON file and rewrite it from the v1 structure to the v2 structure shown above.
 
-By default, this scans the `assets/config/` directory recursively and updates all credential config files in place.
+If you have a credential with multiple namespaces, create one `fields[]` entry per claim and set the correct `namespace` on each field.
 
-#### Step 3: Review and Test
+If a field was optional in the old schema, leave `mandatory` unset or set it to `false`.
 
-1. **Review the converted files** — diff against your backup
-2. **Test issuance** — issue test credentials in each format (SD-JWT, mDOC)
-3. **Verify selective disclosure** — confirm `disclosable` flags match previous `disclosureFrame` behavior
-4. **Verify mDOC namespaces** — confirm per-field `namespace` values are correct, especially for multi-namespace credentials
+#### Step 2: Verify the converted file
 
-#### Step 4: Update Your Integrations
+Check that:
 
-If you have external code that builds credential configs programmatically:
+1. `configVersion` is set to `2`
+2. `fields[]` contains one entry for each leaf claim you want to issue
+3. `defaultValue` matches the old `claims` value
+4. `disclosable` matches the old `disclosureFrame` behavior for SD-JWT
+5. `namespace` is set correctly for mDOC fields
+6. `display[]` still contains the labels you want shown in the UI
 
-- Update payloads sent to `POST /api/issuer/credentials` to use `fields[]` instead of `claims` / `disclosureFrame` / `schema`
-- The `convertV1ToV2()` helper is exported from `@eudiplo/sdk-core` (and from the backend's `issuer/configuration/credentials/utils`) for transitional code paths
+#### Step 3: Remove legacy top-level keys
+
+Delete these keys from the file once the v2 version is in place:
+
+- `claims`
+- `disclosureFrame`
+- `schema`
+
+Also remove legacy nested config keys:
+
+- `config.namespace`
+- `config.claimsByNamespace`
+- `config.claimsMetadata`
+
+#### Step 4: Update any external generators
+
+If you generate credential configs from code or templates, update them to emit `fields[]` directly instead of the removed v1 keys.
+
+#### Step 5: Validate before upgrade
+
+1. Re-import the config into your environment or test instance
+2. Issue a test credential in each affected format
+3. Confirm the credential payload, selective disclosure, and mDOC namespace behavior match the old config
+4. Only then upgrade the deployment to 5.0
 
 ### Removed Top-Level Fields
 
@@ -270,9 +355,9 @@ No action is required — these are pure UX improvements.
 
 1. **Back up** your database and `assets/config/` directory
 2. **Stop** the running 4.x deployment
-3. **Run `pnpm run migrate:configs:v2 -- --dry-run`** against your config directory to preview file-level changes
-4. **Run `pnpm run migrate:configs:v2`** to convert config files in place
-5. **Deploy 5.0** — the TypeORM migration converts existing DB rows and drops legacy columns
+3. **Convert all credential config files manually** using the example above as the template
+4. **Re-test issuance** with the converted configs before touching production
+5. **Deploy 5.0** once all configs are v2 and validated
 6. **Update API clients** that called the moved `/schema-metadata/sign[-version]` endpoints
 7. **Regenerate SDK types** (`pnpm run gen:api`) and fix any TypeScript errors from removed DTOs
 8. **Verify** by issuing test credentials in each configured format

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -134,6 +134,7 @@ nav:
       - TLS/HTTPS: deployment/tls.md
   - Migration:
       - Overview: migration/index.md
+      - 4.x to 5.0: migration/4.x-to-5.0.md
       - 3.x to 4.0: migration/3.x-to-4.0.md
   - Architecture:
       - Overview: architecture/index.md      
@@ -146,7 +147,7 @@ nav:
         - Webhooks: architecture/webhooks.md
         - Attribute Providers: architecture/attribute-providers.md
         - Interactive Authorization (IAE): architecture/iae.md
-        - OpenID Federation: federation/README.md
+        - OpenID Federation: architecture/federation.md
       - Chained Authorization Server: architecture/chained-as.md
       - Config Import: architecture/configuration-import.md
       - Key Management: architecture/key-management.md


### PR DESCRIPTION
This branch updates the migration documentation set for the v5 transition.

Changes include:
- Expanded and clarified the 4.x to 5.0 migration guide
- Updated the credential offer, issuance configuration, and transaction data getting-started docs
- Renamed the federation docs into the architecture section
- Adjusted the mkdocs navigation to match the new layout

Signed-off-by: Mirko Mollik <mirko.mollik@eudi.sprind.org>