### PR TITLE
fix: support client base href for Monaco assets

### DIFF
--- a/apps/client/docker-entrypoint.sh
+++ b/apps/client/docker-entrypoint.sh
@@ -51,6 +51,9 @@ cat > /usr/share/nginx/html/env.js << EOF
 
   // Cache busting timestamp (changes every container start)
   window['env']['timestamp'] = '${TIMESTAMP}';
+
+  // Base href for the application (used for routing)
+  window['env']['baseHref'] = '${CLIENT_BASE_HREF}';
 })(this);
 EOF
 

--- a/apps/client/src/app/app.config.ts
+++ b/apps/client/src/app/app.config.ts
@@ -25,7 +25,7 @@ const runtimeEnv = globalThis as { env?: { baseHref?: string } };
 const baseHref = runtimeEnv.env?.baseHref ?? '/';
 const monacoBaseUrl = new URL(
   'assets/monaco/min/vs',
-  new URL(baseHref, document.location.origin),
+  new URL(baseHref, document.location.origin)
 ).toString();
 
 const transactionDataArraySchema = {

--- a/apps/client/src/app/app.config.ts
+++ b/apps/client/src/app/app.config.ts
@@ -21,6 +21,13 @@ import { OidcService } from './core/oidc.service';
 
 declare let monaco: any;
 
+const runtimeEnv = globalThis as { env?: { baseHref?: string } };
+const baseHref = runtimeEnv.env?.baseHref ?? '/';
+const monacoBaseUrl = new URL(
+  'assets/monaco/min/vs',
+  new URL(baseHref, document.location.origin),
+).toString();
+
 const transactionDataArraySchema = {
   uri: 'https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TransactionDataArray.schema.json',
   fileMatch: ['a://b/TransactionDataArray*.schema.json'],
@@ -41,6 +48,8 @@ function onMonacoLoad() {
   });
 }
 
+console.log((window as any)['env']);
+
 export const appConfig: ApplicationConfig = {
   providers: [
     {
@@ -54,7 +63,7 @@ export const appConfig: ApplicationConfig = {
     importProvidersFrom(FlexLayoutModule),
     provideHttpClient(withInterceptors([authInterceptor]), withFetch()),
     provideMonacoEditor({
-      baseUrl: window.location.origin + window.location.pathname + '/assets/monaco/min/vs',
+      baseUrl: monacoBaseUrl,
       onMonacoLoad,
       //monacoRequire: (window as any).monacoRequire,
       //requireConfig: { preferScriptTags: true }

--- a/docs/getting-started/web-client.md
+++ b/docs/getting-started/web-client.md
@@ -12,8 +12,14 @@ After completing the [Full Setup](./quick-start.md#step-1-choose-your-setup):
 
 1. **Open your browser** and go to: [http://localhost:4200](http://localhost:4200)
 2. **Login** using the default credentials:
-   - **Username:** `root`
-   - **Password:** `root`
+    - **Username:** `root`
+    - **Password:** `root`
+
+### Hosting from a Subpath
+
+If the client is served from a path such as `https://example.com/client/`, set `CLIENT_BASE_HREF=/client/` when starting the client. This updates the HTML base href and keeps routing and asset loading correct for the subpath.
+
+If you are using a reverse proxy, it must also forward `/client/` to the client container. See [Serving the Client from a Subpath](../deployment/tls.md#serving-the-client-from-a-subpath) for a full example.
 
 > **Important:** Change the default credentials before using EUDIPLO in production. See [Authentication](../api/authentication.md) for details.
 
@@ -60,9 +66,8 @@ The web client is designed for intuitive and robust configuration management:
 - **OpenAPI Specification:** An OpenAPI spec is generated from these DTOs and entities, providing a standardized interface for backend interaction.
 - **SDK Integration:** The web client uses an SDK generated from the OpenAPI spec for seamless and type-safe communication with the backend.
 - **Editing Experience:**
-  
     - Simple variables (strings, numbers, booleans) are edited via text inputs, select options, or checkboxes.
     - Complex data structures are managed using an integrated JSON editor (Monaco Editor), which leverages JSON schemas for each variable.
-  
+
 - **Client-Side Validation & Guidance:** The JSON editor uses the provided JSON schemas to offer inline descriptions, auto-completion, and validation directly in the browser.
 - **Direct JSON Access:** Each configuration can be viewed and edited as raw JSON for advanced use cases.


### PR DESCRIPTION
## Summary
- build Monaco `baseUrl` from runtime `env.baseHref` using safe URL resolution
- ensure subpath hosting like `https://example.com/client/` resolves Monaco assets correctly
- document subpath hosting in the web client getting started guide, including `CLIENT_BASE_HREF=/client/`
- fixing #765 

## Changed files
- apps/client/src/app/app.config.ts
- docs/getting-started/web-client.md
- apps/client/docker-entrypoint.sh

## Notes
- branch includes formatting commit already present on this branch
- local generated file `apps/client/public/env.js` is untracked and intentionally not part of this PR