### PR TITLE
feat: implement credential offer by reference for vci

### DIFF
--- a/apps/backend/src/issuer/issuance/oid4vci/oid4vci.controller.ts
+++ b/apps/backend/src/issuer/issuance/oid4vci/oid4vci.controller.ts
@@ -1,6 +1,7 @@
 import {
     Body,
     Controller,
+    Get,
     Header,
     HttpCode,
     HttpException,
@@ -30,6 +31,20 @@ import { Oid4vciService } from "./oid4vci.service";
 @Controller("issuers/:tenantId/vci")
 export class Oid4vciController {
     constructor(private readonly oid4vciService: Oid4vciService) {}
+
+    /**
+     * Credential offer endpoint for `credential_offer_uri` references.
+     */
+    @Get("credential-offers/:sessionId")
+    credentialOfferByReference(
+        @Param("tenantId") tenantId: string,
+        @Param("sessionId") sessionId: string,
+    ) {
+        return this.oid4vciService.getCredentialOfferByReference(
+            tenantId,
+            sessionId,
+        );
+    }
 
     /**
      * Endpoint to issue credentials

--- a/apps/backend/src/issuer/issuance/oid4vci/oid4vci.service.ts
+++ b/apps/backend/src/issuer/issuance/oid4vci/oid4vci.service.ts
@@ -3,6 +3,7 @@ import {
     BadRequestException,
     ConflictException,
     Injectable,
+    NotFoundException,
 } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { Cron, CronExpression } from "@nestjs/schedule";
@@ -19,6 +20,7 @@ import {
 import {
     CreateCredentialResponseReturn,
     CredentialOfferAuthorizationCodeGrant,
+    CredentialOfferObject,
     CredentialOfferPreAuthorizedCodeGrant,
     type CredentialResponse,
     type CredentialRequest,
@@ -449,12 +451,14 @@ export class Oid4vciService {
 
         const issuer = this.getIssuer(session.tenantId, session.id);
         const issuerMetadata = await this.issuerMetadata(tenantId, issuer);
+        const credentialOfferUri = `${this.configService.getOrThrow<string>("PUBLIC_URL")}/issuers/${tenantId}/vci/credential-offers/${session.id}`;
 
         return issuer
             .createCredentialOffer({
                 credentialConfigurationIds,
                 grants,
                 issuerMetadata,
+                credentialOfferUri,
             })
             .then(
                 async (offer) => {
@@ -474,6 +478,26 @@ export class Oid4vciService {
                     );
                 },
             );
+    }
+
+    /**
+     * Resolve credential offers sent by reference (credential_offer_uri).
+     */
+    async getCredentialOfferByReference(
+        tenantId: string,
+        sessionId: string,
+    ): Promise<CredentialOfferObject> {
+        const session = await this.sessionService
+            .getBy({ id: sessionId, tenantId })
+            .catch(() => {
+                throw new NotFoundException("Credential offer not found");
+            });
+
+        if (!session.offer) {
+            throw new NotFoundException("Credential offer not found");
+        }
+
+        return session.offer as CredentialOfferObject;
     }
 
     /**

--- a/apps/backend/test/issuance/issuance-iae.e2e-spec.ts
+++ b/apps/backend/test/issuance/issuance-iae.e2e-spec.ts
@@ -129,6 +129,50 @@ describe("Interactive Authorization Endpoint (IAE)", () => {
             expect(response.body.status).toBe("require_interaction");
         });
 
+        test("should expose credential offer by reference endpoint", async () => {
+            const offerResponse = await request(app.getHttpServer())
+                .post("/issuer/offer")
+                .trustLocalhost()
+                .set("Authorization", `Bearer ${authToken}`)
+                .send({
+                    response_type: "uri",
+                    credentialConfigurationIds: ["pid-no-key"],
+                    flow: "authorization_code",
+                })
+                .expect(201);
+
+            const offerUri = new URL(offerResponse.body.uri);
+            const credentialOfferUri = offerUri.searchParams.get(
+                "credential_offer_uri",
+            );
+
+            expect(credentialOfferUri).toBeDefined();
+            expect(offerUri.searchParams.get("credential_offer")).toBeNull();
+
+            const offerPayloadResponse = await new Promise<
+                request.Response
+            >((resolve, reject) => {
+                request(app.getHttpServer())
+                    .get(new URL(credentialOfferUri!).pathname)
+                    .end((err, response) => {
+                        if (err) {
+                            reject(err);
+                            return;
+                        }
+                        resolve(response);
+                    });
+            });
+
+            expect(offerPayloadResponse.status).toBe(200);
+
+            expect(offerPayloadResponse.body.credential_issuer).toContain(
+                `/issuers/${tenantId}`,
+            );
+            expect(
+                offerPayloadResponse.body.credential_configuration_ids,
+            ).toContain("pid-no-key");
+        });
+
         test("should include issuer_state when provided", async () => {
             // First create an offer to get an issuer_state
             const offerResponse = await request(app.getHttpServer())
@@ -144,9 +188,32 @@ describe("Interactive Authorization Endpoint (IAE)", () => {
 
             // Extract issuer_state from the offer URI
             const offerUri = new URL(offerResponse.body.uri);
-            const issuerState =
-                offerUri.searchParams.get("credential_offer_uri") ||
-                offerResponse.body.session;
+            const credentialOfferUri = offerUri.searchParams.get(
+                "credential_offer_uri",
+            );
+            let issuerState: string | undefined;
+
+            if (credentialOfferUri) {
+                const offerPayloadResponse = await new Promise<
+                    request.Response
+                >((resolve, reject) => {
+                    request(app.getHttpServer())
+                        .get(new URL(credentialOfferUri).pathname)
+                        .end((err, response) => {
+                            if (err) {
+                                reject(err);
+                                return;
+                            }
+                            resolve(response);
+                        });
+                });
+                expect(offerPayloadResponse.status).toBe(200);
+                issuerState =
+                    offerPayloadResponse.body.grants?.authorization_code
+                        ?.issuer_state;
+            }
+
+            issuerState ??= offerResponse.body.session;
 
             if (issuerState) {
                 const response = await request(app.getHttpServer())

--- a/apps/backend/test/issuance/issuance-iae.e2e-spec.ts
+++ b/apps/backend/test/issuance/issuance-iae.e2e-spec.ts
@@ -149,19 +149,19 @@ describe("Interactive Authorization Endpoint (IAE)", () => {
             expect(credentialOfferUri).toBeDefined();
             expect(offerUri.searchParams.get("credential_offer")).toBeNull();
 
-            const offerPayloadResponse = await new Promise<
-                request.Response
-            >((resolve, reject) => {
-                request(app.getHttpServer())
-                    .get(new URL(credentialOfferUri!).pathname)
-                    .end((err, response) => {
-                        if (err) {
-                            reject(err);
-                            return;
-                        }
-                        resolve(response);
-                    });
-            });
+            const offerPayloadResponse = await new Promise<request.Response>(
+                (resolve, reject) => {
+                    request(app.getHttpServer())
+                        .get(new URL(credentialOfferUri!).pathname)
+                        .end((err, response) => {
+                            if (err) {
+                                reject(err);
+                                return;
+                            }
+                            resolve(response);
+                        });
+                },
+            );
 
             expect(offerPayloadResponse.status).toBe(200);
 
@@ -194,19 +194,18 @@ describe("Interactive Authorization Endpoint (IAE)", () => {
             let issuerState: string | undefined;
 
             if (credentialOfferUri) {
-                const offerPayloadResponse = await new Promise<
-                    request.Response
-                >((resolve, reject) => {
-                    request(app.getHttpServer())
-                        .get(new URL(credentialOfferUri).pathname)
-                        .end((err, response) => {
-                            if (err) {
-                                reject(err);
-                                return;
-                            }
-                            resolve(response);
-                        });
-                });
+                const offerPayloadResponse =
+                    await new Promise<request.Response>((resolve, reject) => {
+                        request(app.getHttpServer())
+                            .get(new URL(credentialOfferUri).pathname)
+                            .end((err, response) => {
+                                if (err) {
+                                    reject(err);
+                                    return;
+                                }
+                                resolve(response);
+                            });
+                    });
                 expect(offerPayloadResponse.status).toBe(200);
                 issuerState =
                     offerPayloadResponse.body.grants?.authorization_code


### PR DESCRIPTION
## Summary
- generate OID4VCI credential offers using `credential_offer_uri` (offer-by-reference)
- add public endpoint to resolve referenced offers: `GET /issuers/:tenantId/vci/credential-offers/:sessionId`
- add/adjust issuance e2e coverage for offer-by-reference and issuer_state resolution

## Why
This aligns issuance offer handling with the OID4VCI spec section for sending credential offers by reference and improves QR/deep-link usability by avoiding large inline offer payloads.

## Testing
- updated issuance IAE e2e spec to validate by-reference behavior
