### PR TITLE
feat(verifier): support webhook endpoint selection for presentation configs

### DIFF
--- a/apps/backend/src/verifier/presentations/entities/presentation-config.entity.ts
+++ b/apps/backend/src/verifier/presentations/entities/presentation-config.entity.ts
@@ -20,11 +20,13 @@ import {
     Column,
     CreateDateColumn,
     Entity,
+    JoinColumn,
     ManyToOne,
     UpdateDateColumn,
 } from "typeorm";
 import { TenantEntity } from "../../../auth/tenant/entitites/tenant.entity";
 import { WebhookConfig } from "../../../shared/utils/webhook/webhook.dto";
+import { WebhookEndpointEntity } from "../../../issuer/configuration/webhook-endpoint/entities/webhook-endpoint.entity";
 import { RegistrationCertificateRequest } from "../dto/vp-request.dto";
 import { IsTransactionData } from "../validators/transaction-data.validator";
 
@@ -258,7 +260,26 @@ export class PresentationConfig {
     registrationCertCache?: RegistrationCertCache | null;
 
     /**
+     * Reference to the webhook endpoint used for notifications.
+     * Optional: if set, notifications will be sent to this endpoint.
+     */
+    @IsOptional()
+    @IsString()
+    @Column("varchar", { nullable: true })
+    webhookEndpointId?: string | null;
+
+    @ManyToOne(() => WebhookEndpointEntity, {
+        createForeignKeyConstraints: false,
+    })
+    @JoinColumn([
+        { name: "webhookEndpointId", referencedColumnName: "id" },
+        { name: "tenantId", referencedColumnName: "tenantId" },
+    ])
+    webhookEndpoint?: WebhookEndpointEntity;
+
+    /**
      * Optional webhook URL to receive the response.
+     * @deprecated This field is deprecated. Use webhookEndpointId and the WebhookEndpoint relationship instead.
      */
     @Column("json", { nullable: true })
     @IsOptional()

--- a/apps/client/src/app/presentation/presentation-config/presentation-create/presentation-create.component.html
+++ b/apps/client/src/app/presentation/presentation-config/presentation-create/presentation-create.component.html
@@ -473,11 +473,25 @@
             <mat-card-header>
               <mat-card-title>
                 <mat-icon>webhook</mat-icon>
-                Webhook Configuration
+                Webhook Endpoint
               </mat-card-title>
+              <mat-card-subtitle>
+                Select a webhook endpoint to receive presentation lifecycle events
+              </mat-card-subtitle>
             </mat-card-header>
-            <mat-card-content fxLayout="column" fxLayoutGap="16px" formGroupName="webhook">
-              <app-webhook-config-edit [group]="getFormGroup('webhook')"></app-webhook-config-edit>
+            <mat-card-content fxLayout="column" fxLayoutGap="16px">
+              <mat-form-field>
+                <mat-label>Webhook Endpoint</mat-label>
+                <mat-select formControlName="webhookEndpointId">
+                  <mat-option value="">None</mat-option>
+                  @for (endpoint of webhookEndpoints; track endpoint.id) {
+                    <mat-option [value]="endpoint.id"
+                      >{{ endpoint.name }} ({{ endpoint.id }})</mat-option
+                    >
+                  }
+                </mat-select>
+                <mat-hint>Endpoint that receives presentation lifecycle notifications</mat-hint>
+              </mat-form-field>
             </mat-card-content>
           </mat-card>
         </div>

--- a/apps/client/src/app/presentation/presentation-config/presentation-create/presentation-create.component.ts
+++ b/apps/client/src/app/presentation/presentation-config/presentation-create/presentation-create.component.ts
@@ -14,7 +14,9 @@ import {
   presentationManagementControllerUpdateConfiguration,
   presentationManagementControllerReissueRegistrationCertificate,
   keyChainControllerGetAll,
+  webhookEndpointControllerGetAll,
   KeyChainResponseDto,
+  WebhookEndpointEntity,
 } from '@eudiplo/sdk-core';
 import { PresentationManagementService } from '../presentation-management.service';
 import { MatDialog } from '@angular/material/dialog';
@@ -27,7 +29,7 @@ import { MatDividerModule } from '@angular/material/divider';
 import { configs } from './pre-config';
 import { MonacoEditorModule } from 'ngx-monaco-editor-v2';
 import { EditorComponent, extractSchema } from '../../../utils/editor/editor.component';
-import { WebhookConfigEditComponent } from '../../../utils/webhook-config-edit/webhook-config-edit.component';
+
 import {
   DCQLSchema,
   presentationConfigSchema,
@@ -59,7 +61,6 @@ import { RegistrarService } from '../../../registrar/registrar.service';
     MatTabsModule,
     MonacoEditorModule,
     EditorComponent,
-    WebhookConfigEditComponent,
     CredentialIdsComponent,
   ],
   templateUrl: './presentation-create.component.html',
@@ -81,6 +82,7 @@ export class PresentationCreateComponent implements OnInit {
   public predefinedConfigs = configs;
 
   public keyChains: KeyChainResponseDto[] = [];
+  public webhookEndpoints: WebhookEndpointEntity[] = [];
 
   readonly purposeLanguageOptions = [
     { value: 'en-US', label: 'English (US)' },
@@ -133,16 +135,7 @@ export class PresentationCreateComponent implements OnInit {
       registrationCertBodyPurpose: new FormArray([]),
       transaction_data: new FormControl(undefined), // Optional transaction data
       attached: new FormArray([]),
-      webhook: new FormGroup({
-        url: new FormControl(undefined), // Optional, but if filled, should be valid URL
-        auth: new FormGroup({
-          type: new FormControl(undefined), // Optional
-          config: new FormGroup({
-            headerName: new FormControl(undefined), // Optional
-            value: new FormControl(undefined), // Optional
-          }),
-        }),
-      }),
+      webhookEndpointId: new FormControl(''), // Predefined webhook endpoint selector
     });
   }
 
@@ -156,6 +149,17 @@ export class PresentationCreateComponent implements OnInit {
       (error) => {
         console.error('Failed to load key chains:', error);
         this.snackBar.open('Failed to load key chains', 'Close', {
+          duration: 3000,
+        });
+      }
+    );
+
+    // Load webhook endpoints for the select dropdown
+    webhookEndpointControllerGetAll({}).then(
+      (res) => (this.webhookEndpoints = (res.data || []) as WebhookEndpointEntity[]),
+      (error) => {
+        console.error('Failed to load webhook endpoints:', error);
+        this.snackBar.open('Failed to load webhook endpoints', 'Close', {
           duration: 3000,
         });
       }
@@ -195,6 +199,9 @@ export class PresentationCreateComponent implements OnInit {
           }
 
           (formData.attached || []).forEach(() => this.addAttachment());
+
+          // Remove inline webhook config since we only support webhook endpoint references
+          delete formData.webhook;
 
           if (this.copyMode) {
             // Copy mode: clear ID and keep it editable, set create mode
@@ -295,9 +302,8 @@ export class PresentationCreateComponent implements OnInit {
 
     formValue.registration_cert = this.buildRegistrationCertFromForm();
 
-    if (!formValue.webhook.url) {
-      formValue.webhook = null; // Set to null to clear the webhook
-    }
+    // Clean up webhookEndpointId - use null to clear (PATCH semantics)
+    formValue.webhookEndpointId = formValue.webhookEndpointId?.trim() || null;
 
     if (!formValue.registration_cert) {
       formValue.registration_cert = null; // Set to null to clear registration_cert

--- a/apps/client/src/app/presentation/presentation-config/presentation-show/presentation-show.component.html
+++ b/apps/client/src/app/presentation/presentation-config/presentation-show/presentation-show.component.html
@@ -392,12 +392,57 @@
           Integration
         </ng-template>
         <div fxLayout="column" fxLayoutGap="24px" class="tab-content">
-          <!-- Webhook -->
-          <app-webhook-config-show
-            [config]="config.webhook"
-            title="Verification Result"
-            descriptions="Where verification results are sent"
-          ></app-webhook-config-show>
+          <!-- Webhook Endpoint -->
+          <mat-card>
+            <mat-card-header>
+              <mat-card-title>
+                <mat-icon>webhook</mat-icon>
+                Webhook Endpoint
+              </mat-card-title>
+              <mat-card-subtitle>
+                Endpoint that receives presentation lifecycle notifications
+              </mat-card-subtitle>
+            </mat-card-header>
+            <mat-card-content>
+              @if ($any(config).webhookEndpointId) {
+                <mat-list class="config-list">
+                  @if ($any(config).webhookEndpoint?.name) {
+                    <mat-list-item>
+                      <mat-icon matListItemIcon>label</mat-icon>
+                      <span matListItemTitle>Name</span>
+                      <span matListItemLine>{{ $any(config).webhookEndpoint.name }}</span>
+                    </mat-list-item>
+                  }
+                  <mat-list-item>
+                    <mat-icon matListItemIcon>fingerprint</mat-icon>
+                    <span matListItemTitle>Endpoint ID</span>
+                    <span matListItemLine>{{ $any(config).webhookEndpointId }}</span>
+                  </mat-list-item>
+                </mat-list>
+
+                <div fxLayout="row" fxLayoutGap="12px" fxLayoutWrap>
+                  <button
+                    mat-stroked-button
+                    type="button"
+                    [routerLink]="['/webhook-endpoints', $any(config).webhookEndpointId]"
+                  >
+                    <mat-icon>open_in_new</mat-icon>
+                    Open endpoint
+                  </button>
+                  <button mat-button type="button" [routerLink]="['/webhook-endpoints']">
+                    <mat-icon>list</mat-icon>
+                    View all endpoints
+                  </button>
+                </div>
+              } @else {
+                <p>No webhook endpoint configured.</p>
+                <button mat-button type="button" [routerLink]="['/webhook-endpoints']">
+                  <mat-icon>settings</mat-icon>
+                  Configure webhook endpoints
+                </button>
+              }
+            </mat-card-content>
+          </mat-card>
 
           <!-- Attached Data -->
           @if (config.attached) {

--- a/apps/client/src/app/presentation/presentation-config/presentation-show/presentation-show.component.ts
+++ b/apps/client/src/app/presentation/presentation-config/presentation-show/presentation-show.component.ts
@@ -15,7 +15,6 @@ import { FlexLayoutModule } from 'ngx-flexible-layout';
 import { PresentationConfig } from '@eudiplo/sdk-core';
 import { PresentationManagementService } from '../presentation-management.service';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import { WebhookConfigShowComponent } from '../../../utils/webhook-config-show/webhook-config-show.component';
 import { presentationManagementControllerReissueRegistrationCertificate } from '@eudiplo/sdk-core';
 import { decodeJwt, decodeProtectedHeader } from 'jose';
 import {
@@ -41,7 +40,6 @@ import { downloadJsonFile } from '../../../common/download-json.util';
     FlexLayoutModule,
     RouterModule,
     ClipboardModule,
-    WebhookConfigShowComponent,
   ],
   templateUrl: './presentation-show.component.html',
   changeDetection: ChangeDetectionStrategy.Eager,


### PR DESCRIPTION
## Summary
- add webhook endpoint selection to presentation config create/edit flow
- persist webhook endpoint reference for presentation configs on backend
- show configured webhook endpoint info in presentation configuration details

## Details
- frontend: presentation create form now supports selecting a predefined webhook endpoint
- frontend: presentation show page displays selected webhook endpoint with quick navigation
- backend: presentation config entity now supports  relation
- keep legacy inline  field deprecated for compatibility

## Validation
- pnpm --filter @eudiplo/client lint
- pnpm --filter @eudiplo/backend build
- pnpm build

## Notes
- this PR contains the branch changes currently pushed on .
