### PR TITLE
fix(issuance): advertise both mdoc COSE alg IDs for ES256

### DIFF
--- a/apps/backend/src/crypto/key/crypto-implementation/crypto-implementation.service.spec.ts
+++ b/apps/backend/src/crypto/key/crypto-implementation/crypto-implementation.service.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "vitest";
+import { ConfigService } from "@nestjs/config";
+import { CredentialFormat } from "../../../issuer/configuration/credentials/entities/credential.entity";
+import { CryptoImplementationService } from "./crypto-implementation.service";
+
+describe("CryptoImplementationService", () => {
+    test("returns both classic and fully-specified COSE alg values for mDOC", () => {
+        const configService = {
+            get: () => "ES256",
+        } as unknown as ConfigService;
+        const service = new CryptoImplementationService(configService);
+
+        const algs = service.getAlgs(CredentialFormat.MSO_MDOC);
+
+        expect(algs).toEqual(expect.arrayContaining([-7, -9]));
+    });
+
+    test("returns JOSE alg values for SD-JWT VC", () => {
+        const configService = {
+            get: () => "ES256",
+        } as unknown as ConfigService;
+        const service = new CryptoImplementationService(configService);
+
+        const algs = service.getAlgs(CredentialFormat.SD_JWT_VC);
+
+        expect(algs).toContain("ES256");
+    });
+});

--- a/apps/backend/src/crypto/key/crypto-implementation/crypto-implementation.service.ts
+++ b/apps/backend/src/crypto/key/crypto-implementation/crypto-implementation.service.ts
@@ -12,6 +12,12 @@ export type CryptoType = "ES256";
  */
 export type JoseAlgorithm = "ES256" | "ES384" | "ES512";
 
+const JOSE_TO_CLASSIC_COSE_ALG: Record<JoseAlgorithm, number> = {
+    ES256: -7,
+    ES384: -35,
+    ES512: -36,
+};
+
 /**
  * COSE algorithm identifiers used for mDOC (ISO 18013-5)
  * Uses RFC 9864 fully-specified algorithm identifiers
@@ -57,11 +63,21 @@ export class CryptoImplementationService {
         }
 
         if (credentialFormat === CredentialFormat.MSO_MDOC) {
-            return joseAlgs
-                .map((alg) =>
-                    jwaSignatureAlgorithmToFullySpecifiedCoseAlgorithm(alg),
-                )
-                .filter((alg) => alg !== undefined);
+            const coseAlgs = new Set<number>();
+
+            for (const alg of joseAlgs) {
+                // Include classic COSE alg IDs for compatibility with generic identifiers.
+                coseAlgs.add(JOSE_TO_CLASSIC_COSE_ALG[alg]);
+
+                // Also include RFC 9864 fully-specified identifiers.
+                const fullySpecifiedAlg =
+                    jwaSignatureAlgorithmToFullySpecifiedCoseAlgorithm(alg);
+                if (fullySpecifiedAlg !== undefined) {
+                    coseAlgs.add(fullySpecifiedAlg);
+                }
+            }
+
+            return Array.from(coseAlgs);
         }
 
         // Default to JOSE algorithms


### PR DESCRIPTION
## 📝 Description

This PR addresses the mDOC algorithm metadata mismatch reported in #814 by advertising both classic and fully-specified COSE algorithm identifiers for ES256 in `credential_signing_alg_values_supported`.

This makes metadata acceptable for strict validators that require explicit support for classic `-7`, while remaining compliant with fully-specified identifier support (`-9`).

Fixes #814

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality
      to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test improvements
- [ ] 🏗️ Build/CI changes

## 💥 Breaking Changes (if applicable)

- **API changes**: None
- **Environment variables**: None
- **Config import format**: None
- **Database**: None

## 🧪 Testing

- [x] Unit tests pass
- [ ] Integration tests pass
- [ ] E2E tests pass
- [ ] Manual testing performed

**Test Configuration**:

- Node.js version: v26.1.0
- OS: macOS
- Test environment: local dev

Executed:

- `cd apps/backend && pnpm vitest run src/crypto/key/crypto-implementation/crypto-implementation.service.spec.ts --config vitest.config.ts`

## 📸 Screenshots (if applicable)

N/A

## ✔️ Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## 📋 Additional Notes

- Behavior change for mDOC metadata generation:
  - Previously: fully-specified COSE alg only (e.g. `-9` for ES256)
  - Now: both classic and fully-specified values (e.g. `[-7, -9]`)
- This is intentionally metadata-only. mDOC issuance signing behavior is unchanged.
