### PR TITLE
fix(security): harden tenant/session isolation and outbound webhook safety

### DIFF
--- a/apps/backend/src/all-exceptions.filter.ts
+++ b/apps/backend/src/all-exceptions.filter.ts
@@ -14,9 +14,11 @@ export class AllExceptionsFilter implements ExceptionFilter {
     private readonly logger = new Logger(AllExceptionsFilter.name);
 
     catch(exception: unknown, host: ArgumentsHost) {
+        const isProduction = process.env.NODE_ENV === "production";
         const ctx = host.switchToHttp();
         const response = ctx.getResponse<Response>();
         const request = ctx.getRequest<Request>();
+        const requestPath = request.path || request.url.split("?")[0] || "/";
 
         let status: number;
         if (exception instanceof HttpException) {
@@ -30,7 +32,7 @@ export class AllExceptionsFilter implements ExceptionFilter {
         let message: unknown;
         if (exception instanceof HttpException) {
             message = exception.getResponse();
-        } else if (exception instanceof Error) {
+        } else if (exception instanceof Error && !isProduction) {
             message = exception.message;
         } else {
             message = "Internal Server Error";
@@ -38,14 +40,14 @@ export class AllExceptionsFilter implements ExceptionFilter {
 
         // Log the error with stack trace if available using NestJS Logger
         this.logger.error(
-            `[${request.method}] ${request.url} ${status} - ${JSON.stringify(message)}`,
+            `[${request.method}] ${requestPath} ${status} - ${JSON.stringify(message)}`,
             exception instanceof Error ? exception.stack : undefined,
         );
 
         response.status(status).json({
             statusCode: status,
             timestamp: new Date().toISOString(),
-            path: request.url,
+            path: requestPath,
             message,
         });
     }

--- a/apps/backend/src/issuer/configuration/attribute-provider/attribute-provider.service.ts
+++ b/apps/backend/src/issuer/configuration/attribute-provider/attribute-provider.service.ts
@@ -15,6 +15,7 @@ import {
     ConfigImportOrchestratorService,
     ImportPhase,
 } from "../../../shared/utils/config-import/config-import-orchestrator.service";
+import { OutboundUrlPolicyService } from "../../../shared/utils/webhook/outbound-url-policy.service";
 import { CreateAttributeProviderDto } from "./dto/create-attribute-provider.dto";
 import { UpdateAttributeProviderDto } from "./dto/update-attribute-provider.dto";
 import { AttributeProviderEntity } from "./entities/attribute-provider.entity";
@@ -27,6 +28,7 @@ export class AttributeProviderService {
         private readonly configImportService: ConfigImportService,
         private readonly configImportOrchestrator: ConfigImportOrchestratorService,
         private readonly tenantActionLogService: AuditLogService,
+        private readonly outboundUrlPolicyService: OutboundUrlPolicyService,
     ) {
         this.configImportOrchestrator.register(
             "attribute-providers",
@@ -78,6 +80,8 @@ export class AttributeProviderService {
         actorToken?: TokenPayload,
         req?: Request,
     ) {
+        await this.outboundUrlPolicyService.assertSafeUrl(dto.url);
+
         const saved = await this.repo.save({ ...dto, tenantId });
 
         if (actorToken) {
@@ -105,6 +109,11 @@ export class AttributeProviderService {
         req?: Request,
     ) {
         const existing = await this.getById(tenantId, id);
+
+        if (dto.url) {
+            await this.outboundUrlPolicyService.assertSafeUrl(dto.url);
+        }
+
         const saved = await this.repo.save({
             ...existing,
             ...dto,

--- a/apps/backend/src/issuer/configuration/configuration.module.ts
+++ b/apps/backend/src/issuer/configuration/configuration.module.ts
@@ -7,6 +7,7 @@ import { RegistrarModule } from "../../registrar/registrar.module";
 import { SchemaMetadataController } from "../../registrar/schema-metadata.controller";
 import { SessionModule } from "../../session/session.module";
 import { TrustModule } from "../../shared/trust/trust.module";
+import { OutboundUrlPolicyService } from "../../shared/utils/webhook/outbound-url-policy.service";
 import { WebhookService } from "../../shared/utils/webhook/webhook.service";
 import { PresentationsModule } from "../../verifier/presentations/presentations.module";
 import { StatusListModule } from "../lifecycle/status/status-list.module";
@@ -67,6 +68,7 @@ import { WebhookEndpointService } from "./webhook-endpoint/webhook-endpoint.serv
         CredentialsService,
         CredentialConfigService,
         WebhookService,
+        OutboundUrlPolicyService,
         SdjwtvcIssuerService,
         MdocIssuerService,
         AttributeProviderService,

--- a/apps/backend/src/issuer/configuration/webhook-endpoint/webhook-endpoint.service.ts
+++ b/apps/backend/src/issuer/configuration/webhook-endpoint/webhook-endpoint.service.ts
@@ -15,6 +15,7 @@ import {
     ConfigImportOrchestratorService,
     ImportPhase,
 } from "../../../shared/utils/config-import/config-import-orchestrator.service";
+import { OutboundUrlPolicyService } from "../../../shared/utils/webhook/outbound-url-policy.service";
 import { CreateWebhookEndpointDto } from "./dto/create-webhook-endpoint.dto";
 import { UpdateWebhookEndpointDto } from "./dto/update-webhook-endpoint.dto";
 import { WebhookEndpointEntity } from "./entities/webhook-endpoint.entity";
@@ -27,6 +28,7 @@ export class WebhookEndpointService {
         private readonly configImportService: ConfigImportService,
         private readonly configImportOrchestrator: ConfigImportOrchestratorService,
         private readonly tenantActionLogService: AuditLogService,
+        private readonly outboundUrlPolicyService: OutboundUrlPolicyService,
     ) {
         this.configImportOrchestrator.register(
             "webhook-endpoints",
@@ -78,6 +80,8 @@ export class WebhookEndpointService {
         actorToken?: TokenPayload,
         req?: Request,
     ) {
+        await this.outboundUrlPolicyService.assertSafeUrl(dto.url);
+
         const saved = await this.repo.save({ ...dto, tenantId });
 
         if (actorToken) {
@@ -105,6 +109,11 @@ export class WebhookEndpointService {
         req?: Request,
     ) {
         const existing = await this.getById(tenantId, id);
+
+        if (dto.url) {
+            await this.outboundUrlPolicyService.assertSafeUrl(dto.url);
+        }
+
         const saved = await this.repo.save({
             ...existing,
             ...dto,

--- a/apps/backend/src/issuer/issuance/issuance.module.ts
+++ b/apps/backend/src/issuer/issuance/issuance.module.ts
@@ -4,6 +4,7 @@ import { TypeOrmModule } from "@nestjs/typeorm";
 import { CryptoModule } from "../../crypto/crypto.module";
 import { RegistrarModule } from "../../registrar/registrar.module";
 import { SessionModule } from "../../session/session.module";
+import { OutboundUrlPolicyService } from "../../shared/utils/webhook/outbound-url-policy.service";
 import { TrustModule } from "../../shared/trust/trust.module";
 import { WebhookService } from "../../shared/utils/webhook/webhook.service";
 import { Oid4vpModule } from "../../verifier/oid4vp/oid4vp.module";
@@ -60,6 +61,7 @@ import { WellKnownService } from "./oid4vci/well-known/well-known.service";
         Oid4vciService,
         WellKnownService,
         WebhookService,
+        OutboundUrlPolicyService,
     ],
     exports: [AuthorizationModule, Oid4vciService],
 })

--- a/apps/backend/src/issuer/issuer-validation.schema.ts
+++ b/apps/backend/src/issuer/issuer-validation.schema.ts
@@ -5,4 +5,24 @@ export const ISSUER_VALIDATION_SCHEMA = Joi.object({
         .default("http://localhost:3000")
         .description("The public URL of the issuer")
         .meta({ group: "general", order: 10 }),
+
+    OUTBOUND_URL_ALLOW_HTTP: Joi.boolean()
+        .optional()
+        .description("Allow HTTP (non-TLS) for outbound webhook calls")
+        .meta({ group: "issuer", order: 20 }),
+
+    OUTBOUND_URL_ALLOW_PRIVATE_NETWORK: Joi.boolean()
+        .optional()
+        .description(
+            "Allow outbound webhook calls to private, loopback, or link-local IP ranges",
+        )
+        .meta({ group: "issuer", order: 30 }),
+
+    OUTBOUND_URL_ALLOWED_HOSTS: Joi.string()
+        .allow("")
+        .optional()
+        .description(
+            "Comma-separated hostname allowlist for outbound webhook calls (supports exact host and subdomains)",
+        )
+        .meta({ group: "issuer", order: 40 }),
 });

--- a/apps/backend/src/session/session-events.controller.ts
+++ b/apps/backend/src/session/session-events.controller.ts
@@ -100,16 +100,25 @@ export class SessionEventsController {
             );
         }
 
+        let tenantId: string | undefined;
         try {
-            await this.jwtService.verifyToken(token);
+            const payload = await this.jwtService.verifyToken(token);
+            tenantId = payload.entity?.id;
         } catch (error) {
             this.logger.warn(`Invalid token for session ${id} SSE: ${error}`);
             throw new UnauthorizedException("Invalid or expired token");
         }
 
-        // Verify session exists
+        if (!tenantId) {
+            throw new UnauthorizedException("Token is not tenant-scoped");
+        }
+
+        // Verify session exists and belongs to caller tenant.
         try {
-            const session = await this.sessionService.get(id);
+            const session = await this.sessionService.getBy({
+                id,
+                tenantId,
+            });
 
             this.logger.debug(`Client subscribed to session ${id} events`);
 

--- a/apps/backend/src/session/session.controller.ts
+++ b/apps/backend/src/session/session.controller.ts
@@ -49,8 +49,11 @@ export class SessionController {
      */
     @ApiParam({ name: "id", description: "The session ID", type: String })
     @Get(":id")
-    getSession(@Param("id") id: string): Promise<Session> {
-        return this.sessionService.get(id);
+    getSession(
+        @Param("id") id: string,
+        @Token() token: TokenPayload,
+    ): Promise<Session> {
+        return this.sessionService.getBy({ id, tenantId: token.entity!.id });
     }
 
     /**
@@ -75,9 +78,11 @@ export class SessionController {
     @ApiOperation({ summary: "Get session log entries" })
     @ApiResponse({ status: 200, type: [SessionLogEntryResponseDto] })
     @Get(":id/logs")
-    getSessionLogs(
+    async getSessionLogs(
         @Param("id") id: string,
+        @Token() token: TokenPayload,
     ): Promise<SessionLogEntryResponseDto[]> {
+        await this.sessionService.getBy({ id, tenantId: token.entity!.id });
         return this.logStoreService.findBySessionId(id);
     }
 

--- a/apps/backend/src/shared/utils/webhook/outbound-url-policy.service.spec.ts
+++ b/apps/backend/src/shared/utils/webhook/outbound-url-policy.service.spec.ts
@@ -1,0 +1,123 @@
+import { BadRequestException } from "@nestjs/common";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:dns/promises", () => ({
+    lookup: vi.fn(),
+}));
+
+import { lookup } from "node:dns/promises";
+import { OutboundUrlPolicyService } from "./outbound-url-policy.service";
+
+type ConfigValue = string | boolean | undefined;
+
+describe("OutboundUrlPolicyService", () => {
+    const originalNodeEnv = process.env.NODE_ENV;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        process.env.NODE_ENV = originalNodeEnv;
+    });
+
+    function createService(config: Record<string, ConfigValue> = {}) {
+        const configService = {
+            get: vi.fn((key: string) => config[key]),
+        };
+
+        return {
+            service: new OutboundUrlPolicyService(configService as any),
+            configService,
+        };
+    }
+
+    it("rejects invalid URL values", async () => {
+        const { service } = createService();
+
+        await expect(service.assertSafeUrl("not-a-url")).rejects.toBeInstanceOf(
+            BadRequestException,
+        );
+    });
+
+    it("rejects HTTP in production by default", async () => {
+        process.env.NODE_ENV = "production";
+        const { service } = createService();
+
+        await expect(
+            service.assertSafeUrl("http://example.com/webhook"),
+        ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it("allows HTTP in non-production by default", async () => {
+        process.env.NODE_ENV = "development";
+        const { service } = createService();
+
+        await expect(
+            service.assertSafeUrl("http://example.com/webhook"),
+        ).resolves.toBeUndefined();
+    });
+
+    it("rejects localhost targets", async () => {
+        process.env.NODE_ENV = "production";
+        const { service } = createService();
+
+        await expect(
+            service.assertSafeUrl("https://localhost/internal"),
+        ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it("rejects direct private IP targets", async () => {
+        process.env.NODE_ENV = "production";
+        const { service } = createService();
+
+        await expect(
+            service.assertSafeUrl("https://10.0.0.1/internal"),
+        ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it("rejects hostnames that resolve to private IPs", async () => {
+        process.env.NODE_ENV = "production";
+        vi.mocked(lookup).mockResolvedValue([{ address: "127.0.0.1", family: 4 }]);
+
+        const { service } = createService();
+
+        await expect(
+            service.assertSafeUrl("https://issuer.example/webhook"),
+        ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it("allows configured host allowlist including subdomains", async () => {
+        process.env.NODE_ENV = "production";
+        vi.mocked(lookup).mockResolvedValue([
+            { address: "93.184.216.34", family: 4 },
+        ]);
+
+        const { service } = createService({
+            OUTBOUND_URL_ALLOWED_HOSTS: "example.com",
+        });
+
+        await expect(
+            service.assertSafeUrl("https://hooks.example.com/webhook"),
+        ).resolves.toBeUndefined();
+    });
+
+    it("rejects hosts outside configured allowlist", async () => {
+        process.env.NODE_ENV = "production";
+        const { service } = createService({
+            OUTBOUND_URL_ALLOWED_HOSTS: "example.com",
+        });
+
+        await expect(
+            service.assertSafeUrl("https://attacker.test/webhook"),
+        ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it("allows private network targets when explicitly enabled", async () => {
+        process.env.NODE_ENV = "production";
+        const { service } = createService({
+            OUTBOUND_URL_ALLOW_PRIVATE_NETWORK: true,
+        });
+
+        await expect(
+            service.assertSafeUrl("https://10.1.2.3/internal"),
+        ).resolves.toBeUndefined();
+    });
+});

--- a/apps/backend/src/shared/utils/webhook/outbound-url-policy.service.spec.ts
+++ b/apps/backend/src/shared/utils/webhook/outbound-url-policy.service.spec.ts
@@ -75,7 +75,9 @@ describe("OutboundUrlPolicyService", () => {
 
     it("rejects hostnames that resolve to private IPs", async () => {
         process.env.NODE_ENV = "production";
-        vi.mocked(lookup).mockResolvedValue([{ address: "127.0.0.1", family: 4 }]);
+        vi.mocked(lookup).mockResolvedValue([
+            { address: "127.0.0.1", family: 4 },
+        ]);
 
         const { service } = createService();
 

--- a/apps/backend/src/shared/utils/webhook/outbound-url-policy.service.ts
+++ b/apps/backend/src/shared/utils/webhook/outbound-url-policy.service.ts
@@ -16,7 +16,10 @@ export class OutboundUrlPolicyService {
         }
 
         const protocol = parsed.protocol.toLowerCase();
-        if (protocol !== "https:" && !(protocol === "http:" && this.allowHttp())) {
+        if (
+            protocol !== "https:" &&
+            !(protocol === "http:" && this.allowHttp())
+        ) {
             throw new BadRequestException(
                 "Outbound URL must use HTTPS in this environment",
             );
@@ -26,8 +29,8 @@ export class OutboundUrlPolicyService {
         const allowlistedHosts = this.allowedHosts();
         if (
             allowlistedHosts.length > 0 &&
-            !allowlistedHosts.some((entry) =>
-                hostname === entry || hostname.endsWith(`.${entry}`),
+            !allowlistedHosts.some(
+                (entry) => hostname === entry || hostname.endsWith(`.${entry}`),
             )
         ) {
             throw new BadRequestException(
@@ -59,11 +62,15 @@ export class OutboundUrlPolicyService {
         try {
             resolved = await lookup(hostname, { all: true, verbatim: true });
         } catch {
-            throw new BadRequestException("Outbound URL host cannot be resolved");
+            throw new BadRequestException(
+                "Outbound URL host cannot be resolved",
+            );
         }
 
         if (resolved.length === 0) {
-            throw new BadRequestException("Outbound URL host cannot be resolved");
+            throw new BadRequestException(
+                "Outbound URL host cannot be resolved",
+            );
         }
 
         if (resolved.some((entry) => this.isPrivateIp(entry.address))) {
@@ -99,7 +106,9 @@ export class OutboundUrlPolicyService {
     }
 
     private allowedHosts(): string[] {
-        const raw = this.configService.get<string>("OUTBOUND_URL_ALLOWED_HOSTS");
+        const raw = this.configService.get<string>(
+            "OUTBOUND_URL_ALLOWED_HOSTS",
+        );
         if (!raw) return [];
         return raw
             .split(",")
@@ -120,7 +129,9 @@ export class OutboundUrlPolicyService {
 
         const version = isIP(normalized);
         if (version === 4) {
-            const octets = normalized.split(".").map((v) => Number.parseInt(v, 10));
+            const octets = normalized
+                .split(".")
+                .map((v) => Number.parseInt(v, 10));
             const [a, b] = octets;
             if (a === 10) return true;
             if (a === 127) return true;

--- a/apps/backend/src/shared/utils/webhook/outbound-url-policy.service.ts
+++ b/apps/backend/src/shared/utils/webhook/outbound-url-policy.service.ts
@@ -1,0 +1,145 @@
+import { BadRequestException, Injectable } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { lookup } from "node:dns/promises";
+import { isIP } from "node:net";
+
+@Injectable()
+export class OutboundUrlPolicyService {
+    constructor(private readonly configService: ConfigService) {}
+
+    async assertSafeUrl(url: string): Promise<void> {
+        let parsed: URL;
+        try {
+            parsed = new URL(url);
+        } catch {
+            throw new BadRequestException("Invalid outbound URL");
+        }
+
+        const protocol = parsed.protocol.toLowerCase();
+        if (protocol !== "https:" && !(protocol === "http:" && this.allowHttp())) {
+            throw new BadRequestException(
+                "Outbound URL must use HTTPS in this environment",
+            );
+        }
+
+        const hostname = parsed.hostname.toLowerCase();
+        const allowlistedHosts = this.allowedHosts();
+        if (
+            allowlistedHosts.length > 0 &&
+            !allowlistedHosts.some((entry) =>
+                hostname === entry || hostname.endsWith(`.${entry}`),
+            )
+        ) {
+            throw new BadRequestException(
+                "Outbound URL host is not in the allowlist",
+            );
+        }
+
+        if (this.allowPrivateNetwork()) {
+            return;
+        }
+
+        if (this.isReservedHost(hostname)) {
+            throw new BadRequestException(
+                "Outbound URL host is not allowed in this environment",
+            );
+        }
+
+        const directIpVersion = isIP(hostname);
+        if (directIpVersion > 0) {
+            if (this.isPrivateIp(hostname)) {
+                throw new BadRequestException(
+                    "Outbound URL target resolves to a private or loopback IP",
+                );
+            }
+            return;
+        }
+
+        let resolved;
+        try {
+            resolved = await lookup(hostname, { all: true, verbatim: true });
+        } catch {
+            throw new BadRequestException("Outbound URL host cannot be resolved");
+        }
+
+        if (resolved.length === 0) {
+            throw new BadRequestException("Outbound URL host cannot be resolved");
+        }
+
+        if (resolved.some((entry) => this.isPrivateIp(entry.address))) {
+            throw new BadRequestException(
+                "Outbound URL target resolves to a private or loopback IP",
+            );
+        }
+    }
+
+    private allowHttp(): boolean {
+        return this.readBoolean(
+            "OUTBOUND_URL_ALLOW_HTTP",
+            process.env.NODE_ENV !== "production",
+        );
+    }
+
+    private allowPrivateNetwork(): boolean {
+        return this.readBoolean(
+            "OUTBOUND_URL_ALLOW_PRIVATE_NETWORK",
+            process.env.NODE_ENV !== "production",
+        );
+    }
+
+    private readBoolean(key: string, fallback: boolean): boolean {
+        const configured = this.configService.get<string | boolean>(key);
+        if (configured === undefined) {
+            return fallback;
+        }
+        if (typeof configured === "boolean") {
+            return configured;
+        }
+        return configured.toLowerCase() === "true";
+    }
+
+    private allowedHosts(): string[] {
+        const raw = this.configService.get<string>("OUTBOUND_URL_ALLOWED_HOSTS");
+        if (!raw) return [];
+        return raw
+            .split(",")
+            .map((value) => value.trim().toLowerCase())
+            .filter((value) => value.length > 0);
+    }
+
+    private isReservedHost(hostname: string): boolean {
+        return hostname === "localhost" || hostname.endsWith(".localhost");
+    }
+
+    private isPrivateIp(address: string): boolean {
+        const normalized = address.toLowerCase();
+
+        if (normalized.startsWith("::ffff:")) {
+            return this.isPrivateIp(normalized.slice("::ffff:".length));
+        }
+
+        const version = isIP(normalized);
+        if (version === 4) {
+            const octets = normalized.split(".").map((v) => Number.parseInt(v, 10));
+            const [a, b] = octets;
+            if (a === 10) return true;
+            if (a === 127) return true;
+            if (a === 169 && b === 254) return true;
+            if (a === 172 && b >= 16 && b <= 31) return true;
+            if (a === 192 && b === 168) return true;
+            if (a === 0) return true;
+            return false;
+        }
+
+        if (version === 6) {
+            if (normalized === "::1" || normalized === "::") return true;
+            if (normalized.startsWith("fc") || normalized.startsWith("fd")) {
+                return true;
+            }
+            if (/^fe[89ab]/i.test(normalized)) return true;
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/apps/backend/src/shared/utils/webhook/webhook.service.ts
+++ b/apps/backend/src/shared/utils/webhook/webhook.service.ts
@@ -7,6 +7,7 @@ import {
     Session,
 } from "../../../session/entities/session.entity";
 import { SessionService } from "../../../session/session.service";
+import { OutboundUrlPolicyService } from "./outbound-url-policy.service";
 import { WebhookConfig } from "./webhook.dto";
 import { extractRawTokenFromSubmission } from "./webhook.utils";
 
@@ -50,6 +51,7 @@ export class WebhookService {
     constructor(
         private readonly httpService: HttpService,
         private readonly sessionService: SessionService,
+        private readonly outboundUrlPolicyService: OutboundUrlPolicyService,
         private readonly logger: PinoLogger,
     ) {
         this.logger.setContext("WebhookService");
@@ -60,6 +62,18 @@ export class WebhookService {
      * @returns WebhookResponse containing claims data or deferred issuance indicator
      */
     sendWebhook(values: {
+        webhook: WebhookConfig;
+        session: Session;
+        credentials?: any[];
+        expectResponse: boolean;
+        rawPresentationPayload?: any;
+    }): Promise<WebhookResponse> {
+        return this.outboundUrlPolicyService
+            .assertSafeUrl(values.webhook.url)
+            .then(() => this.sendWebhookInternal(values));
+    }
+
+    private sendWebhookInternal(values: {
         webhook: WebhookConfig;
         session: Session;
         credentials?: any[];
@@ -147,6 +161,8 @@ export class WebhookService {
         session: Session,
         notification: Notification,
     ) {
+        await this.outboundUrlPolicyService.assertSafeUrl(webhook.url);
+
         const headers: Record<string, string> = {};
 
         if (webhook.auth && webhook.auth.type === "apiKey") {
@@ -205,6 +221,8 @@ export class WebhookService {
         };
         credentials?: any[];
     }): Promise<WebhookResponse> {
+        await this.outboundUrlPolicyService.assertSafeUrl(values.webhook.url);
+
         const headers: Record<string, string> = {};
 
         if (values.webhook.auth?.type === "apiKey") {

--- a/apps/backend/src/storage/adapters/local.storage.ts
+++ b/apps/backend/src/storage/adapters/local.storage.ts
@@ -8,7 +8,7 @@ import {
     statSync,
     writeFileSync,
 } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname, relative, resolve } from "node:path";
 import { Readable } from "node:stream";
 import { FileStorage, type PutOptions } from "../storage.types";
 
@@ -22,6 +22,27 @@ export class LocalFileStorage implements FileStorage {
      */
     constructor(private readonly baseDir: string) {}
 
+    private resolveSafePath(key: string): string {
+        if (!key || key.includes("\0")) {
+            throw new Error("Invalid storage key");
+        }
+
+        const basePath = resolve(this.baseDir);
+        const fullPath = resolve(basePath, key);
+        const relativePath = relative(basePath, fullPath);
+
+        // Reject absolute paths and any path escaping the base directory.
+        if (
+            relativePath.startsWith("..") ||
+            relativePath.includes(`/..`) ||
+            relativePath === ""
+        ) {
+            throw new Error("Invalid storage key");
+        }
+
+        return fullPath;
+    }
+
     /**
      * Saves a file to the local storage.
      * @param key
@@ -32,7 +53,7 @@ export class LocalFileStorage implements FileStorage {
         body: Buffer | Readable,
         opts?: PutOptions,
     ): Promise<void> {
-        const fullPath = join(this.baseDir, key);
+        const fullPath = this.resolveSafePath(key);
         mkdirSync(dirname(fullPath), { recursive: true });
 
         await new Promise<void>((resolve, reject) => {
@@ -57,7 +78,7 @@ export class LocalFileStorage implements FileStorage {
      * @returns
      */
     getStream(key: string) {
-        const fullPath = join(this.baseDir, key);
+        const fullPath = this.resolveSafePath(key);
         const stat = statSync(fullPath);
         const metaPath = `${fullPath}.meta`;
         const contentType = existsSync(metaPath)
@@ -76,7 +97,7 @@ export class LocalFileStorage implements FileStorage {
      * @returns
      */
     delete(key: string) {
-        const fullPath = join(this.baseDir, key);
+        const fullPath = this.resolveSafePath(key);
         rmSync(fullPath);
         const metaPath = `${fullPath}.meta`;
         if (existsSync(metaPath)) rmSync(metaPath);
@@ -89,6 +110,10 @@ export class LocalFileStorage implements FileStorage {
      * @returns
      */
     exists(key: string) {
-        return Promise.resolve(existsSync(join(this.baseDir, key)));
+        try {
+            return Promise.resolve(existsSync(this.resolveSafePath(key)));
+        } catch {
+            return Promise.resolve(false);
+        }
     }
 }

--- a/apps/backend/src/verifier/oid4vp/oid4vp.module.ts
+++ b/apps/backend/src/verifier/oid4vp/oid4vp.module.ts
@@ -3,6 +3,7 @@ import { Module } from "@nestjs/common";
 import { CryptoModule } from "../../crypto/crypto.module";
 import { RegistrarModule } from "../../registrar/registrar.module";
 import { SessionModule } from "../../session/session.module";
+import { OutboundUrlPolicyService } from "../../shared/utils/webhook/outbound-url-policy.service";
 import { WebhookService } from "../../shared/utils/webhook/webhook.service";
 import { PresentationsModule } from "../presentations/presentations.module";
 import { Oid4vpController } from "./oid4vp.controller";
@@ -17,7 +18,7 @@ import { Oid4vpService } from "./oid4vp.service";
         PresentationsModule,
     ],
     controllers: [Oid4vpController],
-    providers: [Oid4vpService, WebhookService],
+    providers: [Oid4vpService, WebhookService, OutboundUrlPolicyService],
     exports: [Oid4vpService],
 })
 export class Oid4vpModule {}


### PR DESCRIPTION
## Summary
- scope session reads and session log reads to caller tenant in session APIs
- scope SSE session event subscriptions to caller tenant derived from JWT payload
- harden local storage adapter key handling to block path traversal/escape attempts
- sanitize error handling for production and strip query strings from logged/returned request paths
- add outbound URL safety policy for webhook and attribute-provider targets
- enforce outbound URL safety at both config write-time and request send-time
- add focused unit tests for outbound URL policy behavior

## Security Findings Covered
- [x] 1. Cross-tenant session read
- [x] 2. Cross-tenant SSE session status read
- [x] 3. Local storage path traversal hardening (public download behavior preserved)
- [x] 4. SSRF hardening for tenant-configured webhook/attribute-provider URLs
- [x] 6. Production error message sanitization and URL query redaction
- [ ] 5. Global auth guard (intentionally not changed)

## Validation
- `pnpm --filter @eudiplo/backend lint`
- `pnpm --filter @eudiplo/backend build`
- `pnpm --filter @eudiplo/backend test -- src/shared/utils/webhook/outbound-url-policy.service.spec.ts`
