### PR TITLE
feat: integrate CSC KMS provider and provider selection UX

### DIFF
--- a/apps/backend/src/crypto/key/dto/kms-config.dto.ts
+++ b/apps/backend/src/crypto/key/dto/kms-config.dto.ts
@@ -19,6 +19,7 @@ const KMS_PROVIDER_TYPES = [
     "aws-kms",
     "pkcs11",
     "http",
+    "csc",
 ] as const;
 export type KmsProviderType = (typeof KMS_PROVIDER_TYPES)[number];
 
@@ -380,6 +381,156 @@ class HttpKmsConfigDto extends BaseKmsProviderConfigDto {
     canImport?: boolean;
 }
 
+// ---------------------------------------------------------------------------
+// CSC KMS provider config
+// ---------------------------------------------------------------------------
+
+class CscAuthorizeAuthDataDto {
+    @ApiProperty({
+        description:
+            "Authentication factor identifier expected by the CSC provider (e.g., PIN, OTP).",
+        example: "PIN",
+    })
+    @IsString()
+    @IsNotEmpty()
+    id!: string;
+
+    @ApiProperty({
+        description:
+            "Authentication factor value sent to CSC credentials/authorize.",
+        example: "123456",
+    })
+    @IsString()
+    @IsNotEmpty()
+    value!: string;
+}
+
+/**
+ * Configuration for a CSC (Cloud Signature Consortium) compatible
+ * remote signature service.
+ */
+class CscKmsConfigDto extends BaseKmsProviderConfigDto {
+    @ApiProperty({
+        description: "Type of the KMS provider.",
+        enum: ["csc"],
+        example: "csc",
+    })
+    @IsIn(["csc"])
+    declare type: "csc";
+
+    @ApiProperty({
+        description:
+            "Base URL of the CSC service (without trailing slash). Supports ${ENV_VAR} placeholders.",
+        example: "${CSC_URL}",
+    })
+    @IsString()
+    @IsNotEmpty()
+    baseUrl!: string;
+
+    @ApiProperty({
+        description:
+            "OAuth2 token endpoint URL for client-credentials flow. Supports ${ENV_VAR} placeholders.",
+        example: "${CSC_TOKEN_URL}",
+    })
+    @IsUrl({ require_tld: false })
+    tokenUrl!: string;
+
+    @ApiProperty({
+        description: "OAuth2 client ID. Supports ${ENV_VAR} placeholders.",
+        example: "${CSC_CLIENT_ID}",
+    })
+    @IsString()
+    @IsNotEmpty()
+    clientId!: string;
+
+    @ApiProperty({
+        description: "OAuth2 client secret. Supports ${ENV_VAR} placeholders.",
+        example: "${CSC_CLIENT_SECRET}",
+    })
+    @IsString()
+    @IsNotEmpty()
+    clientSecret!: string;
+
+    @ApiPropertyOptional({
+        description: "OAuth2 scope to request during token acquisition.",
+        example: "service",
+    })
+    @IsString()
+    @IsOptional()
+    scope?: string;
+
+    @ApiPropertyOptional({
+        description:
+            "Default CSC credential ID. If omitted, the adapter calls credentials/list and picks the first entry.",
+        example: "[INTESIQCSEALEC]_SEAL_351_SIGN_1781018892758",
+    })
+    @IsString()
+    @IsOptional()
+    credentialId?: string;
+
+    @ApiPropertyOptional({
+        description: "Optional CSC user ID used in credentials/list requests.",
+        example: "eudiplo_user",
+    })
+    @IsString()
+    @IsOptional()
+    userId?: string;
+
+    @ApiPropertyOptional({
+        description:
+            "CSC API path prefix appended to baseUrl. Defaults to /csc/v2.",
+        example: "/csc/v2",
+    })
+    @IsString()
+    @IsOptional()
+    apiPath?: string;
+
+    @ApiPropertyOptional({
+        description:
+            "Hash algorithm OID for signatures/signHash and credentials/authorize. Defaults to SHA-256 OID.",
+        example: "2.16.840.1.101.3.4.2.1",
+    })
+    @IsString()
+    @IsOptional()
+    hashAlgorithmOid?: string;
+
+    @ApiPropertyOptional({
+        description:
+            "Signature algorithm OID for signatures/signHash. Defaults to ecdsa-with-SHA256 OID.",
+        example: "1.2.840.10045.4.3.2",
+    })
+    @IsString()
+    @IsOptional()
+    signAlgorithmOid?: string;
+
+    @ApiPropertyOptional({
+        description:
+            "Static SAD token. If set, the adapter sends it directly in signatures/signHash requests.",
+    })
+    @IsString()
+    @IsOptional()
+    sad?: string;
+
+    @ApiPropertyOptional({
+        description:
+            "When true and no static SAD is provided, the adapter calls credentials/authorize to obtain SAD before signatures/signHash.",
+        example: false,
+    })
+    @IsOptional()
+    useAuthorizeEndpoint?: boolean;
+
+    @ApiPropertyOptional({
+        description:
+            "Optional authData array passed to credentials/authorize (e.g., PIN/OTP factors).",
+        type: [CscAuthorizeAuthDataDto],
+    })
+    @IsArray()
+    @ValidateNested({ each: true })
+    @Type(() => CscAuthorizeAuthDataDto)
+    @IsOptional()
+    authorizeAuthData?: CscAuthorizeAuthDataDto[];
+}
+
 /**
  * Union type for all provider configurations.
  */
@@ -388,7 +539,8 @@ export type KmsProviderConfigDto =
     | VaultKmsConfigDto
     | AwsKmsConfigDto
     | Pkcs11KmsConfigDto
-    | HttpKmsConfigDto;
+    | HttpKmsConfigDto
+    | CscKmsConfigDto;
 
 /**
  * Root DTO for kms.json.
@@ -452,6 +604,7 @@ export class KmsConfigDto {
                 { value: AwsKmsConfigDto, name: "aws-kms" },
                 { value: Pkcs11KmsConfigDto, name: "pkcs11" },
                 { value: HttpKmsConfigDto, name: "http" },
+                { value: CscKmsConfigDto, name: "csc" },
             ],
         },
         keepDiscriminatorProperty: true,

--- a/apps/backend/src/crypto/key/kms/adapters/csc-kms.adapter.ts
+++ b/apps/backend/src/crypto/key/kms/adapters/csc-kms.adapter.ts
@@ -1,0 +1,495 @@
+import { createHash, X509Certificate } from "node:crypto";
+import { Logger, NotImplementedException } from "@nestjs/common";
+import type { JWK } from "jose";
+import { firstValueFrom } from "rxjs";
+import { HttpService } from "@nestjs/axios";
+import type { KmsProviderType } from "../../dto/kms-config.dto";
+import type {
+    KmsAdapter,
+    KmsAdapterCapabilities,
+    KmsHealthResult,
+    KmsKeyMaterial,
+    KmsKeyRef,
+    KmsSigningAlg,
+} from "../kms-adapter";
+import { PublicJwkCache } from "../public-jwk-cache";
+
+const DEFAULT_HASH_ALGORITHM_OID = "2.16.840.1.101.3.4.2.1"; // SHA-256
+const DEFAULT_SIGN_ALGORITHM_OID = "1.2.840.10045.4.3.2"; // ecdsa-with-SHA256
+const DEFAULT_API_PATH = "/csc/v2";
+
+interface CscAuthorizeAuthData {
+    id: string;
+    value: string;
+}
+
+export interface CscKmsAdapterConfig {
+    providerId: string;
+    baseUrl: string;
+    tokenUrl: string;
+    clientId: string;
+    clientSecret: string;
+    scope?: string;
+    credentialId?: string;
+    userId?: string;
+    hashAlgorithmOid?: string;
+    signAlgorithmOid?: string;
+    sad?: string;
+    useAuthorizeEndpoint?: boolean;
+    authorizeAuthData?: CscAuthorizeAuthData[];
+    apiPath?: string;
+}
+
+/**
+ * CSC (Cloud Signature Consortium) adapter.
+ *
+ * Integrates with CSC v2 APIs for remote signing:
+ * - credentials/list
+ * - credentials/info
+ * - signatures/signHash
+ *
+ * Optional SAD acquisition via credentials/authorize is supported when
+ * configured.
+ */
+export class CscKmsAdapter implements KmsAdapter {
+    private readonly logger = new Logger(CscKmsAdapter.name);
+
+    readonly providerId: string;
+    readonly type: KmsProviderType = "csc";
+    readonly capabilities: KmsAdapterCapabilities = {
+        canCreate: true,
+        canImport: false,
+        canDelete: false,
+        supportedAlgs: ["ES256"],
+        defaultAlg: "ES256",
+    };
+
+    private readonly baseUrl: string;
+    private readonly tokenUrl: string;
+    private readonly clientId: string;
+    private readonly clientSecret: string;
+    private readonly scope?: string;
+    private readonly configuredCredentialId?: string;
+    private readonly userId?: string;
+    private readonly hashAlgorithmOid: string;
+    private readonly signAlgorithmOid: string;
+    private readonly configuredSad?: string;
+    private readonly useAuthorizeEndpoint: boolean;
+    private readonly authorizeAuthData?: CscAuthorizeAuthData[];
+    private readonly apiPath: string;
+    private readonly jwkCache = new PublicJwkCache();
+
+    private oauth2TokenCache: {
+        accessToken: string;
+        expiresAt: number;
+    } | null = null;
+
+    private resolvedCredentialId: string | null = null;
+
+    constructor(
+        config: CscKmsAdapterConfig,
+        private readonly http: HttpService,
+    ) {
+        this.providerId = config.providerId;
+        this.baseUrl = config.baseUrl.replace(/\/$/, "");
+        this.tokenUrl = config.tokenUrl;
+        this.clientId = config.clientId;
+        this.clientSecret = config.clientSecret;
+        this.scope = config.scope;
+        this.configuredCredentialId = config.credentialId;
+        this.userId = config.userId;
+        this.hashAlgorithmOid =
+            config.hashAlgorithmOid || DEFAULT_HASH_ALGORITHM_OID;
+        this.signAlgorithmOid =
+            config.signAlgorithmOid || DEFAULT_SIGN_ALGORITHM_OID;
+        this.configuredSad = config.sad;
+        this.useAuthorizeEndpoint = Boolean(config.useAuthorizeEndpoint);
+        this.authorizeAuthData = config.authorizeAuthData;
+        this.apiPath = config.apiPath ?? DEFAULT_API_PATH;
+    }
+
+    async generateKey(opts: {
+        kid: string;
+        alg?: KmsSigningAlg;
+    }): Promise<KmsKeyMaterial> {
+        const alg = opts.alg ?? this.capabilities.defaultAlg;
+        this.assertSupported(alg);
+
+        const credentialId = await this.resolveCredentialId();
+        const publicJwk = await this.fetchPublicJwk(
+            credentialId,
+            alg,
+            opts.kid,
+        );
+
+        return {
+            ref: {
+                externalKeyId: credentialId,
+                publicJwk,
+                alg,
+            },
+        };
+    }
+
+    importKey(_opts: {
+        kid: string;
+        privateJwk: JWK;
+        alg?: KmsSigningAlg;
+    }): Promise<KmsKeyMaterial> {
+        throw new NotImplementedException(
+            `CscKmsAdapter[${this.providerId}]: importKey is not supported by CSC provider`,
+        );
+    }
+
+    async sign(
+        ref: KmsKeyRef,
+        data: Uint8Array,
+        alg?: KmsSigningAlg,
+    ): Promise<Uint8Array> {
+        const signAlg = alg ?? ref.alg;
+        this.assertSupported(signAlg);
+
+        const credentialId =
+            ref.externalKeyId ||
+            this.configuredCredentialId ||
+            (await this.resolveCredentialId());
+
+        const digest = createHash("sha256").update(Buffer.from(data)).digest();
+        const digestB64 = digest.toString("base64");
+        const sad = await this.resolveSad(credentialId, digestB64);
+
+        const body: Record<string, unknown> = {
+            credentialID: credentialId,
+            hashes: [digestB64],
+            hashAlgorithmOID: this.hashAlgorithmOid,
+            signAlgo: this.signAlgorithmOid,
+        };
+        if (sad) {
+            body.SAD = sad;
+        }
+
+        const response = await firstValueFrom(
+            this.http.post<{
+                signatures?: string[];
+                signature?: string;
+            }>(
+                this.endpoint("/signatures/signHash"),
+                body,
+                await this.requestConfig(),
+            ),
+        );
+
+        const encoded =
+            response.data?.signatures?.[0] ?? response.data?.signature;
+        if (!encoded) {
+            throw new Error(
+                `CscKmsAdapter[${this.providerId}]: signatures/signHash returned no signature`,
+            );
+        }
+
+        const signatureBytes = base64UrlOrBase64ToBytes(encoded);
+        if (signatureBytes.length === 64) {
+            return signatureBytes;
+        }
+
+        if (signatureBytes[0] === 0x30) {
+            return derEcdsaToRaw(signatureBytes, 32);
+        }
+
+        throw new Error(
+            `CscKmsAdapter[${this.providerId}]: unsupported signature format returned by CSC provider`,
+        );
+    }
+
+    async deleteKey(_ref: KmsKeyRef): Promise<void> {
+        // CSC credentials are managed externally.
+    }
+
+    async health(): Promise<KmsHealthResult> {
+        const start = Date.now();
+        try {
+            await this.resolveCredentialId();
+            return { ok: true, latencyMs: Date.now() - start };
+        } catch (err) {
+            return {
+                ok: false,
+                latencyMs: Date.now() - start,
+                error: String(err),
+            };
+        }
+    }
+
+    private async resolveCredentialId(): Promise<string> {
+        if (this.configuredCredentialId) {
+            this.resolvedCredentialId = this.configuredCredentialId;
+            return this.configuredCredentialId;
+        }
+        if (this.resolvedCredentialId) {
+            return this.resolvedCredentialId;
+        }
+
+        const body: Record<string, unknown> = {
+            certInfo: true,
+            authInfo: true,
+            credentialInfo: true,
+            onlyValid: true,
+        };
+        if (this.userId) {
+            body.userID = this.userId;
+        }
+
+        const response = await firstValueFrom(
+            this.http.post<{
+                credentialIDs?: string[];
+                credentialIds?: string[];
+            }>(
+                this.endpoint("/credentials/list"),
+                body,
+                await this.requestConfig(),
+            ),
+        );
+
+        const ids =
+            response.data?.credentialIDs ?? response.data?.credentialIds;
+        const credentialId = ids?.[0];
+        if (!credentialId) {
+            throw new Error(
+                `CscKmsAdapter[${this.providerId}]: credentials/list returned no credential IDs and no credentialId is configured`,
+            );
+        }
+        this.resolvedCredentialId = credentialId;
+        return credentialId;
+    }
+
+    private async fetchPublicJwk(
+        credentialId: string,
+        alg: KmsSigningAlg,
+        kid: string,
+    ): Promise<JWK> {
+        const cacheKey = `${credentialId}:${kid}`;
+        const cached = this.jwkCache.get(cacheKey);
+        if (cached) {
+            return cached;
+        }
+
+        const response = await firstValueFrom(
+            this.http.post<Record<string, unknown>>(
+                this.endpoint("/credentials/info"),
+                {
+                    credentialID: credentialId,
+                    certInfo: true,
+                    authInfo: true,
+                },
+                await this.requestConfig(),
+            ),
+        );
+
+        const certEntry = extractFirstCertificate(response.data);
+        if (!certEntry) {
+            throw new Error(
+                `CscKmsAdapter[${this.providerId}]: credentials/info returned no certificate data for credential ${credentialId}`,
+            );
+        }
+
+        const certPem = normalizeCertificateToPem(certEntry);
+        const x509 = new X509Certificate(certPem);
+        const jwk = x509.publicKey.export({ format: "jwk" }) as JWK;
+        jwk.kid = kid;
+        jwk.alg = alg;
+
+        this.jwkCache.set(cacheKey, jwk);
+        return jwk;
+    }
+
+    private async resolveSad(
+        credentialId: string,
+        digestB64: string,
+    ): Promise<string | undefined> {
+        if (this.configuredSad) {
+            return this.configuredSad;
+        }
+        if (!this.useAuthorizeEndpoint) {
+            return undefined;
+        }
+
+        const body: Record<string, unknown> = {
+            credentialID: credentialId,
+            numSignatures: 1,
+            hashes: [digestB64],
+            hashAlgorithmOID: this.hashAlgorithmOid,
+        };
+        if (this.authorizeAuthData?.length) {
+            body.authData = this.authorizeAuthData;
+        }
+
+        const response = await firstValueFrom(
+            this.http.post<{ SAD?: string; sad?: string }>(
+                this.endpoint("/credentials/authorize"),
+                body,
+                await this.requestConfig(),
+            ),
+        );
+
+        const sad = response.data?.SAD ?? response.data?.sad;
+        if (!sad) {
+            throw new Error(
+                `CscKmsAdapter[${this.providerId}]: credentials/authorize returned no SAD`,
+            );
+        }
+        return sad;
+    }
+
+    private endpoint(path: string): string {
+        return `${this.baseUrl}${this.apiPath}${path}`;
+    }
+
+    private async requestConfig(): Promise<{
+        headers: Record<string, string>;
+    }> {
+        const token = await this.getOAuth2Token();
+        return {
+            headers: {
+                Authorization: `Bearer ${token}`,
+            },
+        };
+    }
+
+    private async getOAuth2Token(): Promise<string> {
+        const now = Date.now();
+        if (this.oauth2TokenCache && this.oauth2TokenCache.expiresAt > now) {
+            return this.oauth2TokenCache.accessToken;
+        }
+
+        const params = new URLSearchParams({
+            grant_type: "client_credentials",
+            client_id: this.clientId,
+            client_secret: this.clientSecret,
+        });
+        if (this.scope) {
+            params.set("scope", this.scope);
+        }
+
+        const response = await firstValueFrom(
+            this.http.post<{ access_token: string; expires_in?: number }>(
+                this.tokenUrl,
+                params.toString(),
+                {
+                    headers: {
+                        "Content-Type": "application/x-www-form-urlencoded",
+                    },
+                },
+            ),
+        );
+
+        const accessToken = response.data?.access_token;
+        if (!accessToken) {
+            throw new Error(
+                `CscKmsAdapter[${this.providerId}]: token endpoint returned no access_token`,
+            );
+        }
+
+        const expiresIn = response.data?.expires_in ?? 3600;
+        this.oauth2TokenCache = {
+            accessToken,
+            expiresAt: now + Math.max(expiresIn - 30, 10) * 1000,
+        };
+
+        return accessToken;
+    }
+
+    private assertSupported(alg: KmsSigningAlg): void {
+        if (!this.capabilities.supportedAlgs.includes(alg)) {
+            throw new Error(
+                `CscKmsAdapter[${this.providerId}]: unsupported alg '${alg}'`,
+            );
+        }
+    }
+}
+
+function extractFirstCertificate(
+    data: Record<string, unknown>,
+): string | undefined {
+    const certObject = (data.cert as Record<string, unknown> | undefined) || {};
+    const certs =
+        (certObject.certificates as unknown[] | undefined) ||
+        (certObject.certificateChain as unknown[] | undefined) ||
+        (data.certificates as unknown[] | undefined);
+
+    const first = certs?.[0];
+    if (typeof first === "string" && first.length > 0) {
+        return first;
+    }
+
+    const single = data.certificate;
+    if (typeof single === "string" && single.length > 0) {
+        return single;
+    }
+
+    return undefined;
+}
+
+function normalizeCertificateToPem(value: string): string {
+    const trimmed = value.trim();
+    if (trimmed.includes("-----BEGIN CERTIFICATE-----")) {
+        return trimmed;
+    }
+
+    const normalized = trimmed.replace(/\s+/g, "");
+    const body =
+        Buffer.from(normalized, "base64")
+            .toString("base64")
+            .match(/.{1,64}/g)
+            ?.join("\n") || "";
+    return `-----BEGIN CERTIFICATE-----\n${body}\n-----END CERTIFICATE-----`;
+}
+
+function base64UrlOrBase64ToBytes(s: string): Uint8Array {
+    const normalized = s.replaceAll("-", "+").replaceAll("_", "/");
+    const padded = normalized + "=".repeat((4 - (normalized.length % 4)) % 4);
+    return new Uint8Array(Buffer.from(padded, "base64"));
+}
+
+function derEcdsaToRaw(der: Uint8Array, coordLength: number): Uint8Array {
+    let offset = 0;
+    if (der[offset++] !== 0x30) {
+        throw new Error("Invalid ECDSA signature: missing SEQUENCE tag");
+    }
+
+    let seqLen = der[offset++];
+    if (seqLen & 0x80) {
+        const lenOfLen = seqLen & 0x7f;
+        seqLen = 0;
+        for (let i = 0; i < lenOfLen; i++) {
+            seqLen = (seqLen << 8) | der[offset++];
+        }
+    }
+
+    const readInt = (): Uint8Array => {
+        if (der[offset++] !== 0x02) {
+            throw new Error("Invalid ECDSA signature: missing INTEGER tag");
+        }
+
+        let len = der[offset++];
+        if (len & 0x80) {
+            const lenOfLen = len & 0x7f;
+            len = 0;
+            for (let i = 0; i < lenOfLen; i++) {
+                len = (len << 8) | der[offset++];
+            }
+        }
+
+        let value = der.subarray(offset, offset + len);
+        offset += len;
+        if (value.length > coordLength && value[0] === 0x00) {
+            value = value.subarray(1);
+        }
+        return value;
+    };
+
+    const r = readInt();
+    const s = readInt();
+    const out = new Uint8Array(coordLength * 2);
+    out.set(r, coordLength - r.length);
+    out.set(s, coordLength * 2 - s.length);
+    return out;
+}

--- a/apps/backend/src/crypto/key/kms/kms-adapter.ts
+++ b/apps/backend/src/crypto/key/kms/kms-adapter.ts
@@ -12,7 +12,7 @@ export type KmsSigningAlg = "ES256";
  *
  * - For the `db` provider: `privateJwk` is populated (key material lives in
  *   the DB column, encrypted at rest).
- * - For external providers (`vault`, `aws-kms`): `externalKeyId` identifies
+ * - For external providers (`vault`, `aws-kms`, `csc`): `externalKeyId` identifies
  *   the key inside the provider (e.g. Vault key name, AWS KMS key ID/ARN)
  *   and the private key never leaves the provider.
  *
@@ -52,7 +52,7 @@ export interface KmsAdapterCapabilities {
  * Provider-agnostic contract for key material operations.
  *
  * Implementations encapsulate the storage and signing backend (database,
- * HashiCorp Vault, AWS KMS, ...). For non-`db` providers the private key
+ * HashiCorp Vault, AWS KMS, CSC, ...). For non-`db` providers the private key
  * material MUST stay inside the backend — adapters never return private
  * CryptoKey objects. Certificate construction routes its signing
  * operations through a custom `@peculiar/x509` crypto provider that

--- a/apps/backend/src/crypto/key/kms/kms-provider.registry.ts
+++ b/apps/backend/src/crypto/key/kms/kms-provider.registry.ts
@@ -15,6 +15,7 @@ import { KmsCryptoProvider } from "./kms-crypto-provider";
 import type { KmsProviderInfoDto } from "../dto/kms-provider-capabilities.dto";
 import type { KmsProvidersResponseDto } from "../dto/kms-providers-response.dto";
 import { AwsKmsAdapter } from "./adapters/aws-kms.adapter";
+import { CscKmsAdapter } from "./adapters/csc-kms.adapter";
 import { DbKmsAdapter } from "./adapters/db-kms.adapter";
 import { HttpKmsAdapter } from "./adapters/http-kms.adapter";
 import { Pkcs11KmsAdapter } from "./adapters/pkcs11-kms.adapter";
@@ -181,6 +182,31 @@ export class KmsProviderRegistry implements OnModuleInit {
                         keysPath: p.keysPath,
                         healthPath: p.healthPath,
                         canImport: p.canImport,
+                    },
+                    this.httpService,
+                );
+            }
+            case "csc": {
+                const p = provider as Extract<
+                    KmsProviderConfigDto,
+                    { type: "csc" }
+                >;
+                return new CscKmsAdapter(
+                    {
+                        providerId: provider.id,
+                        baseUrl: p.baseUrl,
+                        tokenUrl: p.tokenUrl,
+                        clientId: p.clientId,
+                        clientSecret: p.clientSecret,
+                        scope: p.scope,
+                        credentialId: p.credentialId,
+                        userId: p.userId,
+                        apiPath: p.apiPath,
+                        hashAlgorithmOid: p.hashAlgorithmOid,
+                        signAlgorithmOid: p.signAlgorithmOid,
+                        sad: p.sad,
+                        useAuthorizeEndpoint: p.useAuthorizeEndpoint,
+                        authorizeAuthData: p.authorizeAuthData,
                     },
                     this.httpService,
                 );

--- a/apps/backend/test/key/csc-kms.e2e-spec.ts
+++ b/apps/backend/test/key/csc-kms.e2e-spec.ts
@@ -1,0 +1,352 @@
+import { createSign, createPrivateKey } from "node:crypto";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import {
+    type IncomingMessage,
+    type Server,
+    type ServerResponse,
+    createServer,
+} from "node:http";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { INestApplication, ValidationPipe } from "@nestjs/common";
+import { ConfigModule, ConfigService } from "@nestjs/config";
+import { Test, TestingModule } from "@nestjs/testing";
+import request from "supertest";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { AppModule } from "../../src/app.module";
+import { KeyChainType } from "../../src/crypto/key/dto/key-chain-create.dto";
+import { getToken } from "../utils";
+
+const PROVIDER_ID = "csc-test";
+const CSC_CREDENTIAL_ID = "[INTESIQCSEALEC]_SEAL_351_SIGN_1781018892758";
+const CSC_USER_ID = "eudiplo_user";
+const CSC_PIN = "1123581321";
+const CSC_ACCESS_TOKEN = "mock-csc-access-token";
+const CSC_SAD = "mock-csc-sad-token";
+
+function readBody(req: IncomingMessage): Promise<string> {
+    return new Promise((resolve, reject) => {
+        const chunks: Buffer[] = [];
+        req.on("data", (chunk: Buffer) => chunks.push(chunk));
+        req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+        req.on("error", reject);
+    });
+}
+
+function sendJson(res: ServerResponse, status: number, body: unknown): void {
+    res.writeHead(status, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(body));
+}
+
+function base64UrlOrBase64ToBuffer(value: string): Buffer {
+    const normalized = value.replaceAll("-", "+").replaceAll("_", "/");
+    const padded = normalized + "=".repeat((4 - (normalized.length % 4)) % 4);
+    return Buffer.from(padded, "base64");
+}
+
+type RouteHandler = (
+    req: IncomingMessage,
+    res: ServerResponse,
+) => Promise<boolean>;
+
+function buildCscRouteHandlers(input: {
+    privateKey: ReturnType<typeof createPrivateKey>;
+    certificatePem: string;
+}): RouteHandler[] {
+    const { privateKey, certificatePem } = input;
+
+    const tokenHandler: RouteHandler = async (req, res) => {
+        if (req.method !== "POST" || req.url !== "/oauth2/token") {
+            return false;
+        }
+
+        const body = new URLSearchParams(await readBody(req));
+        if (
+            body.get("grant_type") !== "client_credentials" ||
+            body.get("client_id") !== "eudiplo-test" ||
+            body.get("client_secret") !== "test-secret"
+        ) {
+            sendJson(res, 401, { error: "invalid_client" });
+            return true;
+        }
+
+        sendJson(res, 200, {
+            access_token: CSC_ACCESS_TOKEN,
+            token_type: "Bearer",
+            expires_in: 3600,
+        });
+        return true;
+    };
+
+    const listHandler: RouteHandler = async (req, res) => {
+        if (req.method !== "POST" || req.url !== "/csc/v2/credentials/list") {
+            return false;
+        }
+
+        const payload = JSON.parse(await readBody(req)) as { userID?: string };
+        if (payload.userID !== CSC_USER_ID) {
+            sendJson(res, 400, { error: "invalid_user" });
+            return true;
+        }
+
+        sendJson(res, 200, { credentialIDs: [CSC_CREDENTIAL_ID] });
+        return true;
+    };
+
+    const infoHandler: RouteHandler = async (req, res) => {
+        if (req.method !== "POST" || req.url !== "/csc/v2/credentials/info") {
+            return false;
+        }
+
+        const payload = JSON.parse(await readBody(req)) as {
+            credentialID?: string;
+        };
+        if (payload.credentialID !== CSC_CREDENTIAL_ID) {
+            sendJson(res, 404, { error: "credential_not_found" });
+            return true;
+        }
+
+        const certB64 = certificatePem
+            .replace("-----BEGIN CERTIFICATE-----", "")
+            .replace("-----END CERTIFICATE-----", "")
+            .replace(/\s+/g, "");
+        sendJson(res, 200, {
+            cert: {
+                certificates: [certB64],
+            },
+        });
+        return true;
+    };
+
+    const authorizeHandler: RouteHandler = async (req, res) => {
+        if (
+            req.method !== "POST" ||
+            req.url !== "/csc/v2/credentials/authorize"
+        ) {
+            return false;
+        }
+
+        const payload = JSON.parse(await readBody(req)) as {
+            credentialID?: string;
+            authData?: Array<{ id?: string; value?: string }>;
+        };
+        const pin = payload.authData?.find((a) => a.id === "PIN")?.value;
+        if (payload.credentialID !== CSC_CREDENTIAL_ID || pin !== CSC_PIN) {
+            sendJson(res, 401, { error: "invalid_auth_data" });
+            return true;
+        }
+
+        sendJson(res, 200, { SAD: CSC_SAD });
+        return true;
+    };
+
+    const signHandler: RouteHandler = async (req, res) => {
+        if (
+            req.method !== "POST" ||
+            req.url !== "/csc/v2/signatures/signHash"
+        ) {
+            return false;
+        }
+
+        const payload = JSON.parse(await readBody(req)) as {
+            credentialID?: string;
+            SAD?: string;
+            hashes?: string[];
+        };
+        if (
+            payload.credentialID !== CSC_CREDENTIAL_ID ||
+            payload.SAD !== CSC_SAD ||
+            !payload.hashes?.[0]
+        ) {
+            sendJson(res, 400, { error: "invalid_sign_request" });
+            return true;
+        }
+
+        const digest = base64UrlOrBase64ToBuffer(payload.hashes[0]);
+        const signer = createSign("SHA256");
+        signer.update(digest);
+        signer.end();
+        const derSignature = signer.sign(privateKey);
+
+        sendJson(res, 200, {
+            signatures: [derSignature.toString("base64")],
+        });
+        return true;
+    };
+
+    return [
+        tokenHandler,
+        listHandler,
+        infoHandler,
+        authorizeHandler,
+        signHandler,
+    ];
+}
+
+async function dispatchCscRequest(
+    req: IncomingMessage,
+    res: ServerResponse,
+    handlers: RouteHandler[],
+): Promise<void> {
+    if (
+        req.url !== "/oauth2/token" &&
+        req.headers.authorization !== `Bearer ${CSC_ACCESS_TOKEN}`
+    ) {
+        sendJson(res, 401, { error: "unauthorized" });
+        return;
+    }
+
+    for (const handler of handlers) {
+        if (await handler(req, res)) {
+            return;
+        }
+    }
+
+    sendJson(res, 404, { error: "not_found" });
+}
+
+function startCscServer(): Promise<{ server: Server; baseUrl: string }> {
+    const privateKeyPem = readFileSync(join(__dirname, "../key.pem"), "utf8");
+    const certificatePem = readFileSync(join(__dirname, "../cert.pem"), "utf8");
+    const privateKey = createPrivateKey(privateKeyPem);
+    const handlers = buildCscRouteHandlers({ privateKey, certificatePem });
+
+    const server = createServer(async (req, res) => {
+        try {
+            await dispatchCscRequest(req, res, handlers);
+        } catch (err) {
+            sendJson(res, 500, { error: String(err) });
+        }
+    });
+
+    return new Promise((resolve) => {
+        server.listen(0, "127.0.0.1", () => {
+            const { port } = server.address() as AddressInfo;
+            resolve({ server, baseUrl: `http://127.0.0.1:${port}` });
+        });
+    });
+}
+
+describe("Key Chain - CSC KMS adapter (e2e)", () => {
+    let cscServer: Server;
+    let app: INestApplication;
+    let authToken: string;
+
+    beforeAll(async () => {
+        const { server, baseUrl } = await startCscServer();
+        cscServer = server;
+
+        const tmpConfigDir = mkdtempSync(
+            join(tmpdir(), "eudiplo-csc-kms-test-"),
+        );
+        writeFileSync(
+            join(tmpConfigDir, "kms.json"),
+            JSON.stringify({
+                defaultProvider: PROVIDER_ID,
+                providers: [
+                    { id: "db", type: "db" },
+                    {
+                        id: PROVIDER_ID,
+                        type: "csc",
+                        baseUrl,
+                        tokenUrl: `${baseUrl}/oauth2/token`,
+                        clientId: "eudiplo-test",
+                        clientSecret: "test-secret",
+                        scope: "service",
+                        userId: CSC_USER_ID,
+                        useAuthorizeEndpoint: true,
+                        authorizeAuthData: [
+                            {
+                                id: "PIN",
+                                value: CSC_PIN,
+                            },
+                        ],
+                    },
+                ],
+            }),
+        );
+
+        const moduleFixture: TestingModule = await Test.createTestingModule({
+            imports: [
+                ConfigModule.forRoot({
+                    isGlobal: true,
+                    load: [() => ({ CONFIG_FOLDER: tmpConfigDir })],
+                }),
+                AppModule,
+            ],
+        }).compile();
+
+        app = moduleFixture.createNestApplication();
+        app.useGlobalPipes(new ValidationPipe());
+        await app.init();
+
+        const configService = app.get(ConfigService);
+        const clientId = configService.getOrThrow<string>("AUTH_CLIENT_ID");
+        const clientSecret =
+            configService.getOrThrow<string>("AUTH_CLIENT_SECRET");
+        authToken = await getToken(app, clientId, clientSecret);
+    });
+
+    afterAll(async () => {
+        await app?.close();
+        await new Promise<void>((resolve) => cscServer?.close(() => resolve()));
+    });
+
+    test("csc provider is listed with expected capabilities", async () => {
+        const res = await request(app.getHttpServer())
+            .get("/key-chain/providers")
+            .set("Authorization", `Bearer ${authToken}`)
+            .expect(200);
+
+        const provider = res.body.providers.find(
+            (p: { name: string }) => p.name === PROVIDER_ID,
+        );
+
+        expect(provider).toBeDefined();
+        expect(provider.type).toBe("csc");
+        expect(provider.capabilities.canCreate).toBe(true);
+        expect(provider.capabilities.canImport).toBe(false);
+        expect(provider.capabilities.canDelete).toBe(false);
+    });
+
+    test("csc provider health check passes", async () => {
+        const res = await request(app.getHttpServer())
+            .get("/key-chain/providers/health")
+            .set("Authorization", `Bearer ${authToken}`)
+            .expect(200);
+
+        const providerHealth = res.body.find(
+            (p: { providerId: string }) => p.providerId === PROVIDER_ID,
+        );
+
+        expect(providerHealth).toBeDefined();
+        expect(providerHealth.ok).toBe(true);
+    });
+
+    test("create key chain with CSC provider", async () => {
+        const createRes = await request(app.getHttpServer())
+            .post("/key-chain")
+            .set("Authorization", `Bearer ${authToken}`)
+            .send({
+                type: KeyChainType.Standalone,
+                usageType: "access",
+                kmsProvider: PROVIDER_ID,
+                description: "csc kms e2e test",
+            })
+            .expect(201);
+
+        const keyChainId: string = createRes.body.id;
+        expect(keyChainId).toBeDefined();
+
+        const keyRes = await request(app.getHttpServer())
+            .get(`/key-chain/${keyChainId}`)
+            .set("Authorization", `Bearer ${authToken}`)
+            .expect(200);
+
+        expect(keyRes.body.kmsProvider).toBe(PROVIDER_ID);
+        expect(keyRes.body.activePublicKey.kty).toBe("EC");
+
+        expect(keyRes.body.activeCertificate).toBeDefined();
+    });
+});

--- a/apps/client/src/app/app.component.html
+++ b/apps/client/src/app/app.component.html
@@ -135,6 +135,15 @@
             <mat-icon matListItemIcon>vpn_key</mat-icon>
             <span matListItemTitle>Keys</span>
           </mat-list-item>
+
+          <mat-list-item
+            [routerLink]="['/keys/providers']"
+            routerLinkActive="active-link"
+            (click)="closeSidenavOnMobile()"
+          >
+            <mat-icon matListItemIcon>dns</mat-icon>
+            <span matListItemTitle>KMS Providers</span>
+          </mat-list-item>
         }
 
         <!-- Credential Issuance Section -->

--- a/apps/client/src/app/key-management/key-chain.service.ts
+++ b/apps/client/src/app/key-management/key-chain.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import {
+  type KmsProvidersResponseDto,
   type KeyChainCreateDto,
   type KeyChainResponseDto,
   type KeyChainUpdateDto,
@@ -8,6 +9,8 @@ import {
   keyChainControllerExport,
   keyChainControllerGetAll,
   keyChainControllerGetById,
+  keyChainControllerGetProviders,
+  keyChainControllerGetProvidersHealth,
   keyChainControllerRotate,
   keyChainControllerUpdate,
 } from '@eudiplo/sdk-core';
@@ -24,6 +27,40 @@ import {
   providedIn: 'root',
 })
 export class KeyChainService {
+  /**
+   * Get available KMS providers and configured default provider.
+   */
+  async getProviders(): Promise<KmsProvidersResponseDto> {
+    const response = await keyChainControllerGetProviders();
+    return response.data as KmsProvidersResponseDto;
+  }
+
+  /**
+   * Get runtime health for all configured KMS providers.
+   */
+  async getProvidersHealth(): Promise<
+    {
+      providerId: string;
+      type: string;
+      ok: boolean;
+      latencyMs?: number;
+      error?: string;
+    }[]
+  > {
+    const response = await keyChainControllerGetProvidersHealth();
+    return (
+      (response.data as
+        | {
+            providerId: string;
+            type: string;
+            ok: boolean;
+            latencyMs?: number;
+            error?: string;
+          }[]
+        | undefined) || []
+    );
+  }
+
   /**
    * Get all key chains for the current tenant.
    */

--- a/apps/client/src/app/key-management/key-create-wizard/key-create-wizard.component.html
+++ b/apps/client/src/app/key-management/key-create-wizard/key-create-wizard.component.html
@@ -249,6 +249,26 @@
                 />
                 <mat-hint>Optional description for this key chain</mat-hint>
               </mat-form-field>
+
+              <mat-form-field appearance="outline">
+                <mat-label>KMS Provider</mat-label>
+                <mat-select formControlName="kmsProvider" [disabled]="isLoadingKmsProviders">
+                  @if (availableKmsProviders.length > 0) {
+                    @for (provider of availableKmsProviders; track provider.name) {
+                      <mat-option [value]="provider.name">
+                        {{ provider.name }} ({{ provider.type }})
+                      </mat-option>
+                    }
+                  } @else {
+                    <mat-option value="db">db (fallback)</mat-option>
+                  }
+                </mat-select>
+                @if (isLoadingKmsProviders) {
+                  <mat-hint>Loading configured providers...</mat-hint>
+                } @else {
+                  <mat-hint> Selected provider stores and signs with this key chain. </mat-hint>
+                }
+              </mat-form-field>
             </mat-card-content>
           </mat-card>
 

--- a/apps/client/src/app/key-management/key-create-wizard/key-create-wizard.component.ts
+++ b/apps/client/src/app/key-management/key-create-wizard/key-create-wizard.component.ts
@@ -12,11 +12,11 @@ import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatStepper, MatStepperModule } from '@angular/material/stepper';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
-import { Router, RouterModule } from '@angular/router';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { FlexLayoutModule } from 'ngx-flexible-layout';
 import { KeyChainService } from '../key-chain.service';
 import { RegistrarConfig, RegistrarService } from '../../registrar/registrar.service';
-import { KeyChainCreateDto } from '@eudiplo/sdk-core';
+import { KeyChainCreateDto, KmsProviderInfoDto } from '@eudiplo/sdk-core';
 
 export type KeyUsageSelection = 'attestation' | 'statusList' | 'access' | 'trustList';
 export type KeyChainTypeSelection = 'internalChain' | 'standalone';
@@ -57,8 +57,11 @@ export class KeyCreateWizardComponent implements OnInit {
 
   isSubmitting = false;
   isCheckingRegistrar = false;
+  isLoadingKmsProviders = false;
   registrarConfig: RegistrarConfig | null = null;
   registrarConfigChecked = false;
+  availableKmsProviders: KmsProviderInfoDto[] = [];
+  defaultKmsProvider = 'db';
 
   // Usage options with descriptions
   usageOptions = [
@@ -134,6 +137,7 @@ export class KeyCreateWizardComponent implements OnInit {
     private readonly fb: FormBuilder,
     private readonly keyChainService: KeyChainService,
     private readonly registrarService: RegistrarService,
+    private readonly route: ActivatedRoute,
     private readonly router: Router,
     private readonly snackBar: MatSnackBar
   ) {
@@ -156,6 +160,8 @@ export class KeyCreateWizardComponent implements OnInit {
     this.configForm = this.fb.group({
       // Description for the key chain
       description: [''],
+      // KMS provider for key storage/signing
+      kmsProvider: ['db', Validators.required],
       // Rotation settings (only for internal chain)
       rotationEnabled: [true],
       rotationIntervalDays: [30, [Validators.min(1)]],
@@ -166,6 +172,42 @@ export class KeyCreateWizardComponent implements OnInit {
   ngOnInit(): void {
     // Pre-check registrar config so we can show status quickly
     this.checkRegistrarConfig();
+    this.loadKmsProviders();
+  }
+
+  /**
+   * Load available KMS providers and preselect backend default provider.
+   */
+  async loadKmsProviders(): Promise<void> {
+    this.isLoadingKmsProviders = true;
+    try {
+      const response = await this.keyChainService.getProviders();
+      this.availableKmsProviders = response.providers || [];
+      this.defaultKmsProvider = response.default || 'db';
+
+      const requestedProvider = this.route.snapshot.queryParamMap.get('kmsProvider');
+      const requestedIsValid =
+        requestedProvider != null &&
+        this.availableKmsProviders.some((p) => p.name === requestedProvider);
+
+      const selected =
+        (requestedIsValid ? requestedProvider : null) ||
+        this.availableKmsProviders.find((p) => p.name === this.defaultKmsProvider)?.name ||
+        this.availableKmsProviders[0]?.name ||
+        'db';
+
+      this.configForm.patchValue({ kmsProvider: selected });
+    } catch (error) {
+      console.error('Failed to load KMS providers:', error);
+      this.availableKmsProviders = [];
+      this.defaultKmsProvider = 'db';
+      this.configForm.patchValue({ kmsProvider: 'db' });
+      this.snackBar.open('Failed to load KMS providers. Falling back to db.', 'Close', {
+        duration: 3000,
+      });
+    } finally {
+      this.isLoadingKmsProviders = false;
+    }
   }
 
   /**
@@ -285,7 +327,7 @@ export class KeyCreateWizardComponent implements OnInit {
         usageType: usage,
         type: usage === 'access' || !this.isInternalChain ? 'standalone' : 'internalChain',
         description: description || this.getDefaultDescription(),
-        kmsProvider: 'db', // Default to database storage
+        kmsProvider: this.configForm.value.kmsProvider || this.defaultKmsProvider || 'db',
         rotationPolicy: {
           enabled: this.rotationEnabled,
           intervalDays: this.rotationEnabled
@@ -411,6 +453,15 @@ export class KeyCreateWizardComponent implements OnInit {
 
     if (this.configForm.value.description) {
       summary.push({ label: 'Description', value: this.configForm.value.description });
+    }
+
+    const selectedKmsProvider = this.configForm.value.kmsProvider;
+    if (selectedKmsProvider) {
+      const providerInfo = this.availableKmsProviders.find((p) => p.name === selectedKmsProvider);
+      summary.push({
+        label: 'KMS Provider',
+        value: providerInfo ? `${providerInfo.name} (${providerInfo.type})` : selectedKmsProvider,
+      });
     }
 
     if (this.isInternalChain) {

--- a/apps/client/src/app/key-management/key-management-list/key-management-list.component.html
+++ b/apps/client/src/app/key-management/key-management-list/key-management-list.component.html
@@ -2,6 +2,10 @@
   <div fxLayout="row" fxLayoutAlign="space-between center" class="header">
     <h2>Key Management</h2>
     <div fxLayout="row" fxLayoutGap="8px">
+      <button mat-stroked-button [routerLink]="['providers']">
+        <mat-icon>dns</mat-icon>
+        Providers
+      </button>
       @if (usageGroups.length > 0) {
         <button mat-icon-button (click)="collapseAll()" matTooltip="Collapse all">
           <mat-icon>unfold_less</mat-icon>

--- a/apps/client/src/app/key-management/key-management-providers/key-management-providers.component.html
+++ b/apps/client/src/app/key-management/key-management-providers/key-management-providers.component.html
@@ -1,0 +1,134 @@
+<div class="providers-container" fxLayout="column" fxLayoutGap="16px">
+  <div fxLayout="row" fxLayoutAlign="space-between center" class="header">
+    <div>
+      <h2>KMS Providers</h2>
+      <p class="subtitle">Configured key management systems and runtime health status.</p>
+    </div>
+    <div fxLayout="row" fxLayoutGap="8px">
+      <button mat-stroked-button type="button" [routerLink]="['/keys']">
+        <mat-icon>arrow_back</mat-icon>
+        Back to Keys
+      </button>
+      <button
+        mat-flat-button
+        color="primary"
+        type="button"
+        (click)="refresh()"
+        [disabled]="isLoading"
+      >
+        <mat-icon>refresh</mat-icon>
+        Refresh
+      </button>
+    </div>
+  </div>
+
+  @if (isLoading) {
+    <div class="loading" fxLayout="row" fxLayoutAlign="center center" fxLayoutGap="8px">
+      <mat-spinner diameter="28"></mat-spinner>
+      <span>Loading KMS providers...</span>
+    </div>
+  } @else {
+    <mat-card>
+      <mat-card-content>
+        <table mat-table [dataSource]="rows" class="providers-table">
+          <ng-container matColumnDef="name">
+            <th mat-header-cell *matHeaderCellDef>Provider</th>
+            <td mat-cell *matCellDef="let row">
+              <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="8px">
+                <span>{{ row.name }}</span>
+                @if (row.isDefault) {
+                  <mat-chip class="default-chip">Default</mat-chip>
+                }
+              </div>
+            </td>
+          </ng-container>
+
+          <ng-container matColumnDef="type">
+            <th mat-header-cell *matHeaderCellDef>Type</th>
+            <td mat-cell *matCellDef="let row">
+              <mat-chip>{{ row.type }}</mat-chip>
+            </td>
+          </ng-container>
+
+          <ng-container matColumnDef="capabilities">
+            <th mat-header-cell *matHeaderCellDef>Capabilities</th>
+            <td mat-cell *matCellDef="let row">
+              <div fxLayout="row" fxLayoutGap="6px" class="caps">
+                <mat-chip [class.cap-ok]="row.canCreate" [class.cap-off]="!row.canCreate"
+                  >create</mat-chip
+                >
+                <mat-chip [class.cap-ok]="row.canImport" [class.cap-off]="!row.canImport"
+                  >import</mat-chip
+                >
+                <mat-chip [class.cap-ok]="row.canDelete" [class.cap-off]="!row.canDelete"
+                  >delete</mat-chip
+                >
+              </div>
+            </td>
+          </ng-container>
+
+          <ng-container matColumnDef="algorithms">
+            <th mat-header-cell *matHeaderCellDef>Algorithms</th>
+            <td mat-cell *matCellDef="let row">
+              <div fxLayout="row" fxLayoutGap="6px" class="algs">
+                @for (alg of row.supportedAlgs; track alg) {
+                  <mat-chip>{{ alg }}</mat-chip>
+                }
+              </div>
+            </td>
+          </ng-container>
+
+          <ng-container matColumnDef="health">
+            <th mat-header-cell *matHeaderCellDef>Health</th>
+            <td mat-cell *matCellDef="let row">
+              @if (row.healthOk === true) {
+                <div
+                  fxLayout="row"
+                  fxLayoutAlign="start center"
+                  fxLayoutGap="6px"
+                  class="health ok"
+                >
+                  <mat-icon>check_circle</mat-icon>
+                  <span>OK</span>
+                  @if (row.latencyMs !== null) {
+                    <span class="latency">({{ row.latencyMs }} ms)</span>
+                  }
+                </div>
+              } @else if (row.healthOk === false) {
+                <div
+                  fxLayout="row"
+                  fxLayoutAlign="start center"
+                  fxLayoutGap="6px"
+                  class="health err"
+                  [matTooltip]="row.healthError || ''"
+                >
+                  <mat-icon>error</mat-icon>
+                  <span>Unavailable</span>
+                </div>
+              } @else {
+                <span class="muted">Unknown</span>
+              }
+            </td>
+          </ng-container>
+
+          <ng-container matColumnDef="actions">
+            <th mat-header-cell *matHeaderCellDef>Use</th>
+            <td mat-cell *matCellDef="let row">
+              <button
+                mat-button
+                type="button"
+                [routerLink]="['/keys/create']"
+                [queryParams]="{ kmsProvider: row.name }"
+              >
+                Create key
+              </button>
+            </td>
+          </ng-container>
+
+          <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+          <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+        </table>
+      </mat-card-content>
+    </mat-card>
+  }
+</div>

--- a/apps/client/src/app/key-management/key-management-providers/key-management-providers.component.scss
+++ b/apps/client/src/app/key-management/key-management-providers/key-management-providers.component.scss
@@ -1,0 +1,57 @@
+.providers-container {
+  padding: 24px;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.header {
+  h2 {
+    margin: 0;
+  }
+
+  .subtitle {
+    margin: 4px 0 0;
+    color: var(--mat-sys-on-surface-variant);
+  }
+}
+
+.loading {
+  padding: 32px;
+  color: var(--mat-sys-on-surface-variant);
+}
+
+.providers-table {
+  width: 100%;
+}
+
+.default-chip {
+  background: var(--mat-sys-primary-container);
+  color: var(--mat-sys-on-primary-container);
+}
+
+.caps,
+.algs {
+  flex-wrap: wrap;
+}
+
+.cap-ok {
+  background: var(--mat-sys-tertiary-container);
+  color: var(--mat-sys-on-tertiary-container);
+}
+
+.cap-off {
+  opacity: 0.6;
+}
+
+.health.ok {
+  color: var(--mat-sys-tertiary);
+}
+
+.health.err {
+  color: var(--mat-sys-error);
+}
+
+.latency,
+.muted {
+  color: var(--mat-sys-on-surface-variant);
+}

--- a/apps/client/src/app/key-management/key-management-providers/key-management-providers.component.ts
+++ b/apps/client/src/app/key-management/key-management-providers/key-management-providers.component.ts
@@ -1,0 +1,115 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatChipsModule } from '@angular/material/chips';
+import { MatIconModule } from '@angular/material/icon';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatTableModule } from '@angular/material/table';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { RouterModule } from '@angular/router';
+import { FlexLayoutModule } from 'ngx-flexible-layout';
+import { KmsProviderInfoDto } from '@eudiplo/sdk-core';
+import { KeyChainService } from '../key-chain.service';
+
+interface ProviderHealthItem {
+  providerId: string;
+  type: string;
+  ok: boolean;
+  latencyMs?: number;
+  error?: string;
+}
+
+interface ProviderRow {
+  name: string;
+  type: string;
+  isDefault: boolean;
+  canCreate: boolean;
+  canImport: boolean;
+  canDelete: boolean;
+  supportedAlgs: string[];
+  healthOk?: boolean;
+  latencyMs?: number;
+  healthError?: string;
+}
+
+@Component({
+  selector: 'app-key-management-providers',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatButtonModule,
+    MatCardModule,
+    MatChipsModule,
+    MatIconModule,
+    MatProgressSpinnerModule,
+    MatSnackBarModule,
+    MatTableModule,
+    MatTooltipModule,
+    RouterModule,
+    FlexLayoutModule,
+  ],
+  templateUrl: './key-management-providers.component.html',
+  styleUrl: './key-management-providers.component.scss',
+  changeDetection: ChangeDetectionStrategy.Eager,
+})
+export class KeyManagementProvidersComponent implements OnInit {
+  isLoading = false;
+  defaultProvider = 'db';
+  rows: ProviderRow[] = [];
+  displayedColumns = ['name', 'type', 'capabilities', 'algorithms', 'health', 'actions'];
+
+  constructor(
+    private readonly keyChainService: KeyChainService,
+    private readonly snackBar: MatSnackBar
+  ) {}
+
+  ngOnInit(): void {
+    this.loadProviders();
+  }
+
+  async refresh(): Promise<void> {
+    await this.loadProviders();
+  }
+
+  private async loadProviders(): Promise<void> {
+    this.isLoading = true;
+    try {
+      const [providersRes, healthRes] = await Promise.all([
+        this.keyChainService.getProviders(),
+        this.keyChainService.getProvidersHealth(),
+      ]);
+
+      this.defaultProvider = providersRes.default;
+      const healthByProvider = new Map<string, ProviderHealthItem>();
+      for (const h of healthRes) {
+        healthByProvider.set(h.providerId, h);
+      }
+
+      this.rows = providersRes.providers.map((provider) =>
+        this.toRow(provider, healthByProvider.get(provider.name))
+      );
+    } catch (error) {
+      console.error('Failed to load KMS providers:', error);
+      this.snackBar.open('Failed to load KMS providers', 'Dismiss', { duration: 4000 });
+    } finally {
+      this.isLoading = false;
+    }
+  }
+
+  private toRow(provider: KmsProviderInfoDto, health?: ProviderHealthItem): ProviderRow {
+    return {
+      name: provider.name,
+      type: provider.type,
+      isDefault: provider.name === this.defaultProvider,
+      canCreate: provider.capabilities.canCreate,
+      canImport: provider.capabilities.canImport,
+      canDelete: provider.capabilities.canDelete,
+      supportedAlgs: provider.capabilities.supportedAlgs,
+      healthOk: health?.ok,
+      latencyMs: health?.latencyMs,
+      healthError: health?.error,
+    };
+  }
+}

--- a/apps/client/src/app/key-management/key-management.routes.ts
+++ b/apps/client/src/app/key-management/key-management.routes.ts
@@ -9,6 +9,13 @@ export const keyManagementRoutes: Routes = [
       ),
   },
   {
+    path: 'providers',
+    loadComponent: () =>
+      import('./key-management-providers/key-management-providers.component').then(
+        (m) => m.KeyManagementProvidersComponent
+      ),
+  },
+  {
     path: 'create',
     loadComponent: () =>
       import('./key-create-wizard/key-create-wizard.component').then(

--- a/docs/architecture/key-management.md
+++ b/docs/architecture/key-management.md
@@ -8,13 +8,14 @@ configured in a single `kms.json` file inside the config folder.
 
 ## Available Providers
 
-| Provider                            | Type     | Description                            | Import Support |
-| ----------------------------------- | -------- | -------------------------------------- | -------------- |
-| [`db`](#database-key-management-db) | Built-in | Keys stored encrypted in the database  | ✅ Yes         |
-| [`vault`](#vault-hashicorp-vault)   | Built-in | HashiCorp Vault Transit secrets engine | ❌ No          |
-| [`aws-kms`](#aws-kms)               | Built-in | AWS Key Management Service             | ❌ No          |
-| [`pkcs11`](#pkcs11-hsm)             | Built-in | PKCS#11 Hardware Security Module       | ❌ No          |
-| [`http`](#http-remote-kms)          | Built-in | Remote KMS microservice (HTTP/HTTPS)   | ✅ Optional    |
+| Provider                                 | Type     | Description                            | Import Support |
+| ---------------------------------------- | -------- | -------------------------------------- | -------------- |
+| [`db`](#database-key-management-db)      | Built-in | Keys stored encrypted in the database  | ✅ Yes         |
+| [`vault`](#vault-hashicorp-vault)        | Built-in | HashiCorp Vault Transit secrets engine | ❌ No          |
+| [`aws-kms`](#aws-kms)                    | Built-in | AWS Key Management Service             | ❌ No          |
+| [`pkcs11`](#pkcs11-hsm)                  | Built-in | PKCS#11 Hardware Security Module       | ❌ No          |
+| [`http`](#http-remote-kms)               | Built-in | Remote KMS microservice (HTTP/HTTPS)   | ✅ Optional    |
+| [`csc`](#csc-cloud-signature-consortium) | Built-in | Cloud Signature Consortium (CSC) API   | ❌ No          |
 
 ## Configuration
 
@@ -53,7 +54,7 @@ Each provider entry has:
 | Field         | Description                                                              |
 | ------------- | ------------------------------------------------------------------------ |
 | `id`          | Unique identifier for the provider instance (used when generating keys). |
-| `type`        | Adapter type: `db`, `vault`, `aws-kms`, or `pkcs11`.                     |
+| `type`        | Adapter type: `db`, `vault`, `aws-kms`, `pkcs11`, `http`, or `csc`.      |
 | `description` | Optional human-readable description.                                     |
 | ...           | Additional type-specific configuration fields.                           |
 
@@ -557,6 +558,68 @@ In this mode:
 - All **signing operations** are delegated to the remote service.
 - EUDIPLO only stores a stub entity (kid + cached public JWK) locally.
 - The remote service is fully responsible for protecting the private keys.
+
+---
+
+## CSC (Cloud Signature Consortium)
+
+The `csc` provider integrates EUDIPLO with remote signing services that expose
+the CSC v2 API.
+
+Supported operations:
+
+- `credentials/list` (optional, used when `credentialId` is not configured)
+- `credentials/info` (load public certificate / key metadata)
+- `signatures/signHash` (remote signing)
+- `credentials/authorize` (optional, used to request SAD)
+
+### Configuration
+
+```json
+{
+    "defaultProvider": "csc-main",
+    "providers": [
+        { "id": "db", "type": "db" },
+        {
+            "id": "csc-main",
+            "type": "csc",
+            "description": "Qualified remote signing service",
+            "baseUrl": "${CSC_URL}",
+            "apiPath": "/csc/v2",
+            "tokenUrl": "${CSC_TOKEN_URL}",
+            "clientId": "${CSC_CLIENT_ID}",
+            "clientSecret": "${CSC_CLIENT_SECRET}",
+            "scope": "service",
+            "userId": "${CSC_USER_ID}",
+            "credentialId": "${CSC_CREDENTIAL_ID}",
+            "useAuthorizeEndpoint": true,
+            "authorizeAuthData": [{ "id": "PIN", "value": "${CSC_PIN}" }]
+        }
+    ]
+}
+```
+
+| Field                  | Description                                                                                |
+| ---------------------- | ------------------------------------------------------------------------------------------ |
+| `baseUrl`              | Base URL of the CSC service (e.g. `https://csc.example.com`).                              |
+| `apiPath`              | CSC path prefix. Defaults to `/csc/v2`.                                                    |
+| `tokenUrl`             | OAuth2 token endpoint for client credentials flow.                                         |
+| `clientId`             | OAuth2 client ID.                                                                          |
+| `clientSecret`         | OAuth2 client secret.                                                                      |
+| `scope`                | Optional OAuth2 scope (e.g. `service`).                                                    |
+| `userId`               | Optional CSC user ID for `credentials/list`.                                               |
+| `credentialId`         | Optional fixed CSC credential ID. If omitted, EUDIPLO resolves one via `credentials/list`. |
+| `hashAlgorithmOid`     | Optional hash OID for `signatures/signHash` (default: SHA-256 OID).                        |
+| `signAlgorithmOid`     | Optional signing algorithm OID (default: ECDSA-with-SHA256 OID).                           |
+| `sad`                  | Optional static SAD value passed to `signatures/signHash`.                                 |
+| `useAuthorizeEndpoint` | If `true`, EUDIPLO calls `credentials/authorize` to obtain SAD dynamically.                |
+| `authorizeAuthData`    | Optional auth data array sent to `credentials/authorize` (e.g. PIN/OTP factors).           |
+
+### Notes
+
+- CSC credentials are managed externally by the CSC service.
+- EUDIPLO does not import or delete CSC private keys.
+- Private keys never leave the remote CSC provider.
 
 ---
 


### PR DESCRIPTION
## 📝 Description

Integrates CSC API support as a KMS provider and exposes provider selection/visibility in the client key-management flow.

Fixes #477

## 🔄 Type of Change

- [x] 🚀 New feature (non-breaking change which adds functionality)
- [x] 📚 Documentation update
- [x] 🧪 Test improvements

## 💥 Breaking Changes (if applicable)

None.

## 🧪 Testing

Describe the tests that you ran to verify your changes:

- [ ] Unit tests pass
- [ ] Integration tests pass
- [x] E2E tests pass
- [x] Manual testing performed

**Test Configuration**:

- Node.js version: local dev environment
- OS: macOS
- Test environment: local workspace

## 📸 Screenshots (if applicable)

N/A

## ✔️ Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## 📋 Additional Notes

### Backend
- Added CSC support in KMS config DTOs and provider registry.
- Added CSC adapter implementation with OAuth2 and CSC endpoints (`credentials/list`, `credentials/info`, `credentials/authorize`, `signatures/signHash`).
- Added CSC E2E coverage with a mock CSC server.

### Config
- Added CSC provider configuration in `assets/config/kms.json`.

### Frontend
- Added provider selection in the key creation wizard final configuration step.
- Added a dedicated providers page (`/keys/providers`) with health/capability visibility.
- Added navigation entry for KMS Providers under Cryptographic Assets.
