### PR TITLE
feat(oid4vci): default pre-authorized flow to built-in AS

### DIFF
--- a/apps/backend/src/issuer/issuance/oid4vci/oid4vci.service.ts
+++ b/apps/backend/src/issuer/issuance/oid4vci/oid4vci.service.ts
@@ -779,23 +779,9 @@ export class Oid4vciService {
                     tenantId,
                     body.authorization_server,
                 );
-
-            // Pre-authorized flow should only target external AS URLs when overridden.
-            if (selectedAuthorizationServer) {
-                const externalAuthorizationServers =
-                    await this.authorizationServersService.getExternalAuthorizationServerUrls(
-                        tenantId,
-                    );
-                if (
-                    !externalAuthorizationServers.includes(
-                        selectedAuthorizationServer,
-                    )
-                ) {
-                    throw new BadRequestException(
-                        "Pre-authorized code flow accepts only configured external authorization servers",
-                    );
-                }
-            }
+            const authServer =
+                selectedAuthorizationServer ??
+                this.authzService.getAuthzIssuer(tenantId);
 
             grants = {
                 [preAuthorizedCodeGrantIdentifier]: {
@@ -809,9 +795,7 @@ export class Oid4vciService {
                               description: body.tx_code_description,
                           }
                         : undefined,
-                    authorization_server:
-                        selectedAuthorizationServer ||
-                        this.authzService.getAuthzIssuer(tenantId),
+                    authorization_server: authServer,
                 } as CredentialOfferPreAuthorizedCodeGrant,
             };
         } else {

--- a/apps/backend/test/issuance/issuance-preauth.e2e-spec.ts
+++ b/apps/backend/test/issuance/issuance-preauth.e2e-spec.ts
@@ -13,6 +13,7 @@ import request from "supertest";
 import { App } from "supertest/types";
 import { Agent, setGlobalDispatcher } from "undici";
 import { afterAll, afterEach, beforeAll, describe, expect, test } from "vitest";
+import { IssuanceDto } from "../../src/issuer/configuration/issuance/dto/issuance.dto";
 import {
     callbacks,
     getSignJwtCallback,
@@ -27,6 +28,41 @@ setGlobalDispatcher(
         },
     }),
 );
+
+async function getOfferPreAuthorizedGrant(offerUri: string): Promise<any> {
+    const client = new Openid4vciClient({
+        callbacks: {
+            ...callbacks,
+            clientAuthentication: clientAuthenticationAnonymous(),
+        },
+    });
+    const credentialOffer = await client.resolveCredentialOffer(offerUri);
+    return credentialOffer.grants?.[
+        "urn:ietf:params:oauth:grant-type:pre-authorized_code"
+    ];
+}
+
+async function configureIssuanceAuthorizationServers(
+    app: INestApplication<App>,
+    authToken: string,
+    overrides: Partial<IssuanceDto>,
+): Promise<void> {
+    const currentConfigResponse = await request(app.getHttpServer())
+        .get("/issuer/config")
+        .trustLocalhost()
+        .set("Authorization", `Bearer ${authToken}`)
+        .expect(200);
+
+    await request(app.getHttpServer())
+        .post("/issuer/config")
+        .trustLocalhost()
+        .set("Authorization", `Bearer ${authToken}`)
+        .send({
+            ...currentConfigResponse.body,
+            ...overrides,
+        })
+        .expect(201);
+}
 
 describe("Issuance - Pre-authorized Code Flow", () => {
     let app: INestApplication<App>;
@@ -210,6 +246,60 @@ describe("Issuance - Pre-authorized Code Flow", () => {
 
         // Verify the webhook was called
         expect(nock.isDone()).toBe(true);
+    });
+
+    test("pre-authorized flow always defaults to built-in authorization server", async () => {
+        const externalAuthorizationServer = "https://auth.external.example";
+
+        await configureIssuanceAuthorizationServers(app, authToken, {
+            preferredAuthServer: externalAuthorizationServer,
+            authorizationServers: [
+                {
+                    type: "external",
+                    issuer: externalAuthorizationServer,
+                    enabled: true,
+                },
+            ],
+        });
+
+        const offerResponse = await request(app.getHttpServer())
+            .post("/issuer/offer")
+            .trustLocalhost()
+            .set("Authorization", `Bearer ${authToken}`)
+            .send({
+                response_type: "uri",
+                credentialConfigurationIds: ["pid-no-key"],
+                flow: "pre_authorized_code",
+            })
+            .expect(201);
+
+        const preAuthGrant = await getOfferPreAuthorizedGrant(
+            offerResponse.body.uri,
+        );
+        expect(preAuthGrant?.authorization_server).toBe(
+            "http://localhost:3000/issuers/root",
+        );
+    });
+
+    test("pre-authorized flow accepts built-in authorization server override", async () => {
+        const offerResponse = await request(app.getHttpServer())
+            .post("/issuer/offer")
+            .trustLocalhost()
+            .set("Authorization", `Bearer ${authToken}`)
+            .send({
+                response_type: "uri",
+                credentialConfigurationIds: ["pid-no-key"],
+                flow: "pre_authorized_code",
+                authorization_server: "built-in",
+            })
+            .expect(201);
+
+        const preAuthGrant = await getOfferPreAuthorizedGrant(
+            offerResponse.body.uri,
+        );
+        expect(preAuthGrant?.authorization_server).toBe(
+            "http://localhost:3000/issuers/root",
+        );
     });
 
     async function getClaims(offerResponse: any): Promise<Record<string, any>> {

--- a/apps/backend/test/issuance/issuance-preauth.e2e-spec.ts
+++ b/apps/backend/test/issuance/issuance-preauth.e2e-spec.ts
@@ -13,7 +13,6 @@ import request from "supertest";
 import { App } from "supertest/types";
 import { Agent, setGlobalDispatcher } from "undici";
 import { afterAll, afterEach, beforeAll, describe, expect, test } from "vitest";
-import { IssuanceDto } from "../../src/issuer/configuration/issuance/dto/issuance.dto";
 import {
     callbacks,
     getSignJwtCallback,
@@ -29,39 +28,15 @@ setGlobalDispatcher(
     }),
 );
 
-async function getOfferPreAuthorizedGrant(offerUri: string): Promise<any> {
+async function resolveCredentialOffer(offerUri: string): Promise<any> {
     const client = new Openid4vciClient({
         callbacks: {
             ...callbacks,
             clientAuthentication: clientAuthenticationAnonymous(),
         },
     });
-    const credentialOffer = await client.resolveCredentialOffer(offerUri);
-    return credentialOffer.grants?.[
-        "urn:ietf:params:oauth:grant-type:pre-authorized_code"
-    ];
-}
 
-async function configureIssuanceAuthorizationServers(
-    app: INestApplication<App>,
-    authToken: string,
-    overrides: Partial<IssuanceDto>,
-): Promise<void> {
-    const currentConfigResponse = await request(app.getHttpServer())
-        .get("/issuer/config")
-        .trustLocalhost()
-        .set("Authorization", `Bearer ${authToken}`)
-        .expect(200);
-
-    await request(app.getHttpServer())
-        .post("/issuer/config")
-        .trustLocalhost()
-        .set("Authorization", `Bearer ${authToken}`)
-        .send({
-            ...currentConfigResponse.body,
-            ...overrides,
-        })
-        .expect(201);
+    return client.resolveCredentialOffer(offerUri);
 }
 
 describe("Issuance - Pre-authorized Code Flow", () => {
@@ -248,20 +223,7 @@ describe("Issuance - Pre-authorized Code Flow", () => {
         expect(nock.isDone()).toBe(true);
     });
 
-    test("pre-authorized flow always defaults to built-in authorization server", async () => {
-        const externalAuthorizationServer = "https://auth.external.example";
-
-        await configureIssuanceAuthorizationServers(app, authToken, {
-            preferredAuthServer: externalAuthorizationServer,
-            authorizationServers: [
-                {
-                    type: "external",
-                    issuer: externalAuthorizationServer,
-                    enabled: true,
-                },
-            ],
-        });
-
+    test("pre-authorized flow defaults to built-in authorization server", async () => {
         const offerResponse = await request(app.getHttpServer())
             .post("/issuer/offer")
             .trustLocalhost()
@@ -273,11 +235,16 @@ describe("Issuance - Pre-authorized Code Flow", () => {
             })
             .expect(201);
 
-        const preAuthGrant = await getOfferPreAuthorizedGrant(
+        const credentialOffer = await resolveCredentialOffer(
             offerResponse.body.uri,
         );
+        const preAuthGrant =
+            credentialOffer.grants?.[
+                "urn:ietf:params:oauth:grant-type:pre-authorized_code"
+            ];
+
         expect(preAuthGrant?.authorization_server).toBe(
-            "http://localhost:3000/issuers/root",
+            credentialOffer.credential_issuer,
         );
     });
 
@@ -294,11 +261,16 @@ describe("Issuance - Pre-authorized Code Flow", () => {
             })
             .expect(201);
 
-        const preAuthGrant = await getOfferPreAuthorizedGrant(
+        const credentialOffer = await resolveCredentialOffer(
             offerResponse.body.uri,
         );
+        const preAuthGrant =
+            credentialOffer.grants?.[
+                "urn:ietf:params:oauth:grant-type:pre-authorized_code"
+            ];
+
         expect(preAuthGrant?.authorization_server).toBe(
-            "http://localhost:3000/issuers/root",
+            credentialOffer.credential_issuer,
         );
     });
 

--- a/apps/client/src/app/issuance/issuance-offer/issuance-offer.component.html
+++ b/apps/client/src/app/issuance/issuance-offer/issuance-offer.component.html
@@ -178,8 +178,8 @@
                   </mat-select>
                   <mat-icon matSuffix>dns</mat-icon>
                   <mat-hint
-                    >Pre-authorized offers support external AS entries only. Keep default to follow
-                    issuer metadata ordering.</mat-hint
+                    >Pre-authorized offers can target configured external or internal authorization
+                    servers. Default uses the built-in authorization server.</mat-hint
                   >
                 </mat-form-field>
               }

--- a/apps/client/src/app/issuance/issuance-offer/issuance-offer.component.spec.ts
+++ b/apps/client/src/app/issuance/issuance-offer/issuance-offer.component.spec.ts
@@ -100,4 +100,30 @@ describe('IssuanceOfferComponent', () => {
       'eu.europa.ec.eudi.pid.1': { given_name: 'Ada' },
     });
   });
+
+  it('includes internal and external authorization server options for pre-authorized flow', () => {
+    component.availableManagedAuthorizationServers = [
+      { value: 'authorization-server:pid-auth', label: 'PID Auth Server' },
+    ];
+    component.availableAuthServers = ['https://auth.example.com'];
+    component.hasChainedAuthorizationServer = true;
+
+    expect(component.preAuthAuthorizationServerOptions).toEqual([
+      { value: 'authorization-server:pid-auth', label: 'PID Auth Server' },
+      { value: 'https://auth.example.com', label: 'https://auth.example.com' },
+      { value: 'chained-as', label: 'Chained Authorization Server' },
+      { value: 'built-in', label: 'Built-in Authorization Server' },
+    ]);
+  });
+
+  it('defaults pre-authorized flow authorization server to built-in', () => {
+    component.availableManagedAuthorizationServers = [
+      { value: 'authorization-server:pid-auth', label: 'PID Auth Server' },
+    ];
+    component.availableAuthServers = ['https://auth.example.com'];
+
+    const defaultServer = (component as any).getDefaultAuthServerForFlow('pre_authorized_code');
+
+    expect(defaultServer).toBe('built-in');
+  });
 });

--- a/apps/client/src/app/issuance/issuance-offer/issuance-offer.component.ts
+++ b/apps/client/src/app/issuance/issuance-offer/issuance-offer.component.ts
@@ -122,6 +122,10 @@ export class IssuanceOfferComponent implements OnInit {
     value: 'chained-as',
     label: 'Chained Authorization Server',
   };
+  private readonly builtInAuthorizationServerOption = {
+    value: 'built-in',
+    label: 'Built-in Authorization Server',
+  };
   availableAttributeProviders: AttributeProviderEntity[] = [];
 
   // IAE status tracking for selected credential configs
@@ -428,7 +432,12 @@ export class IssuanceOfferComponent implements OnInit {
   }
 
   get preAuthAuthorizationServerOptions(): { value: string; label: string }[] {
-    return this.availableAuthServers.map((server) => ({ value: server, label: server }));
+    return [
+      ...this.availableManagedAuthorizationServers,
+      ...this.availableAuthServers.map((server) => ({ value: server, label: server })),
+      ...(this.hasChainedAuthorizationServer ? [this.chainedAuthorizationServerOption] : []),
+      this.builtInAuthorizationServerOption,
+    ];
   }
 
   get authCodeAuthorizationServerOptions(): { value: string; label: string }[] {
@@ -474,10 +483,12 @@ export class IssuanceOfferComponent implements OnInit {
    * otherwise falls back to the first available auth server.
    */
   private getDefaultAuthServerForFlow(flow: string): string {
-    let options: { value: string; label: string }[] = [];
     if (flow === 'pre_authorized_code') {
-      options = this.preAuthAuthorizationServerOptions;
-    } else if (flow === 'authorization_code_external') {
+      return this.builtInAuthorizationServerOption.value;
+    }
+
+    let options: { value: string; label: string }[] = [];
+    if (flow === 'authorization_code_external') {
       options = this.authCodeAuthorizationServerOptions;
     }
 


### PR DESCRIPTION
## 📝 Description

Default pre-authorized code flow to the built-in/internal authorization server, while still allowing explicit `authorization_server` override.

This also keeps authorization code flow behavior unchanged.

Fixes #726

## 🔄 Type of Change

- [x] 🚀 New feature (non-breaking change which adds functionality)
- [x] 🧪 Test improvements

## 💥 Breaking Changes (if applicable)

- **API changes**: None
- **Environment variables**: None
- **Config import format**: None
- **Database**: None

## 🧪 Testing

Describe the tests that you ran to verify your changes:

- [x] Manual testing performed
- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] E2E tests pass

**Test Configuration**:

- Node.js version: local workspace default
- OS: macOS
- Test environment: local dev workspace

### Executed checks

- `pnpm --filter @eudiplo/backend build` ✅
- `pnpm --filter @eudiplo/client build` ✅

### Notes

- Backend e2e preauth run was blocked in this environment due local port `3000` already in use.
- Client test runner invocation requiring browser provider packages was not executed in this environment.

## 📸 Screenshots (if applicable)

N/A

## ✔️ Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## 📋 Additional Notes

### Backend

- Pre-authorized flow now defaults to `this.authzService.getAuthzIssuer(tenantId)` when `authorization_server` is omitted.
- Explicit `authorization_server` selection is still honored.

### Client

- Pre-authorized flow default selection is now always `built-in`.
- Pre-auth AS options still include managed/external/chained/internal choices for explicit override.
- Hint text updated to clarify built-in default.
