### PR TITLE
fix: support DCQL claim_sets in OpenID4VP

### DIFF
--- a/apps/backend/src/verifier/presentations/entities/presentation-config.entity.ts
+++ b/apps/backend/src/verifier/presentations/entities/presentation-config.entity.ts
@@ -65,9 +65,7 @@ export class TrustedAuthorityQuery {
 }
 
 @ValidatorConstraint({ name: "claimSetsConsistency", async: false })
-class ClaimSetsConsistencyConstraint
-    implements ValidatorConstraintInterface
-{
+class ClaimSetsConsistencyConstraint implements ValidatorConstraintInterface {
     validate(claimSets: string[][] | undefined, args: ValidationArguments) {
         if (!claimSets || claimSets.length === 0) {
             return true;
@@ -80,9 +78,7 @@ class ClaimSetsConsistencyConstraint
         }
 
         const claimIds = claims.map((claim) => claim.id);
-        if (
-            claimIds.some((id) => typeof id !== "string" || id.trim() === "")
-        ) {
+        if (claimIds.some((id) => typeof id !== "string" || id.trim() === "")) {
             return false;
         }
 
@@ -98,8 +94,7 @@ class ClaimSetsConsistencyConstraint
                 new Set(claimSet).size === claimSet.length &&
                 claimSet.every(
                     (claimId) =>
-                        typeof claimId === "string" &&
-                        claimIdSet.has(claimId),
+                        typeof claimId === "string" && claimIdSet.has(claimId),
                 ),
         );
     }

--- a/apps/backend/src/verifier/presentations/entities/presentation-config.entity.ts
+++ b/apps/backend/src/verifier/presentations/entities/presentation-config.entity.ts
@@ -16,6 +16,9 @@ import {
     IsString,
     Validate,
     ValidateNested,
+    ValidationArguments,
+    ValidatorConstraint,
+    ValidatorConstraintInterface,
 } from "class-validator";
 import {
     Column,
@@ -61,6 +64,51 @@ export class TrustedAuthorityQuery {
     values!: string[];
 }
 
+@ValidatorConstraint({ name: "claimSetsConsistency", async: false })
+class ClaimSetsConsistencyConstraint
+    implements ValidatorConstraintInterface
+{
+    validate(claimSets: string[][] | undefined, args: ValidationArguments) {
+        if (!claimSets || claimSets.length === 0) {
+            return true;
+        }
+
+        const credentialQuery = args.object as CredentialQuery;
+        const claims = credentialQuery.claims;
+        if (!claims || claims.length === 0) {
+            return false;
+        }
+
+        const claimIds = claims.map((claim) => claim.id);
+        if (
+            claimIds.some((id) => typeof id !== "string" || id.trim() === "")
+        ) {
+            return false;
+        }
+
+        if (new Set(claimIds).size !== claimIds.length) {
+            return false;
+        }
+
+        const claimIdSet = new Set(claimIds);
+        return claimSets.every(
+            (claimSet) =>
+                Array.isArray(claimSet) &&
+                claimSet.length > 0 &&
+                new Set(claimSet).size === claimSet.length &&
+                claimSet.every(
+                    (claimId) =>
+                        typeof claimId === "string" &&
+                        claimIdSet.has(claimId),
+                ),
+        );
+    }
+
+    defaultMessage() {
+        return "claim_sets requires claims to be present, each claim to define a unique id, and every claim_set entry to reference ids from claims.";
+    }
+}
+
 //TODO: extend: https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#name-credential-query
 export class CredentialQuery {
     @IsString()
@@ -81,6 +129,17 @@ export class CredentialQuery {
     @ValidateNested({ each: true })
     @Type(() => ClaimsQuery)
     claims?: ClaimsQuery[];
+
+    @IsOptional()
+    @IsArray()
+    @Validate(ClaimSetsConsistencyConstraint)
+    @ApiPropertyOptional({
+        type: "array",
+        items: { type: "array", items: { type: "string" } },
+        description:
+            "Ordered alternative claim combinations for this credential query.",
+    })
+    claim_sets?: string[][];
 
     @IsObject()
     meta!: any;

--- a/apps/backend/src/verifier/presentations/presentations.service.ts
+++ b/apps/backend/src/verifier/presentations/presentations.service.ts
@@ -1389,9 +1389,8 @@ export class PresentationsService {
                     dcqlCredential.claims,
                     type,
                 );
-                const claimSelections = this.getCredentialClaimSelections(
-                    dcqlCredential,
-                );
+                const claimSelections =
+                    this.getCredentialClaimSelections(dcqlCredential);
                 const hasClaimSets =
                     !!dcqlCredential.claim_sets &&
                     dcqlCredential.claim_sets.length > 0;
@@ -1656,8 +1655,9 @@ export class PresentationsService {
 
         const claimsById = new Map(
             claims
-                .filter((claim): claim is ClaimsQuery & { id: string } =>
-                    typeof claim.id === "string" && claim.id.trim() !== "",
+                .filter(
+                    (claim): claim is ClaimsQuery & { id: string } =>
+                        typeof claim.id === "string" && claim.id.trim() !== "",
                 )
                 .map((claim) => [claim.id, claim] as const),
         );
@@ -1706,7 +1706,9 @@ export class PresentationsService {
             return this.verifySdJwtCredentialValue(options);
         }
 
-        throw new ConflictException(`Unsupported credential type: ${options.type}`);
+        throw new ConflictException(
+            `Unsupported credential type: ${options.type}`,
+        );
     }
 
     private async verifyMdocCredentialValue(options: {
@@ -1741,9 +1743,7 @@ export class PresentationsService {
             protocol: "openid4vp" as const,
             responseMode:
                 options.requestObjectSessionData?.response_mode ??
-                (options.session.useDcApi
-                    ? "dc_api.jwt"
-                    : "direct_post.jwt"),
+                (options.session.useDcApi ? "dc_api.jwt" : "direct_post.jwt"),
             jwkThumbprint: options.requestObjectJwkThumbprint,
         };
 
@@ -1884,12 +1884,13 @@ export class PresentationsService {
         });
 
         if (options.hasClaimSets) {
-            const matchingSelection = options.claimSelections.find((selectedClaims) =>
-                this.matchesClaimSelection(
-                    (result.payload ?? {}) as Record<string, unknown>,
-                    options.dcqlCredential.claims,
-                    selectedClaims,
-                ),
+            const matchingSelection = options.claimSelections.find(
+                (selectedClaims) =>
+                    this.matchesClaimSelection(
+                        (result.payload ?? {}) as Record<string, unknown>,
+                        options.dcqlCredential.claims,
+                        selectedClaims,
+                    ),
             );
 
             if (!matchingSelection) {
@@ -1910,7 +1911,9 @@ export class PresentationsService {
         this.logger.debug(
             {
                 credentialId: options.attId,
-                requiredClaimKeys: options.hasClaimSets ? [] : options.requiredClaimKeys,
+                requiredClaimKeys: options.hasClaimSets
+                    ? []
+                    : options.requiredClaimKeys,
                 disclosedClaimKeys: Object.keys(result.payload ?? {}),
             },
             "SD-JWT-VC disclosed claims after verification",
@@ -1918,7 +1921,9 @@ export class PresentationsService {
         this.logger.trace(
             {
                 credentialId: options.attId,
-                requiredClaimKeys: options.hasClaimSets ? [] : options.requiredClaimKeys,
+                requiredClaimKeys: options.hasClaimSets
+                    ? []
+                    : options.requiredClaimKeys,
                 disclosedClaims: result.payload,
             },
             "[TRACE] SD-JWT-VC full disclosed claims payload",
@@ -1955,7 +1960,9 @@ export class PresentationsService {
         };
 
         const reason =
-            (result.failureType ? reasonByType[result.failureType] : undefined) ||
+            (result.failureType
+                ? reasonByType[result.failureType]
+                : undefined) ||
             result.failureReason ||
             "mDOC verification failed";
 

--- a/apps/backend/src/verifier/presentations/presentations.service.ts
+++ b/apps/backend/src/verifier/presentations/presentations.service.ts
@@ -1389,119 +1389,28 @@ export class PresentationsService {
                     dcqlCredential.claims,
                     type,
                 );
+                const claimSelections = this.getCredentialClaimSelections(
+                    dcqlCredential,
+                );
+                const hasClaimSets =
+                    !!dcqlCredential.claim_sets &&
+                    dcqlCredential.claim_sets.length > 0;
 
                 const values = await Promise.all(
                     credentials.map(async (cred) => {
-                        if (type === "mso_mdoc") {
-                            const result =
-                                await this.mdocverifierService.verify(
-                                    cred,
-                                    {
-                                        nonce:
-                                            requestObjectSessionData?.nonce ??
-                                            (session.vp_nonce as string),
-                                        clientId:
-                                            requestObjectSessionData?.client_id ??
-                                            session.clientId!,
-                                        responseUri:
-                                            requestObjectSessionData?.response_uri ??
-                                            session.responseUri!,
-                                        protocol: "openid4vp",
-                                        responseMode:
-                                            requestObjectSessionData?.response_mode ??
-                                            (session.useDcApi
-                                                ? "dc_api.jwt"
-                                                : "direct_post.jwt"),
-                                        jwkThumbprint:
-                                            requestObjectJwkThumbprint,
-                                    },
-                                    verifyOptions,
-                                    dcqlCredential.claims?.map(
-                                        (claim) => claim.path,
-                                    ),
-                                );
-                            if (!result.verified) {
-                                const reasonByType: Record<string, string> = {
-                                    signature_invalid:
-                                        "mDOC signature is invalid",
-                                    no_trust_chain_to_root:
-                                        "no trust chain to a trusted root could be built",
-                                    trust_chain_not_trusted:
-                                        "certificate chain does not match any trusted entity",
-                                    x5c_missing:
-                                        "credential does not include an x5c chain but it is required",
-                                    verification_error:
-                                        "mDOC verification failed",
-                                };
-
-                                const reason =
-                                    (result.failureType
-                                        ? reasonByType[result.failureType]
-                                        : undefined) ||
-                                    result.failureReason ||
-                                    "mDOC verification failed";
-
-                                this.logger.warn(
-                                    {
-                                        credentialId: attId,
-                                        failureType: result.failureType,
-                                        failureReason: result.failureReason,
-                                    },
-                                    "mDOC verification failed",
-                                );
-
-                                throw new BadRequestException(
-                                    `mDOC verification failed for credential "${attId}": ${reason}`,
-                                );
-                            }
-
-                            // Validate all required claims are present in mDOC
-                            this.validateMdocClaims(
-                                attId,
-                                dcqlCredential.claims,
-                                result.claims,
-                            );
-
-                            return result.claims;
-                        } else if (type === "dc+sd-jwt") {
-                            const result =
-                                await this.sdjwtvcverifierService.verify(cred, {
-                                    requiredClaimKeys,
-                                    keyBindingNonce: session.vp_nonce!,
-                                    keyBindingAudience:
-                                        this.resolveSdJwtKeyBindingAudience(
-                                            session,
-                                            requestObjectSessionData,
-                                        ),
-                                    ...verifyOptions,
-                                });
-                            this.logger.debug(
-                                {
-                                    credentialId: attId,
-                                    requiredClaimKeys,
-                                    disclosedClaimKeys: Object.keys(
-                                        result.payload ?? {},
-                                    ),
-                                },
-                                "SD-JWT-VC disclosed claims after verification",
-                            );
-                            this.logger.trace(
-                                {
-                                    credentialId: attId,
-                                    requiredClaimKeys,
-                                    disclosedClaims: result.payload,
-                                },
-                                "[TRACE] SD-JWT-VC full disclosed claims payload",
-                            );
-                            return {
-                                ...result.payload,
-                                cnf: undefined,
-                                status: undefined,
-                            };
-                        }
-                        throw new ConflictException(
-                            `Unsupported credential type: ${type}`,
-                        );
+                        return this.verifyCredentialValue({
+                            cred,
+                            attId,
+                            type,
+                            session,
+                            requestObjectSessionData,
+                            requestObjectJwkThumbprint,
+                            verifyOptions,
+                            dcqlCredential,
+                            claimSelections,
+                            hasClaimSets,
+                            requiredClaimKeys,
+                        });
                     }),
                 );
 
@@ -1734,5 +1643,399 @@ export class PresentationsService {
                 { missingClaims: { [credentialId]: missingClaims } },
             );
         }
+    }
+
+    private getCredentialClaimSelections(
+        credential: CredentialQuery,
+    ): ClaimsQuery[][] {
+        const claims = credential.claims ?? [];
+
+        if (!credential.claim_sets || credential.claim_sets.length === 0) {
+            return [claims];
+        }
+
+        const claimsById = new Map(
+            claims
+                .filter((claim): claim is ClaimsQuery & { id: string } =>
+                    typeof claim.id === "string" && claim.id.trim() !== "",
+                )
+                .map((claim) => [claim.id, claim] as const),
+        );
+
+        return credential.claim_sets.map((claimSet) => {
+            const resolvedClaims = claimSet.map((claimId) => {
+                const claim = claimsById.get(claimId);
+                if (!claim) {
+                    throw new BadRequestException(
+                        `claim_sets references unknown claim id '${claimId}' for credential '${credential.id}'`,
+                    );
+                }
+                return claim;
+            });
+
+            return resolvedClaims;
+        });
+    }
+
+    private async verifyCredentialValue(options: {
+        cred: string;
+        attId: string;
+        type: CredentialType;
+        session: Session;
+        requestObjectSessionData:
+            | {
+                  nonce?: string;
+                  client_id?: string;
+                  response_uri?: string;
+                  response_mode?: string;
+                  expected_origins?: string[];
+              }
+            | undefined;
+        requestObjectJwkThumbprint: Uint8Array | undefined;
+        verifyOptions: VerifierOptions;
+        dcqlCredential: CredentialQuery;
+        claimSelections: ClaimsQuery[][];
+        hasClaimSets: boolean;
+        requiredClaimKeys: string[];
+    }): Promise<Record<string, unknown>> {
+        if (options.type === "mso_mdoc") {
+            return this.verifyMdocCredentialValue(options);
+        }
+
+        if (options.type === "dc+sd-jwt") {
+            return this.verifySdJwtCredentialValue(options);
+        }
+
+        throw new ConflictException(`Unsupported credential type: ${options.type}`);
+    }
+
+    private async verifyMdocCredentialValue(options: {
+        cred: string;
+        attId: string;
+        session: Session;
+        requestObjectSessionData:
+            | {
+                  nonce?: string;
+                  client_id?: string;
+                  response_uri?: string;
+                  response_mode?: string;
+                  expected_origins?: string[];
+              }
+            | undefined;
+        requestObjectJwkThumbprint: Uint8Array | undefined;
+        verifyOptions: VerifierOptions;
+        dcqlCredential: CredentialQuery;
+        claimSelections: ClaimsQuery[][];
+        hasClaimSets: boolean;
+    }): Promise<Record<string, unknown>> {
+        const sessionData = {
+            nonce:
+                options.requestObjectSessionData?.nonce ??
+                (options.session.vp_nonce as string),
+            clientId:
+                options.requestObjectSessionData?.client_id ??
+                options.session.clientId!,
+            responseUri:
+                options.requestObjectSessionData?.response_uri ??
+                options.session.responseUri!,
+            protocol: "openid4vp" as const,
+            responseMode:
+                options.requestObjectSessionData?.response_mode ??
+                (options.session.useDcApi
+                    ? "dc_api.jwt"
+                    : "direct_post.jwt"),
+            jwkThumbprint: options.requestObjectJwkThumbprint,
+        };
+
+        if (options.hasClaimSets) {
+            return this.verifyMdocCredentialWithClaimSets({
+                ...options,
+                sessionData,
+            });
+        }
+
+        const result = await this.mdocverifierService.verify(
+            options.cred,
+            sessionData,
+            options.verifyOptions,
+            options.dcqlCredential.claims?.map((claim) => claim.path),
+        );
+
+        if (!result.verified) {
+            this.throwMdocVerificationFailure(options.attId, result);
+        }
+
+        this.validateMdocClaims(
+            options.attId,
+            options.dcqlCredential.claims,
+            result.claims,
+        );
+
+        return result.claims;
+    }
+
+    private async verifyMdocCredentialWithClaimSets(options: {
+        cred: string;
+        attId: string;
+        sessionData: {
+            nonce: string;
+            clientId: string;
+            responseUri: string;
+            protocol: "openid4vp";
+            responseMode: string;
+            jwkThumbprint: Uint8Array | undefined;
+        };
+        verifyOptions: VerifierOptions;
+        dcqlCredential: CredentialQuery;
+        claimSelections: ClaimsQuery[][];
+    }): Promise<Record<string, unknown>> {
+        let lastVerificationFailure:
+            | {
+                  failureType?:
+                      | "signature_invalid"
+                      | "no_trust_chain_to_root"
+                      | "trust_chain_not_trusted"
+                      | "x5c_missing"
+                      | "verification_error";
+                  failureReason?: string;
+              }
+            | undefined;
+
+        for (const selectedClaims of options.claimSelections) {
+            let result;
+
+            try {
+                result = await this.mdocverifierService.verify(
+                    options.cred,
+                    options.sessionData,
+                    options.verifyOptions,
+                    selectedClaims.map((claim) => claim.path),
+                );
+            } catch (error) {
+                lastVerificationFailure = {
+                    failureType: "verification_error",
+                    failureReason:
+                        error instanceof Error ? error.message : undefined,
+                };
+
+                continue;
+            }
+
+            if (!result.verified) {
+                lastVerificationFailure = result;
+                continue;
+            }
+
+            if (this.matchesMdocClaimSelection(result.claims, selectedClaims)) {
+                return result.claims;
+            }
+        }
+
+        if (lastVerificationFailure) {
+            this.throwMdocVerificationFailure(
+                options.attId,
+                lastVerificationFailure,
+            );
+        }
+
+        throw new IncompletePresentationException(
+            `Credential "${options.attId}" does not satisfy any claim_set`,
+            {
+                missingClaims: {
+                    [options.attId]:
+                        options.dcqlCredential.claims?.map((claim) =>
+                            claim.path.join("."),
+                        ) ?? [],
+                },
+            },
+        );
+    }
+
+    private async verifySdJwtCredentialValue(options: {
+        cred: string;
+        attId: string;
+        session: Session;
+        requestObjectSessionData:
+            | {
+                  nonce?: string;
+                  client_id?: string;
+                  response_uri?: string;
+                  response_mode?: string;
+                  expected_origins?: string[];
+              }
+            | undefined;
+        requestObjectJwkThumbprint: Uint8Array | undefined;
+        verifyOptions: VerifierOptions;
+        dcqlCredential: CredentialQuery;
+        claimSelections: ClaimsQuery[][];
+        hasClaimSets: boolean;
+        requiredClaimKeys: string[];
+    }): Promise<Record<string, unknown>> {
+        const result = await this.sdjwtvcverifierService.verify(options.cred, {
+            requiredClaimKeys: options.hasClaimSets
+                ? []
+                : options.requiredClaimKeys,
+            keyBindingNonce: options.session.vp_nonce!,
+            keyBindingAudience: this.resolveSdJwtKeyBindingAudience(
+                options.session,
+                options.requestObjectSessionData,
+            ),
+            ...options.verifyOptions,
+        });
+
+        if (options.hasClaimSets) {
+            const matchingSelection = options.claimSelections.find((selectedClaims) =>
+                this.matchesClaimSelection(
+                    (result.payload ?? {}) as Record<string, unknown>,
+                    options.dcqlCredential.claims,
+                    selectedClaims,
+                ),
+            );
+
+            if (!matchingSelection) {
+                throw new IncompletePresentationException(
+                    `Credential "${options.attId}" does not satisfy any claim_set`,
+                    {
+                        missingClaims: {
+                            [options.attId]:
+                                options.dcqlCredential.claims?.map((claim) =>
+                                    claim.path.join("."),
+                                ) ?? [],
+                        },
+                    },
+                );
+            }
+        }
+
+        this.logger.debug(
+            {
+                credentialId: options.attId,
+                requiredClaimKeys: options.hasClaimSets ? [] : options.requiredClaimKeys,
+                disclosedClaimKeys: Object.keys(result.payload ?? {}),
+            },
+            "SD-JWT-VC disclosed claims after verification",
+        );
+        this.logger.trace(
+            {
+                credentialId: options.attId,
+                requiredClaimKeys: options.hasClaimSets ? [] : options.requiredClaimKeys,
+                disclosedClaims: result.payload,
+            },
+            "[TRACE] SD-JWT-VC full disclosed claims payload",
+        );
+
+        return {
+            ...result.payload,
+            cnf: undefined,
+            status: undefined,
+        };
+    }
+
+    private throwMdocVerificationFailure(
+        attId: string,
+        result: {
+            failureType?:
+                | "signature_invalid"
+                | "no_trust_chain_to_root"
+                | "trust_chain_not_trusted"
+                | "x5c_missing"
+                | "verification_error";
+            failureReason?: string;
+        },
+    ): never {
+        const reasonByType: Record<string, string> = {
+            signature_invalid: "mDOC signature is invalid",
+            no_trust_chain_to_root:
+                "no trust chain to a trusted root could be built",
+            trust_chain_not_trusted:
+                "certificate chain does not match any trusted entity",
+            x5c_missing:
+                "credential does not include an x5c chain but it is required",
+            verification_error: "mDOC verification failed",
+        };
+
+        const reason =
+            (result.failureType ? reasonByType[result.failureType] : undefined) ||
+            result.failureReason ||
+            "mDOC verification failed";
+
+        this.logger.warn(
+            {
+                credentialId: attId,
+                failureType: result.failureType,
+                failureReason: result.failureReason,
+            },
+            "mDOC verification failed",
+        );
+
+        throw new BadRequestException(
+            `mDOC verification failed for credential "${attId}": ${reason}`,
+        );
+    }
+
+    private matchesClaimSelection(
+        payload: Record<string, unknown>,
+        allClaims: ClaimsQuery[] | undefined,
+        selectedClaims: ClaimsQuery[],
+    ): boolean {
+        if (!allClaims || allClaims.length === 0) {
+            return selectedClaims.length === 0;
+        }
+
+        return selectedClaims.every((claim) =>
+            this.hasClaimPath(payload, claim.path),
+        );
+    }
+
+    private matchesMdocClaimSelection(
+        payload: Record<string, unknown>,
+        selectedClaims: ClaimsQuery[],
+    ): boolean {
+        return selectedClaims.every((claim) => {
+            const claimName =
+                claim.path.length > 1 ? claim.path[1] : claim.path[0];
+
+            return claimName in payload;
+        });
+    }
+
+    private areClaimPathsEqual(left: string[], right: string[]): boolean {
+        if (left.length !== right.length) {
+            return false;
+        }
+
+        return left.every((segment, index) => segment === right[index]);
+    }
+
+    private hasClaimPath(value: unknown, path: string[]): boolean {
+        let current: unknown = value;
+
+        for (const segment of path) {
+            if (current === null || current === undefined) {
+                return false;
+            }
+
+            if (Array.isArray(current)) {
+                const index = Number(segment);
+                if (!Number.isInteger(index) || index < 0) {
+                    return false;
+                }
+
+                current = current[index];
+                continue;
+            }
+
+            if (typeof current !== "object") {
+                return false;
+            }
+
+            if (!(segment in current)) {
+                return false;
+            }
+
+            current = (current as Record<string, unknown>)[segment];
+        }
+
+        return current !== undefined;
     }
 }

--- a/apps/backend/test/presentation/presentation-mdoc.e2e-spec.ts
+++ b/apps/backend/test/presentation/presentation-mdoc.e2e-spec.ts
@@ -32,7 +32,6 @@ describe("Presentation - mDOC Credential", () => {
     let privateIssuerKey: CryptoKey;
     let issuerCert: string;
     let ctx: PresentationTestContext;
-
     let client: Openid4vpClient;
 
     function computeJwkThumbprint(jwks?: {
@@ -176,6 +175,122 @@ describe("Presentation - mDOC Credential", () => {
         });
 
         expect(submitRes).toBeDefined();
+        expect(submitRes.response.status).toBe(200);
+    });
+
+    test("present mso mdoc credential using claim_sets preference order", async () => {
+        await request(app.getHttpServer())
+            .post("/verifier/config")
+            .trustLocalhost()
+            .set("Authorization", `Bearer ${authToken}`)
+            .send({
+                id: "pid-mdoc-claim-sets",
+                description: "mDOC with alternative claim sets",
+                dcql_query: {
+                    credentials: [
+                        {
+                            id: "pid-mso-mdoc",
+                            format: "mso_mdoc",
+                            meta: {
+                                doctype_value: "eu.europa.ec.eudi.pid.1",
+                            },
+                            claims: [
+                                {
+                                    id: "given_name",
+                                    path: [
+                                        "eu.europa.ec.eudi.pid.1",
+                                        "given_name",
+                                    ],
+                                },
+                                {
+                                    id: "family_name",
+                                    path: [
+                                        "eu.europa.ec.eudi.pid.1",
+                                        "family_name",
+                                    ],
+                                },
+                                {
+                                    id: "first_name",
+                                    path: [
+                                        "eu.europa.ec.eudi.pid.1",
+                                        "first_name",
+                                    ],
+                                },
+                                {
+                                    id: "last_name",
+                                    path: [
+                                        "eu.europa.ec.eudi.pid.1",
+                                        "last_name",
+                                    ],
+                                },
+                                {
+                                    id: "postal_code",
+                                    path: [
+                                        "eu.europa.ec.eudi.pid.1",
+                                        "postal_code",
+                                    ],
+                                },
+                            ],
+                            claim_sets: [
+                                ["postal_code"],
+                                ["given_name", "family_name"],
+                            ],
+                        },
+                    ],
+                },
+            })
+            .expect(201);
+
+        const res = await request(app.getHttpServer())
+            .post("/verifier/offer")
+            .trustLocalhost()
+            .set("Authorization", `Bearer ${authToken}`)
+            .send({
+                response_type: ResponseType.URI,
+                requestId: "pid-mdoc-claim-sets",
+            })
+            .expect(201);
+
+        const authRequest = client.parseOpenid4vpAuthorizationRequest({
+            authorizationRequest: res.body.uri,
+        });
+
+        const resolved = await client.resolveOpenId4vpAuthorizationRequest({
+            authorizationRequestPayload: authRequest.params,
+            responseMode: { type: "direct_post" },
+        });
+
+        const vp_token = await prepareMdocPresentation(
+            resolved.authorizationRequestPayload.nonce,
+            privateIssuerKey,
+            issuerCert,
+            resolved.authorizationRequestPayload.client_id!,
+            resolved.authorizationRequestPayload.response_uri as string,
+            resolved.authorizationRequestPayload.response_mode ??
+                "direct_post.jwt",
+            computeJwkThumbprint(
+                resolved.authorizationRequestPayload.client_metadata?.jwks,
+            ),
+        );
+
+        const jwt = await encryptVpToken(vp_token, "pid-mso-mdoc", resolved);
+
+        const authorizationResponse =
+            await client.createOpenid4vpAuthorizationResponse({
+                authorizationRequestPayload: authRequest.params,
+                authorizationResponsePayload: {
+                    response: jwt,
+                },
+                ...callbacks,
+            });
+
+        const submitRes = await client.submitOpenid4vpAuthorizationResponse({
+            authorizationResponsePayload:
+                authorizationResponse.authorizationResponsePayload,
+            authorizationRequestPayload:
+                resolved.authorizationRequestPayload as Openid4vpAuthorizationRequest,
+        });
+
         expect(submitRes.response.status).toBe(200);
     });
 

--- a/apps/backend/test/presentation/presentation-offer.e2e-spec.ts
+++ b/apps/backend/test/presentation/presentation-offer.e2e-spec.ts
@@ -84,6 +84,32 @@ describe("Presentation - Offer Creation", () => {
             });
     });
 
+    test("rejects presentation configs with claim_sets but no claim ids", async () => {
+        await request(app.getHttpServer())
+            .post("/verifier/config")
+            .trustLocalhost()
+            .set("Authorization", `Bearer ${authToken}`)
+            .send({
+                id: "invalid-claim-sets",
+                description: "Invalid claim_sets config",
+                dcql_query: {
+                    credentials: [
+                        {
+                            id: "pid",
+                            format: "dc+sd-jwt",
+                            meta: {
+                                vct_values: [
+                                    "<TENANT_URL>/credentials-metadata/vct/pid",
+                                ],
+                            },
+                            claim_sets: [["birthdate"]],
+                        },
+                    ],
+                },
+            })
+            .expect(400);
+    });
+
     test("client_id in offer URI matches the accessKeyChainId certificate when multiple access keys exist", async () => {
         // A second access key chain with a distinct certificate (different from the fixture default)
         const secondKeyMaterial = {

--- a/apps/backend/test/presentation/presentation-sdjwt.e2e-spec.ts
+++ b/apps/backend/test/presentation/presentation-sdjwt.e2e-spec.ts
@@ -150,6 +150,98 @@ describe("Presentation - SD-JWT Credential", () => {
         expect(submitRes.response.status).toBe(200);
     });
 
+    test("present sd jwt credential using claim_sets preference order", async () => {
+        await request(app.getHttpServer())
+            .post("/verifier/config")
+            .trustLocalhost()
+            .set("Authorization", `Bearer ${authToken}`)
+            .send({
+                id: "pid-claim-sets",
+                description: "PID with alternative claim sets",
+                dcql_query: {
+                    credentials: [
+                        {
+                            id: "pid",
+                            format: "dc+sd-jwt",
+                            meta: {
+                                vct_values: [
+                                    "<TENANT_URL>/credentials-metadata/vct/pid",
+                                ],
+                            },
+                            claims: [
+                                { id: "birthdate", path: ["birthdate"] },
+                                {
+                                    id: "locality",
+                                    path: ["address", "locality"],
+                                },
+                                {
+                                    id: "postal_code",
+                                    path: ["address", "postal_code"],
+                                },
+                            ],
+                            claim_sets: [
+                                ["postal_code"],
+                                ["birthdate", "locality"],
+                            ],
+                        },
+                    ],
+                },
+            })
+            .expect(201);
+
+        const requestBody: PresentationRequest = {
+            response_type: ResponseType.URI,
+            requestId: "pid-claim-sets",
+        };
+
+        const res = await createPresentationRequest(
+            app,
+            authToken,
+            requestBody,
+        );
+
+        const authRequest = client.parseOpenid4vpAuthorizationRequest({
+            authorizationRequest: res.body.uri,
+        });
+
+        const resolved = await client.resolveOpenId4vpAuthorizationRequest({
+            authorizationRequestPayload: authRequest.params,
+            responseMode: { type: "direct_post" },
+        });
+
+        const vp_token = await preparePresentation(
+            {
+                iat: Math.floor(Date.now() / 1000),
+                aud: resolved.authorizationRequestPayload.client_id as string,
+                nonce: resolved.authorizationRequestPayload.nonce,
+            },
+            privateIssuerKey,
+            issuerCertChain,
+            statusListService,
+            credentialConfigId,
+        );
+
+        const jwt = await encryptVpToken(vp_token, "pid", resolved);
+
+        const authorizationResponse =
+            await client.createOpenid4vpAuthorizationResponse({
+                authorizationRequestPayload: authRequest.params,
+                authorizationResponsePayload: {
+                    response: jwt,
+                },
+                ...callbacks,
+            });
+
+        const submitRes = await client.submitOpenid4vpAuthorizationResponse({
+            authorizationResponsePayload:
+                authorizationResponse.authorizationResponsePayload,
+            authorizationRequestPayload:
+                resolved.authorizationRequestPayload as Openid4vpAuthorizationRequest,
+        });
+
+        expect(submitRes.response.status).toBe(200);
+    });
+
     test("present sd jwt credential with A256GCM encryption", async () => {
         const requestBody: PresentationRequest = {
             response_type: ResponseType.URI,

--- a/schemas/CredentialQuery.schema.json
+++ b/schemas/CredentialQuery.schema.json
@@ -20,6 +20,15 @@
         "$ref": "./ClaimsQuery.schema.json"
       }
     },
+    "claim_sets": {
+      "type": "array",
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    },
     "meta": {
       "type": "object"
     },


### PR DESCRIPTION
## 📝 Description

Add OpenID4VP DCQL `claim_sets` support to presentation verification, including ordered fallback handling, validation for malformed claim-set definitions, and coverage for SD-JWT and mDOC presentation flows.

Fixes #747

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🧪 Test improvements

## 💥 Breaking Changes (if applicable)

None.

## 🧪 Testing

- [x] E2E tests pass
- [x] Manual testing performed

Targeted test run:
- `apps/backend/test/presentation/presentation-sdjwt.e2e-spec.ts`
- `apps/backend/test/presentation/presentation-mdoc.e2e-spec.ts`
- `apps/backend/test/presentation/presentation-offer.e2e-spec.ts`

## 📋 Additional Notes

The mDOC path now evaluates claim sets in order and matches against the flattened verifier output, which keeps the fallback behavior aligned with the credential data returned by the verifier.