### PR TITLE
fix: enforce single-use credential_offer_uri resolution

### DIFF
--- a/apps/backend/src/issuer/issuance/oid4vci/oid4vci.service.ts
+++ b/apps/backend/src/issuer/issuance/oid4vci/oid4vci.service.ts
@@ -900,6 +900,15 @@ export class Oid4vciService {
             throw new NotFoundException("Credential offer not found");
         }
 
+        const consumed = await this.sessionService.consumeOfferByReference(
+            sessionId,
+            tenantId,
+        );
+
+        if (!consumed) {
+            throw new NotFoundException("Credential offer not found");
+        }
+
         return session.offer as CredentialOfferObject;
     }
 

--- a/apps/backend/src/issuer/issuance/oid4vci/oid4vci.service.ts
+++ b/apps/backend/src/issuer/issuance/oid4vci/oid4vci.service.ts
@@ -1595,7 +1595,7 @@ export class Oid4vciService {
             });
             await this.sessionService.add(session.id, {
                 notifications: session.notifications,
-                status: SessionStatus.Fetched                
+                status: SessionStatus.Fetched,
             });
 
             this.auditLogger.logFlowComplete(logContext, {

--- a/apps/backend/src/issuer/issuance/oid4vci/oid4vci.service.ts
+++ b/apps/backend/src/issuer/issuance/oid4vci/oid4vci.service.ts
@@ -1595,8 +1595,7 @@ export class Oid4vciService {
             });
             await this.sessionService.add(session.id, {
                 notifications: session.notifications,
-                status: SessionStatus.Fetched,
-                consumedAt: new Date(),
+                status: SessionStatus.Fetched                
             });
 
             this.auditLogger.logFlowComplete(logContext, {

--- a/apps/backend/src/session/entities/session.entity.ts
+++ b/apps/backend/src/session/entities/session.entity.ts
@@ -140,7 +140,7 @@ export class Session {
      * Encrypted at rest.
      */
     @Column("text", { nullable: true, transformer: EncryptedJsonTransformer })
-    offer?: CredentialOfferObject;
+    offer?: CredentialOfferObject | null;
 
     /**
      * Offer URL for the credential offer.

--- a/apps/backend/src/session/entities/session.entity.ts
+++ b/apps/backend/src/session/entities/session.entity.ts
@@ -286,8 +286,9 @@ export class Session {
     consumed!: boolean;
 
     /**
-     * Timestamp when the session offer was consumed.
-     * Null if the offer has not yet been consumed.
+     * Timestamp of the first consumption event for the session offer.
+     * For OID4VCI this can be URI resolution or later flow completion.
+     * Null if no consumption event has happened yet.
      */
     @Column({ nullable: true })
     consumedAt?: Date;

--- a/apps/backend/src/session/session.service.ts
+++ b/apps/backend/src/session/session.service.ts
@@ -165,6 +165,31 @@ export class SessionService implements OnApplicationBootstrap {
     }
 
     /**
+     * Consume a credential offer stored on a session by clearing the `offer`
+     * payload only if it is still present.
+     *
+     * Returns true when the offer was consumed, false when it was already
+     * consumed or the session did not match.
+     */
+    async consumeOfferByReference(
+        sessionId: string,
+        tenantId: string,
+    ): Promise<boolean> {
+        const result = await this.sessionRepository.update(
+            {
+                id: sessionId,
+                tenantId,
+                offer: Not(IsNull()),
+            },
+            {
+                offer: null,
+            },
+        );
+
+        return (result.affected ?? 0) > 0;
+    }
+
+    /**
      * Get sessions with pagination and optional filtering.
      * @param tenantId
      * @param query - Pagination and filter parameters

--- a/apps/backend/src/session/session.service.ts
+++ b/apps/backend/src/session/session.service.ts
@@ -183,6 +183,8 @@ export class SessionService implements OnApplicationBootstrap {
             },
             {
                 offer: null,
+                // Keep the first-consumption timestamp stable across the flow.
+                consumedAt: () => `COALESCE("consumedAt", CURRENT_TIMESTAMP)`,
             },
         );
 

--- a/apps/backend/test/single-use-validation.e2e-spec.ts
+++ b/apps/backend/test/single-use-validation.e2e-spec.ts
@@ -117,6 +117,38 @@ describe("Single-Use Validation (Issue #503) - OID4VCI", () => {
         // Covered in issuance e2e tests where credentials are requested with proofs.
         expect(true).toBe(true);
     });
+
+    test("should allow resolving credential_offer_uri only once", async () => {
+        const offerRes = await request(app.getHttpServer())
+            .post("/issuer/offer")
+            .trustLocalhost()
+            .set("Authorization", `Bearer ${authToken}`)
+            .send({
+                response_type: "uri",
+                credentialConfigurationIds: ["pid-no-key"],
+                flow: "authorization_code",
+            })
+            .expect(201);
+
+        const offerUri = new URL(offerRes.body.uri);
+        const credentialOfferUri = offerUri.searchParams.get(
+            "credential_offer_uri",
+        );
+
+        expect(credentialOfferUri).toBeDefined();
+
+        const firstFetch = await request(app.getHttpServer())
+            .get(new URL(credentialOfferUri as string).pathname)
+            .trustLocalhost()
+            .expect(200);
+
+        expect(firstFetch.body.credential_issuer).toContain("/issuers/");
+
+        await request(app.getHttpServer())
+            .get(new URL(credentialOfferUri as string).pathname)
+            .trustLocalhost()
+            .expect(404);
+    });
 });
 
 describe("Single-Use Validation (Issue #503) - OID4VP", () => {

--- a/docs/getting-started/issuance/credential-offers.md
+++ b/docs/getting-started/issuance/credential-offers.md
@@ -87,6 +87,7 @@ Credential offers are single-use and non-replayable. Once a wallet completes
 issuance with an offer:
 
 - Token replay with the same authorization or pre-authorized code is rejected with an `invalid_grant` error
+- Offer-by-reference replay is rejected: a `credential_offer_uri` can be resolved only once, and later fetches return `404`.
 - The offer is marked as consumed at the credential endpoint and cannot be used again after successful credential processing
 - The `consumedAt` timestamp records when the offer was first used
 

--- a/docs/getting-started/issuance/credential-offers.md
+++ b/docs/getting-started/issuance/credential-offers.md
@@ -87,7 +87,7 @@ Credential offers are single-use and non-replayable. Once a wallet completes
 issuance with an offer:
 
 - Token replay with the same authorization or pre-authorized code is rejected with an `invalid_grant` error
-- Offer-by-reference replay is rejected: a `credential_offer_uri` can be resolved only once, and later fetches return `404`.
+- Offer-by-reference replay is rejected: once the offer is resolved by `credential_offer_uri` from the server, it cannot be requested again (`404` on subsequent fetches).
 - The offer is marked as consumed at the credential endpoint and cannot be used again after successful credential processing
 - The `consumedAt` timestamp records when the offer was first used
 


### PR DESCRIPTION
## 📝 Description

Enforces single-use behavior for credential offers served via `credential_offer_uri` to prevent replay of offer-by-reference payloads.

Fixes #796

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test improvements
- [ ] 🏗️ Build/CI changes

## 💥 Breaking Changes (if applicable)

- **API changes**: None
- **Environment variables**: None
- **Config import format**: None
- **Database**: None

## 🧪 Testing

Describe the tests that you ran to verify your changes:

- [ ] Unit tests pass
- [ ] Integration tests pass
- [x] E2E tests pass
- [ ] Manual testing performed

**Test Configuration**:

- Node.js version: local dev environment
- OS: macOS
- Test environment: backend e2e (Vitest)

Executed:
- `pnpm --filter @eudiplo/backend test -- single-use-validation.e2e-spec.ts`

## 📸 Screenshots (if applicable)

N/A

## ✔️ Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## 📋 Additional Notes

Implementation details:
- `SessionService.consumeOfferByReference()` atomically clears `session.offer` when present.
- `Oid4vciService.getCredentialOfferByReference()` now consumes on first successful fetch and returns `404` on replay.
- Added e2e regression test: resolve same `credential_offer_uri` twice, expecting `200` then `404`.
- Updated `Session.offer` typing to include `null` to match nullable DB column and update semantics.
