### PR TITLE
fix(client): decouple mdoc namespace from field path

### DIFF
--- a/apps/client/src/app/issuance/credential-config/credential-config-create/credential-config-create.component.html
+++ b/apps/client/src/app/issuance/credential-config/credential-config-create/credential-config-create.component.html
@@ -778,8 +778,10 @@
                 Define the claims/attributes included in this credential. Each field maps to a
                 credential attribute with its type, default value, and disclosure settings. For
                 SD-JWT credentials, the <em>disclosable</em> flag controls selective disclosure. For
-                mDOC credentials, enter claim paths relative to the document type; the docType is
-                used as the namespace prefix automatically.
+                mDOC credentials, set the namespace explicitly per field and enter the claim name in
+                <em>Path</em>. For advanced nested/array mDOC claims, use <em>View as JSON</em> and
+                define path arrays directly (for example
+                <code>["driving_privileges", null, "vehicle_category_code"]</code>).
               </mat-card-subtitle>
             </mat-card-header>
             <mat-card-content>
@@ -804,19 +806,42 @@
                     <div fxLayout="column" fxLayoutGap="16px" class="field-panel-content">
                       <!-- Path + Type row -->
                       <div fxLayout="row" fxLayoutGap="16px">
+                        @if (isMdocFormat) {
+                          <mat-form-field fxFlex="35">
+                            <mat-label>Namespace</mat-label>
+                            <input
+                              matInput
+                              [attr.id]="'field-namespace-' + i"
+                              formControlName="namespace"
+                              placeholder="e.g. eu.europa.ec.eudi.pid.1"
+                            />
+                            <mat-hint>mDOC namespace (for example org.iso.18013.5.1).</mat-hint>
+                          </mat-form-field>
+                        }
                         <mat-form-field fxFlex="60">
                           <mat-label>Path</mat-label>
                           <input
                             matInput
                             [attr.id]="'field-path-' + i"
                             formControlName="path"
-                            placeholder="e.g. given_name or address.locality"
+                            [placeholder]="
+                              isMdocFormat
+                                ? 'e.g. given_name'
+                                : 'e.g. given_name or address.locality'
+                            "
                           />
-                          <mat-hint
-                            >Dot-separated path. Use <code>*</code> for array wildcard.</mat-hint
-                          >
+                          @if (isMdocFormat) {
+                            <mat-hint
+                              >mDOC claim name. For nested arrays use View as JSON with
+                              <code>null</code> wildcard segments.</mat-hint
+                            >
+                          } @else {
+                            <mat-hint
+                              >Dot-separated path. Use <code>*</code> for array wildcard.</mat-hint
+                            >
+                          }
                         </mat-form-field>
-                        <mat-form-field fxFlex="40">
+                        <mat-form-field [fxFlex]="isMdocFormat ? 25 : 40">
                           <mat-label>Type</mat-label>
                           <mat-select formControlName="type">
                             @for (t of fieldTypes; track t) {

--- a/apps/client/src/app/issuance/credential-config/credential-config-create/credential-config-create.component.spec.ts
+++ b/apps/client/src/app/issuance/credential-config/credential-config-create/credential-config-create.component.spec.ts
@@ -20,38 +20,77 @@ describe('CredentialConfigCreateComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('normalizes mDOC field paths to be relative in the form and namespaced when saving', () => {
+  it('normalizes mDOC field paths to be relative in the form and stores namespace separately', () => {
     component.form.get('format')?.setValue('mso_mdoc');
     component.form.get('docType')?.setValue('eu.europa.ec.eudi.pid.1');
 
     const fieldGroup = component.createFieldGroup({
       path: ['eu.europa.ec.eudi.pid.1', 'given_name'],
+      namespace: 'eu.europa.ec.eudi.pid.1',
       type: 'string',
       defaultValue: 'ERIKA',
     } as any);
 
     expect(fieldGroup.get('path')?.value).toBe('given_name');
+    expect(fieldGroup.get('namespace')?.value).toBe('eu.europa.ec.eudi.pid.1');
 
     const payload = (component as any).buildFieldsPayload(
       [
         {
           path: 'given_name',
+          namespace: 'eu.europa.ec.eudi.pid.1',
           type: 'string',
           defaultValue: '"ERIKA"',
           mandatory: true,
         },
       ],
-      true,
-      'eu.europa.ec.eudi.pid.1'
+      true
     );
 
     expect(payload).toEqual([
       {
-        path: ['eu.europa.ec.eudi.pid.1', 'given_name'],
+        path: ['given_name'],
+        namespace: 'eu.europa.ec.eudi.pid.1',
         type: 'string',
         mandatory: true,
         defaultValue: 'ERIKA',
       },
     ]);
+  });
+
+  it('does not split dotted mDOC claim names into nested path segments', () => {
+    component.form.get('format')?.setValue('mso_mdoc');
+
+    const payload = (component as any).buildFieldsPayload(
+      [
+        {
+          path: 'org.iso.18013.5.1.given_name',
+          namespace: 'eu.europa.ec.eudi.mdl.1',
+          type: 'string',
+        },
+      ],
+      true
+    );
+
+    expect(payload).toEqual([
+      {
+        path: ['org.iso.18013.5.1.given_name'],
+        namespace: 'eu.europa.ec.eudi.mdl.1',
+        type: 'string',
+        mandatory: false,
+      },
+    ]);
+  });
+
+  it('does not auto-fill mDOC namespace from docType', () => {
+    component.form.get('format')?.setValue('mso_mdoc');
+    component.form.get('docType')?.setValue('eu.europa.ec.eudi.mdl.1');
+
+    const fieldGroup = component.createFieldGroup({
+      path: ['given_name'],
+      type: 'string',
+    } as any);
+
+    expect(fieldGroup.get('namespace')?.value).toBe('');
   });
 });

--- a/apps/client/src/app/issuance/credential-config/credential-config-create/credential-config-create.component.ts
+++ b/apps/client/src/app/issuance/credential-config/credential-config-create/credential-config-create.component.ts
@@ -701,9 +701,11 @@ export class CredentialConfigCreateComponent implements OnInit {
       (field?.display || []).map((entry) => this.createFieldDisplayGroup(entry))
     );
     const isMdoc = this.form.get('format')?.value === 'mso_mdoc';
+    const namespace = this.getFieldNamespaceForForm(field, isMdoc);
 
     return new FormGroup({
       path: new FormControl(this.normalizeFieldPathForForm(field, isMdoc), [Validators.required]),
+      namespace: new FormControl(namespace),
       type: new FormControl(field?.type || 'string', [Validators.required]),
       defaultValue: new FormControl(this.stringifyField(field?.defaultValue)),
       mandatory: new FormControl(!!field?.mandatory),
@@ -871,11 +873,7 @@ export class CredentialConfigCreateComponent implements OnInit {
       }),
     };
 
-    formValue.fields = this.buildFieldsPayload(
-      formValue.fields || [],
-      isMdoc,
-      formValue.docType || formValue.namespace
-    );
+    formValue.fields = this.buildFieldsPayload(formValue.fields || [], isMdoc);
 
     // Convert empty strings to null to clear optional fields (for PATCH semantics)
     formValue.keyChainId = formValue.keyChainId || null;
@@ -958,25 +956,19 @@ export class CredentialConfigCreateComponent implements OnInit {
     return mode === 'extract' ? extractSchema(value) : parsed;
   }
 
-  private buildFieldsPayload(
-    rawFields: any[],
-    isMdoc: boolean,
-    defaultNamespace?: string
-  ): ClaimFieldDefinitionDto[] {
+  private buildFieldsPayload(rawFields: any[], isMdoc: boolean): ClaimFieldDefinitionDto[] {
     return rawFields
       .map((rawField: any) => {
-        const path = this.parseFieldPath(rawField['path']);
+        const path = this.parseFieldPath(rawField['path'], isMdoc);
         const defaultValueRaw = rawField['defaultValue']?.trim();
-        const namespace = rawField['namespace']?.trim() || defaultNamespace?.trim() || undefined;
-        const normalizedPath =
-          isMdoc && namespace ? this.ensureNamespacedPath(path, namespace) : path;
+        const namespace = rawField['namespace']?.trim() || undefined;
 
         const field: ClaimFieldDefinitionDto = {
-          path: normalizedPath,
+          path,
           type: rawField['type'],
           mandatory: !!rawField['mandatory'],
           ...(isMdoc ? {} : { disclosable: !!rawField['disclosable'] }),
-          ...(!isMdoc && namespace ? { namespace } : {}),
+          ...(namespace ? { namespace } : {}),
         };
 
         if (defaultValueRaw) {
@@ -1000,15 +992,41 @@ export class CredentialConfigCreateComponent implements OnInit {
       .filter((field) => field.path.length > 0);
   }
 
-  private parseFieldPath(value: string): string[] {
+  private parseFieldPath(value: string, isMdoc: boolean): string[] {
     if (!value) {
       return [];
+    }
+
+    if (isMdoc) {
+      const trimmed = value.trim();
+      return trimmed ? [trimmed] : [];
     }
 
     return value
       .split('.')
       .map((segment) => segment.trim())
       .filter(Boolean);
+  }
+
+  private getFieldNamespaceForForm(
+    field: ClaimFieldDefinitionDto | undefined,
+    isMdoc: boolean
+  ): string {
+    const explicitNamespace = field?.namespace?.trim();
+    if (explicitNamespace) {
+      return explicitNamespace;
+    }
+
+    if (!isMdoc) {
+      return '';
+    }
+
+    const firstSegment = field?.path?.[0];
+    if (typeof firstSegment === 'string' && field?.path && field.path.length > 1) {
+      return firstSegment;
+    }
+
+    return '';
   }
 
   private normalizeFieldPathForForm(
@@ -1020,24 +1038,16 @@ export class CredentialConfigCreateComponent implements OnInit {
       return path.join('.') || '';
     }
 
-    const namespace = field?.namespace?.trim() || this.form.get('docType')?.value?.trim() || '';
+    const namespace = this.getFieldNamespaceForForm(field, isMdoc);
     if (namespace && path[0] === namespace) {
       return path.slice(1).join('.');
     }
 
+    if (!field?.namespace && path.length > 1) {
+      return path.slice(1).join('.');
+    }
+
     return path.join('.');
-  }
-
-  private ensureNamespacedPath(path: string[], namespace: string): string[] {
-    if (path.length === 0) {
-      return path;
-    }
-
-    if (path[0] === namespace) {
-      return path;
-    }
-
-    return [namespace, ...path];
   }
 
   /**


### PR DESCRIPTION
## 📝 Description

This PR updates credential field management for mDOC so namespace and claim path are handled explicitly and safely:

- adds explicit `namespace` input for mDOC fields in the create/edit UI
- keeps mDOC `path` as claim-local (no namespace prefix auto-injection)
- stops splitting mDOC path input by `.` (prevents accidental nesting for dotted claim names)
- updates mDOC helper text in Field Management to explain correct configuration
- updates component tests to cover:
  - namespace stored separately
  - dotted mDOC claim names are not split
  - namespace is not auto-filled from `docType`

Fixes #N/A

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test improvements
- [ ] 🏗️ Build/CI changes

## 💥 Breaking Changes (if applicable)

- **API changes**: None
- **Environment variables**: None
- **Config import format**: None
- **Database**: None

## 🧪 Testing

Describe the tests that you ran to verify your changes:

- [x] Unit tests pass
- [ ] Integration tests pass
- [ ] E2E tests pass
- [x] Manual testing performed

**Test Configuration**:

- Node.js version: (local workspace default)
- OS: macOS
- Test environment: local workspace

Commands run:

- `pnpm --filter @eudiplo/client build`
- lint/format checks were also executed by project hooks during commit

## 📸 Screenshots (if applicable)

N/A

## ✔️ Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## 📋 Additional Notes

Branch: `fix/mdoc-namespace-field-management`

This PR intentionally keeps the current simple path UX and clarifies mDOC behavior, instead of introducing a new nested path builder UI.