### PR TITLE
feat: move refresh-token policy to auth server config and unify credential field editing

### DIFF
--- a/apps/backend/src/database/migrations/1768000000000-RemoveRefreshTokenFromIssuanceConfig.ts
+++ b/apps/backend/src/database/migrations/1768000000000-RemoveRefreshTokenFromIssuanceConfig.ts
@@ -22,9 +22,10 @@ export class RemoveRefreshTokenFromIssuanceConfig1768000000000
             return;
         }
 
-        const hasRefreshTokenExpiresInSeconds = issuanceConfigTable.columns.some(
-            (col) => col.name === "refreshTokenExpiresInSeconds",
-        );
+        const hasRefreshTokenExpiresInSeconds =
+            issuanceConfigTable.columns.some(
+                (col) => col.name === "refreshTokenExpiresInSeconds",
+            );
         if (hasRefreshTokenExpiresInSeconds) {
             await queryRunner.dropColumn(
                 "issuance_config",
@@ -78,9 +79,10 @@ export class RemoveRefreshTokenFromIssuanceConfig1768000000000
             );
         }
 
-        const hasRefreshTokenExpiresInSeconds = issuanceConfigTable.columns.some(
-            (col) => col.name === "refreshTokenExpiresInSeconds",
-        );
+        const hasRefreshTokenExpiresInSeconds =
+            issuanceConfigTable.columns.some(
+                (col) => col.name === "refreshTokenExpiresInSeconds",
+            );
         if (!hasRefreshTokenExpiresInSeconds) {
             await queryRunner.addColumn(
                 "issuance_config",

--- a/apps/backend/src/database/migrations/1768000000000-RemoveRefreshTokenFromIssuanceConfig.ts
+++ b/apps/backend/src/database/migrations/1768000000000-RemoveRefreshTokenFromIssuanceConfig.ts
@@ -1,0 +1,99 @@
+import { MigrationInterface, QueryRunner, TableColumn } from "typeorm";
+
+/**
+ * Remove legacy refresh token settings from issuance_config.
+ *
+ * Refresh token behavior is now configured per authorization server
+ * via authorizationServers[].token.
+ */
+export class RemoveRefreshTokenFromIssuanceConfig1768000000000
+    implements MigrationInterface
+{
+    name = "RemoveRefreshTokenFromIssuanceConfig1768000000000";
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const issuanceConfigTable =
+            await queryRunner.getTable("issuance_config");
+
+        if (!issuanceConfigTable) {
+            console.log(
+                "[Migration] issuance_config table not found - skipping (schema may not exist yet).",
+            );
+            return;
+        }
+
+        const hasRefreshTokenExpiresInSeconds = issuanceConfigTable.columns.some(
+            (col) => col.name === "refreshTokenExpiresInSeconds",
+        );
+        if (hasRefreshTokenExpiresInSeconds) {
+            await queryRunner.dropColumn(
+                "issuance_config",
+                "refreshTokenExpiresInSeconds",
+            );
+            console.log(
+                "[Migration] Dropped refreshTokenExpiresInSeconds from issuance_config.",
+            );
+        }
+
+        const hasRefreshTokenEnabled = issuanceConfigTable.columns.some(
+            (col) => col.name === "refreshTokenEnabled",
+        );
+        if (hasRefreshTokenEnabled) {
+            await queryRunner.dropColumn(
+                "issuance_config",
+                "refreshTokenEnabled",
+            );
+            console.log(
+                "[Migration] Dropped refreshTokenEnabled from issuance_config.",
+            );
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const issuanceConfigTable =
+            await queryRunner.getTable("issuance_config");
+
+        if (!issuanceConfigTable) {
+            console.log(
+                "[Migration] issuance_config table not found - skipping (schema may not exist yet).",
+            );
+            return;
+        }
+
+        const hasRefreshTokenEnabled = issuanceConfigTable.columns.some(
+            (col) => col.name === "refreshTokenEnabled",
+        );
+        if (!hasRefreshTokenEnabled) {
+            await queryRunner.addColumn(
+                "issuance_config",
+                new TableColumn({
+                    name: "refreshTokenEnabled",
+                    type: "boolean",
+                    default: true,
+                    isNullable: false,
+                }),
+            );
+            console.log(
+                "[Migration] Re-added refreshTokenEnabled to issuance_config.",
+            );
+        }
+
+        const hasRefreshTokenExpiresInSeconds = issuanceConfigTable.columns.some(
+            (col) => col.name === "refreshTokenExpiresInSeconds",
+        );
+        if (!hasRefreshTokenExpiresInSeconds) {
+            await queryRunner.addColumn(
+                "issuance_config",
+                new TableColumn({
+                    name: "refreshTokenExpiresInSeconds",
+                    type: "int",
+                    default: 2592000,
+                    isNullable: true,
+                }),
+            );
+            console.log(
+                "[Migration] Re-added refreshTokenExpiresInSeconds to issuance_config.",
+            );
+        }
+    }
+}

--- a/apps/backend/src/database/migrations/1769000000000-RemovePreferredAuthServerFromIssuanceConfig.ts
+++ b/apps/backend/src/database/migrations/1769000000000-RemovePreferredAuthServerFromIssuanceConfig.ts
@@ -1,0 +1,67 @@
+import { MigrationInterface, QueryRunner, TableColumn } from "typeorm";
+
+/**
+ * Remove legacy preferred authorization server selection from issuance_config.
+ *
+ * Authorization server priority is now inferred from the order of
+ * authorizationServers[] in configuration.
+ */
+export class RemovePreferredAuthServerFromIssuanceConfig1769000000000
+    implements MigrationInterface
+{
+    name = "RemovePreferredAuthServerFromIssuanceConfig1769000000000";
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const issuanceConfigTable =
+            await queryRunner.getTable("issuance_config");
+
+        if (!issuanceConfigTable) {
+            console.log(
+                "[Migration] issuance_config table not found - skipping (schema may not exist yet).",
+            );
+            return;
+        }
+
+        const hasPreferredAuthServer = issuanceConfigTable.columns.some(
+            (col) => col.name === "preferredAuthServer",
+        );
+        if (hasPreferredAuthServer) {
+            await queryRunner.dropColumn(
+                "issuance_config",
+                "preferredAuthServer",
+            );
+            console.log(
+                "[Migration] Dropped preferredAuthServer from issuance_config.",
+            );
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const issuanceConfigTable =
+            await queryRunner.getTable("issuance_config");
+
+        if (!issuanceConfigTable) {
+            console.log(
+                "[Migration] issuance_config table not found - skipping (schema may not exist yet).",
+            );
+            return;
+        }
+
+        const hasPreferredAuthServer = issuanceConfigTable.columns.some(
+            (col) => col.name === "preferredAuthServer",
+        );
+        if (!hasPreferredAuthServer) {
+            await queryRunner.addColumn(
+                "issuance_config",
+                new TableColumn({
+                    name: "preferredAuthServer",
+                    type: "varchar",
+                    isNullable: true,
+                }),
+            );
+            console.log(
+                "[Migration] Re-added preferredAuthServer to issuance_config.",
+            );
+        }
+    }
+}

--- a/apps/backend/src/database/migrations/index.ts
+++ b/apps/backend/src/database/migrations/index.ts
@@ -32,3 +32,4 @@ export { AddKmsExternalKeyIdCheck1764000000000 } from "./1764000000000-AddKmsExt
 export { RenameKeyChainActiveKeyToActiveJwk1765000000000 } from "./1765000000000-RenameKeyChainActiveKeyToActiveJwk";
 export { AddAuthorizationServersToIssuanceConfig1766000000000 } from "./1766000000000-AddAuthorizationServersToIssuanceConfig";
 export { AddIssuerRegistrationCertificateToIssuanceConfig1767000000000 } from "./1767000000000-AddIssuerRegistrationCertificateToIssuanceConfig";
+export { RemoveRefreshTokenFromIssuanceConfig1768000000000 } from "./1768000000000-RemoveRefreshTokenFromIssuanceConfig";

--- a/apps/backend/src/database/migrations/index.ts
+++ b/apps/backend/src/database/migrations/index.ts
@@ -33,3 +33,4 @@ export { RenameKeyChainActiveKeyToActiveJwk1765000000000 } from "./1765000000000
 export { AddAuthorizationServersToIssuanceConfig1766000000000 } from "./1766000000000-AddAuthorizationServersToIssuanceConfig";
 export { AddIssuerRegistrationCertificateToIssuanceConfig1767000000000 } from "./1767000000000-AddIssuerRegistrationCertificateToIssuanceConfig";
 export { RemoveRefreshTokenFromIssuanceConfig1768000000000 } from "./1768000000000-RemoveRefreshTokenFromIssuanceConfig";
+export { RemovePreferredAuthServerFromIssuanceConfig1769000000000 } from "./1769000000000-RemovePreferredAuthServerFromIssuanceConfig";

--- a/apps/backend/src/issuer/configuration/issuance/dto/authorization-server-config.dto.ts
+++ b/apps/backend/src/issuer/configuration/issuance/dto/authorization-server-config.dto.ts
@@ -6,7 +6,6 @@ import {
     IsOptional,
     IsString,
     IsUrl,
-    ValidateIf,
     ValidateNested,
 } from "class-validator";
 import {
@@ -14,14 +13,21 @@ import {
     UpstreamOidcConfig,
 } from "./chained-as-config.dto";
 
+export type AuthorizationServerType =
+    | "external"
+    | "oid4vp"
+    | "chained"
+    | "built-in";
+
 export class ManagedAuthorizationServerConfig {
     @ApiProperty({
-        description: "Stable identifier used in the AS URL path",
-        example: "pid-auth",
+        description: "Authorization server implementation type",
+        enum: ["external", "oid4vp", "chained", "built-in"],
+        example: "external",
     })
-    @ValidateIf((o) => o.type === "oid4vp")
     @IsString()
-    id?: string;
+    @IsIn(["external", "oid4vp", "chained", "built-in"])
+    type!: AuthorizationServerType;
 
     @ApiPropertyOptional({
         description: "Human-friendly label for the UI",
@@ -31,32 +37,6 @@ export class ManagedAuthorizationServerConfig {
     @IsString()
     label?: string;
 
-    @ApiProperty({
-        description: "Authorization server implementation type",
-        enum: ["external", "oid4vp", "chained", "built-in"],
-        example: "external",
-    })
-    @IsString()
-    @IsIn(["external", "oid4vp", "chained", "built-in"])
-    type!: "external" | "oid4vp" | "chained" | "built-in";
-
-    @ApiPropertyOptional({
-        description: "Issuer URL for external authorization servers",
-        example: "https://auth.example.com",
-    })
-    @ValidateIf((o) => o.type === "external")
-    @IsUrl({ require_tld: false })
-    issuer?: string;
-
-    @ApiPropertyOptional({
-        description: "Upstream OIDC provider configuration for chained mode",
-        type: () => UpstreamOidcConfig,
-    })
-    @ValidateIf((o) => o.type === "chained")
-    @ValidateNested()
-    @Type(() => UpstreamOidcConfig)
-    upstream?: UpstreamOidcConfig;
-
     @ApiPropertyOptional({
         description: "Whether this managed authorization server is enabled",
         default: true,
@@ -64,52 +44,146 @@ export class ManagedAuthorizationServerConfig {
     @IsOptional()
     @IsBoolean()
     enabled?: boolean;
+}
+
+export class ExternalAuthorizationServerConfig extends ManagedAuthorizationServerConfig {
+    @ApiProperty({
+        description: "Authorization server implementation type",
+        enum: ["external"],
+        example: "external",
+    })
+    @IsString()
+    @IsIn(["external"])
+    declare type: "external";
+
+    @ApiProperty({
+        description: "Issuer URL for external authorization servers",
+        example: "https://auth.example.com",
+    })
+    @IsUrl({ require_tld: false })
+    declare issuer: string;
+}
+
+export class Oid4VpAuthorizationServerConfig extends ManagedAuthorizationServerConfig {
+    @ApiProperty({
+        description: "Authorization server implementation type",
+        enum: ["oid4vp"],
+        example: "oid4vp",
+    })
+    @IsString()
+    @IsIn(["oid4vp"])
+    declare type: "oid4vp";
+
+    @ApiProperty({
+        description: "Stable identifier used in the AS URL path",
+        example: "pid-auth",
+    })
+    @IsString()
+    declare id: string;
 
     @ApiProperty({
         description: "Presentation configuration ID to use for OID4VP",
         example: "playground-pid",
     })
-    @ValidateIf((o) => o.type === "oid4vp")
     @IsString()
-    presentationConfigId?: string;
+    declare presentationConfigId: string;
 
     @ApiPropertyOptional({
         description:
             "Immediately redirect the browser into the wallet OID4VP request",
         default: true,
     })
-    @ValidateIf((o) => o.type === "oid4vp")
     @IsOptional()
     @IsBoolean()
-    immediateWalletRedirect?: boolean;
+    declare immediateWalletRedirect?: boolean;
 
     @ApiPropertyOptional({
         description: "Token configuration for this authorization server",
         type: () => ChainedAsTokenConfig,
     })
-    @ValidateIf(
-        (o) =>
-            o.type === "oid4vp" ||
-            o.type === "chained" ||
-            o.type === "built-in",
-    )
     @IsOptional()
     @ValidateNested()
     @Type(() => ChainedAsTokenConfig)
-    token?: ChainedAsTokenConfig;
+    declare token?: ChainedAsTokenConfig;
 
     @ApiPropertyOptional({
         description:
             "Require DPoP for token requests issued by this authorization server",
         default: false,
     })
-    @ValidateIf(
-        (o) =>
-            o.type === "oid4vp" ||
-            o.type === "chained" ||
-            o.type === "built-in",
-    )
     @IsOptional()
     @IsBoolean()
-    requireDPoP?: boolean;
+    declare requireDPoP?: boolean;
 }
+
+export class ChainedAuthorizationServerConfig extends ManagedAuthorizationServerConfig {
+    @ApiProperty({
+        description: "Authorization server implementation type",
+        enum: ["chained"],
+        example: "chained",
+    })
+    @IsString()
+    @IsIn(["chained"])
+    declare type: "chained";
+
+    @ApiProperty({
+        description: "Upstream OIDC provider configuration for chained mode",
+        type: () => UpstreamOidcConfig,
+    })
+    @ValidateNested()
+    @Type(() => UpstreamOidcConfig)
+    declare upstream: UpstreamOidcConfig;
+
+    @ApiPropertyOptional({
+        description: "Token configuration for this authorization server",
+        type: () => ChainedAsTokenConfig,
+    })
+    @IsOptional()
+    @ValidateNested()
+    @Type(() => ChainedAsTokenConfig)
+    declare token?: ChainedAsTokenConfig;
+
+    @ApiPropertyOptional({
+        description:
+            "Require DPoP for token requests issued by this authorization server",
+        default: false,
+    })
+    @IsOptional()
+    @IsBoolean()
+    declare requireDPoP?: boolean;
+}
+
+export class BuiltInAuthorizationServerConfig extends ManagedAuthorizationServerConfig {
+    @ApiProperty({
+        description: "Authorization server implementation type",
+        enum: ["built-in"],
+        example: "built-in",
+    })
+    @IsString()
+    @IsIn(["built-in"])
+    declare type: "built-in";
+
+    @ApiPropertyOptional({
+        description: "Token configuration for this authorization server",
+        type: () => ChainedAsTokenConfig,
+    })
+    @IsOptional()
+    @ValidateNested()
+    @Type(() => ChainedAsTokenConfig)
+    declare token?: ChainedAsTokenConfig;
+
+    @ApiPropertyOptional({
+        description:
+            "Require DPoP for token requests issued by this authorization server",
+        default: false,
+    })
+    @IsOptional()
+    @IsBoolean()
+    declare requireDPoP?: boolean;
+}
+
+export type ManagedAuthorizationServerConfigUnion =
+    | ExternalAuthorizationServerConfig
+    | Oid4VpAuthorizationServerConfig
+    | ChainedAuthorizationServerConfig
+    | BuiltInAuthorizationServerConfig;

--- a/apps/backend/src/issuer/configuration/issuance/dto/authorization-server-config.dto.ts
+++ b/apps/backend/src/issuer/configuration/issuance/dto/authorization-server-config.dto.ts
@@ -33,12 +33,12 @@ export class ManagedAuthorizationServerConfig {
 
     @ApiProperty({
         description: "Authorization server implementation type",
-        enum: ["external", "oid4vp", "chained"],
+        enum: ["external", "oid4vp", "chained", "built-in"],
         example: "external",
     })
     @IsString()
-    @IsIn(["external", "oid4vp", "chained"])
-    type!: "external" | "oid4vp" | "chained";
+    @IsIn(["external", "oid4vp", "chained", "built-in"])
+    type!: "external" | "oid4vp" | "chained" | "built-in";
 
     @ApiPropertyOptional({
         description: "Issuer URL for external authorization servers",
@@ -87,7 +87,12 @@ export class ManagedAuthorizationServerConfig {
         description: "Token configuration for this authorization server",
         type: () => ChainedAsTokenConfig,
     })
-    @ValidateIf((o) => o.type === "oid4vp" || o.type === "chained")
+    @ValidateIf(
+        (o) =>
+            o.type === "oid4vp" ||
+            o.type === "chained" ||
+            o.type === "built-in",
+    )
     @IsOptional()
     @ValidateNested()
     @Type(() => ChainedAsTokenConfig)
@@ -98,7 +103,12 @@ export class ManagedAuthorizationServerConfig {
             "Require DPoP for token requests issued by this authorization server",
         default: false,
     })
-    @ValidateIf((o) => o.type === "oid4vp" || o.type === "chained")
+    @ValidateIf(
+        (o) =>
+            o.type === "oid4vp" ||
+            o.type === "chained" ||
+            o.type === "built-in",
+    )
     @IsOptional()
     @IsBoolean()
     requireDPoP?: boolean;

--- a/apps/backend/src/issuer/configuration/issuance/dto/authorization-server-config.dto.ts
+++ b/apps/backend/src/issuer/configuration/issuance/dto/authorization-server-config.dto.ts
@@ -181,9 +181,3 @@ export class BuiltInAuthorizationServerConfig extends ManagedAuthorizationServer
     @IsBoolean()
     declare requireDPoP?: boolean;
 }
-
-export type ManagedAuthorizationServerConfigUnion =
-    | ExternalAuthorizationServerConfig
-    | Oid4VpAuthorizationServerConfig
-    | ChainedAuthorizationServerConfig
-    | BuiltInAuthorizationServerConfig;

--- a/apps/backend/src/issuer/configuration/issuance/dto/chained-as-config.dto.ts
+++ b/apps/backend/src/issuer/configuration/issuance/dto/chained-as-config.dto.ts
@@ -87,6 +87,31 @@ export class ChainedAsTokenConfig {
     @IsOptional()
     @IsString()
     signingKeyId?: string;
+
+    /**
+     * Whether to issue refresh tokens.
+     * @default true
+     */
+    @ApiPropertyOptional({
+        description: "Whether refresh tokens should be issued",
+        default: true,
+    })
+    @IsOptional()
+    @IsBoolean()
+    refreshTokenEnabled?: boolean;
+
+    /**
+     * Refresh token lifetime in seconds.
+     * @default 2592000 (30 days)
+     */
+    @ApiPropertyOptional({
+        description: "Refresh token lifetime in seconds",
+        default: 2592000,
+    })
+    @IsOptional()
+    @IsNumber()
+    @Min(60)
+    refreshTokenExpiresInSeconds?: number;
 }
 
 /**

--- a/apps/backend/src/issuer/configuration/issuance/dto/update-issuance.dto.ts
+++ b/apps/backend/src/issuer/configuration/issuance/dto/update-issuance.dto.ts
@@ -1,0 +1,8 @@
+import { PartialType } from "@nestjs/swagger";
+import { IssuanceDto } from "./issuance.dto";
+
+/**
+ * DTO for partial issuance configuration updates.
+ * Validation of required runtime invariants happens after merge in the service.
+ */
+export class UpdateIssuanceDto extends PartialType(IssuanceDto) {}

--- a/apps/backend/src/issuer/configuration/issuance/entities/issuance-config.entity.ts
+++ b/apps/backend/src/issuer/configuration/issuance/entities/issuance-config.entity.ts
@@ -1,12 +1,15 @@
 import {
     ApiExtraModels,
     ApiHideProperty,
+    ApiProperty,
     ApiPropertyOptional,
+    getSchemaPath,
 } from "@nestjs/swagger";
 import { Type } from "class-transformer";
 import {
     IsArray,
     IsBoolean,
+    ArrayMinSize,
     IsNumber,
     IsOptional,
     IsString,
@@ -26,7 +29,13 @@ import {
     AuthenticationMethodNone,
     AuthenticationMethodPresentation,
 } from "../dto/authentication-config.dto";
-import { ManagedAuthorizationServerConfig } from "../dto/authorization-server-config.dto";
+import {
+    BuiltInAuthorizationServerConfig,
+    ChainedAuthorizationServerConfig,
+    ExternalAuthorizationServerConfig,
+    ManagedAuthorizationServerConfig,
+    Oid4VpAuthorizationServerConfig,
+} from "../dto/authorization-server-config.dto";
 import { DisplayInfo } from "../dto/display.dto";
 import { FederationConfig } from "../dto/federation-config.dto";
 import {
@@ -41,6 +50,11 @@ import {
     AuthenticationMethodNone,
     AuthenticationMethodAuth,
     AuthenticationMethodPresentation,
+    ManagedAuthorizationServerConfig,
+    ExternalAuthorizationServerConfig,
+    Oid4VpAuthorizationServerConfig,
+    ChainedAuthorizationServerConfig,
+    BuiltInAuthorizationServerConfig,
 )
 @Entity()
 export class IssuanceConfig {
@@ -113,15 +127,44 @@ export class IssuanceConfig {
      * Each entry creates a distinct AS endpoint and can be bound to a different
      * presentation configuration.
      */
-    @ApiPropertyOptional({
-        type: () => ManagedAuthorizationServerConfig,
-        isArray: true,
+    @ApiProperty({
+        description:
+            "Dedicated managed authorization servers hosted by this issuer. At least one entry is required.",
+        type: "array",
+        items: {
+            oneOf: [
+                { $ref: getSchemaPath(ExternalAuthorizationServerConfig) },
+                { $ref: getSchemaPath(Oid4VpAuthorizationServerConfig) },
+                { $ref: getSchemaPath(ChainedAuthorizationServerConfig) },
+                { $ref: getSchemaPath(BuiltInAuthorizationServerConfig) },
+            ],
+            discriminator: {
+                propertyName: "type",
+                mapping: {
+                    external: getSchemaPath(ExternalAuthorizationServerConfig),
+                    oid4vp: getSchemaPath(Oid4VpAuthorizationServerConfig),
+                    chained: getSchemaPath(ChainedAuthorizationServerConfig),
+                    "built-in": getSchemaPath(BuiltInAuthorizationServerConfig),
+                },
+            },
+        },
     })
+    @ArrayMinSize(1)
     @ValidateNested({ each: true })
-    @Type(() => ManagedAuthorizationServerConfig)
-    @IsOptional()
+    @Type(() => ManagedAuthorizationServerConfig, {
+        keepDiscriminatorProperty: true,
+        discriminator: {
+            property: "type",
+            subTypes: [
+                { name: "external", value: ExternalAuthorizationServerConfig },
+                { name: "oid4vp", value: Oid4VpAuthorizationServerConfig },
+                { name: "chained", value: ChainedAuthorizationServerConfig },
+                { name: "built-in", value: BuiltInAuthorizationServerConfig },
+            ],
+        },
+    })
     @Column({ type: "json", nullable: true })
-    authorizationServers?: ManagedAuthorizationServerConfig[] | null;
+    authorizationServers!: ManagedAuthorizationServerConfig[];
 
     /**
      * Optional OpenID Federation configuration used for trust evaluation.

--- a/apps/backend/src/issuer/configuration/issuance/entities/issuance-config.entity.ts
+++ b/apps/backend/src/issuer/configuration/issuance/entities/issuance-config.entity.ts
@@ -109,17 +109,6 @@ export class IssuanceConfig {
     signingKeyId?: string;
 
     /**
-     * The URL of the preferred authorization server for wallet-initiated flows.
-     * When set, this AS is placed first in the `authorization_servers` array
-     * of the credential issuer metadata, signaling wallets to use it by default.
-     * Must match one of the configured auth servers, the chained AS URL, or "built-in".
-     */
-    @IsOptional()
-    @IsString()
-    @Column({ type: "varchar", nullable: true })
-    preferredAuthServer?: string;
-
-    /**
      * Dedicated managed authorization servers hosted by this issuer.
      * Each entry creates a distinct AS endpoint and can be bound to a different
      * presentation configuration.

--- a/apps/backend/src/issuer/configuration/issuance/entities/issuance-config.entity.ts
+++ b/apps/backend/src/issuer/configuration/issuance/entities/issuance-config.entity.ts
@@ -175,20 +175,6 @@ export class IssuanceConfig {
     display!: DisplayInfo[];
 
     /**
-     * Whether to issue refresh tokens for access token requests.
-     * Default: true
-     */
-    @ApiPropertyOptional({
-        description:
-            "Whether refresh tokens should be issued for OID4VCI token responses.",
-        default: true,
-    })
-    @IsBoolean()
-    @IsOptional()
-    @Column("boolean", { default: true })
-    refreshTokenEnabled?: boolean;
-
-    /**
      * Whether to advertise support for credential response encryption in the
      * credential issuer metadata (`credential_response_encryption`). When
      * enabled, wallets MAY request encrypted credential responses. Some
@@ -221,22 +207,6 @@ export class IssuanceConfig {
     @IsOptional()
     @Column("boolean", { default: false })
     credentialRequestEncryption?: boolean;
-
-    /**
-     * Lifetime of issued refresh tokens in seconds.
-     * Default: 2592000 (30 days)
-     * Set to null for non-expiring refresh tokens (not recommended for security).
-     */
-    @ApiPropertyOptional({
-        description:
-            "Refresh token lifetime in seconds. Defaults to 2592000 (30 days).",
-        default: 2592000,
-        nullable: true,
-    })
-    @IsNumber()
-    @IsOptional()
-    @Column("int", { default: 2592000, nullable: true })
-    refreshTokenExpiresInSeconds?: number;
 
     /**
      * Maximum number of failed tx_code (transaction code) validation attempts

--- a/apps/backend/src/issuer/configuration/issuance/issuance-config.controller.ts
+++ b/apps/backend/src/issuer/configuration/issuance/issuance-config.controller.ts
@@ -5,6 +5,7 @@ import { Role } from "../../../auth/roles/role.enum";
 import { Secured } from "../../../auth/secure.decorator";
 import { Token, TokenPayload } from "../../../auth/token.decorator";
 import { IssuanceDto } from "./dto/issuance.dto";
+import { UpdateIssuanceDto } from "./dto/update-issuance.dto";
 import { IssuanceConfig } from "./entities/issuance-config.entity";
 import { IssuanceService } from "./issuance.service";
 
@@ -39,7 +40,7 @@ export class IssuanceConfigController {
      */
     @Post()
     storeIssuanceConfiguration(
-        @Body() config: IssuanceDto,
+        @Body() config: UpdateIssuanceDto,
         @Token() user: TokenPayload,
         @Req() req: Request,
     ) {

--- a/apps/backend/src/issuer/configuration/issuance/issuance.service.ts
+++ b/apps/backend/src/issuer/configuration/issuance/issuance.service.ts
@@ -217,7 +217,6 @@ export class IssuanceService {
             walletAttestationRequired: config.walletAttestationRequired,
             walletProviderTrustLists: config.walletProviderTrustLists,
             signingKeyId: config.signingKeyId,
-            preferredAuthServer: config.preferredAuthServer,
             authorizationServers: config.authorizationServers,
             federation: config.federation,
             registrationCertificate,

--- a/apps/backend/src/issuer/configuration/issuance/issuance.service.ts
+++ b/apps/backend/src/issuer/configuration/issuance/issuance.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from "@nestjs/common";
+import { BadRequestException, Injectable, Logger } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Request } from "express";
 import { Repository } from "typeorm";
@@ -159,6 +159,27 @@ export class IssuanceService {
         const filteredValue = Object.fromEntries(
             Object.entries(value).filter(([, v]) => v !== undefined),
         );
+
+        const configuredAuthorizationServers = (
+            (filteredValue as Partial<IssuanceDto>).authorizationServers ??
+            existingConfig.authorizationServers ??
+            []
+        ) as Array<{ type?: string }>;
+
+        if (configuredAuthorizationServers.length < 1) {
+            throw new BadRequestException(
+                "At least one authorization server must be configured",
+            );
+        }
+
+        const builtInCount = configuredAuthorizationServers.filter(
+            (server) => server?.type === "built-in",
+        ).length;
+        if (builtInCount > 1) {
+            throw new BadRequestException(
+                "Only one built-in authorization server can be configured",
+            );
+        }
 
         const before =
             "tenantId" in existingConfig

--- a/apps/backend/src/issuer/configuration/issuance/issuance.service.ts
+++ b/apps/backend/src/issuer/configuration/issuance/issuance.service.ts
@@ -224,8 +224,6 @@ export class IssuanceService {
             registrationCertificateCache,
             credentialResponseEncryption: config.credentialResponseEncryption,
             credentialRequestEncryption: config.credentialRequestEncryption,
-            refreshTokenEnabled: config.refreshTokenEnabled,
-            refreshTokenExpiresInSeconds: config.refreshTokenExpiresInSeconds,
             txCodeMaxAttempts: config.txCodeMaxAttempts,
         };
     }

--- a/apps/backend/src/issuer/configuration/issuance/issuance.service.ts
+++ b/apps/backend/src/issuer/configuration/issuance/issuance.service.ts
@@ -160,10 +160,11 @@ export class IssuanceService {
             Object.entries(value).filter(([, v]) => v !== undefined),
         );
 
-        const hasIncomingAuthorizationServers = Object.prototype.hasOwnProperty.call(
-            filteredValue,
-            "authorizationServers",
-        );
+        const hasIncomingAuthorizationServers =
+            Object.prototype.hasOwnProperty.call(
+                filteredValue,
+                "authorizationServers",
+            );
         const effectiveAuthorizationServers = hasIncomingAuthorizationServers
             ? (filteredValue as Partial<IssuanceDto>).authorizationServers
             : existingConfig.authorizationServers;
@@ -174,9 +175,10 @@ export class IssuanceService {
             );
         }
 
-        const configuredAuthorizationServers = effectiveAuthorizationServers as Array<{
-            type?: string;
-        }>;
+        const configuredAuthorizationServers =
+            effectiveAuthorizationServers as Array<{
+                type?: string;
+            }>;
 
         if (configuredAuthorizationServers.length < 1) {
             throw new BadRequestException(

--- a/apps/backend/src/issuer/configuration/issuance/issuance.service.ts
+++ b/apps/backend/src/issuer/configuration/issuance/issuance.service.ts
@@ -138,7 +138,7 @@ export class IssuanceService {
      */
     async storeIssuanceConfiguration(
         tenantId: string,
-        value: IssuanceDto,
+        value: Partial<IssuanceDto>,
         actorToken?: TokenPayload,
         req?: Request,
     ) {
@@ -160,11 +160,23 @@ export class IssuanceService {
             Object.entries(value).filter(([, v]) => v !== undefined),
         );
 
-        const configuredAuthorizationServers = ((
-            filteredValue as Partial<IssuanceDto>
-        ).authorizationServers ??
-            existingConfig.authorizationServers ??
-            []) as Array<{ type?: string }>;
+        const hasIncomingAuthorizationServers = Object.prototype.hasOwnProperty.call(
+            filteredValue,
+            "authorizationServers",
+        );
+        const effectiveAuthorizationServers = hasIncomingAuthorizationServers
+            ? (filteredValue as Partial<IssuanceDto>).authorizationServers
+            : existingConfig.authorizationServers;
+
+        if (!Array.isArray(effectiveAuthorizationServers)) {
+            throw new BadRequestException(
+                "At least one authorization server must be configured",
+            );
+        }
+
+        const configuredAuthorizationServers = effectiveAuthorizationServers as Array<{
+            type?: string;
+        }>;
 
         if (configuredAuthorizationServers.length < 1) {
             throw new BadRequestException(

--- a/apps/backend/src/issuer/configuration/issuance/issuance.service.ts
+++ b/apps/backend/src/issuer/configuration/issuance/issuance.service.ts
@@ -160,11 +160,11 @@ export class IssuanceService {
             Object.entries(value).filter(([, v]) => v !== undefined),
         );
 
-        const configuredAuthorizationServers = (
-            (filteredValue as Partial<IssuanceDto>).authorizationServers ??
+        const configuredAuthorizationServers = ((
+            filteredValue as Partial<IssuanceDto>
+        ).authorizationServers ??
             existingConfig.authorizationServers ??
-            []
-        ) as Array<{ type?: string }>;
+            []) as Array<{ type?: string }>;
 
         if (configuredAuthorizationServers.length < 1) {
             throw new BadRequestException(

--- a/apps/backend/src/issuer/issuance/oid4vci/authorization/authorization-servers/authorization-servers.service.ts
+++ b/apps/backend/src/issuer/issuance/oid4vci/authorization/authorization-servers/authorization-servers.service.ts
@@ -106,9 +106,7 @@ export class AuthorizationServersService {
             await this.issuanceService.getIssuanceConfiguration(tenantId);
 
         return (issuanceConfig.authorizationServers ?? []).filter(
-            (
-                config,
-            ): config is Oid4VpManagedAuthorizationServerConfig => {
+            (config): config is Oid4VpManagedAuthorizationServerConfig => {
                 const candidate =
                     config as Partial<Oid4VpManagedAuthorizationServerConfig>;
                 return (

--- a/apps/backend/src/issuer/issuance/oid4vci/authorization/authorization-servers/authorization-servers.service.ts
+++ b/apps/backend/src/issuer/issuance/oid4vci/authorization/authorization-servers/authorization-servers.service.ts
@@ -15,6 +15,7 @@ import { SessionStatus } from "../../../../../session/entities/session.entity";
 import { SessionService } from "../../../../../session/session.service";
 import { WalletAttestationService } from "../../../../../shared/trust/wallet-attestation.service";
 import { ManagedAuthorizationServerConfig } from "../../../../configuration/issuance/dto/authorization-server-config.dto";
+import { ChainedAsTokenConfig } from "../../../../configuration/issuance/dto/chained-as-config.dto";
 import { IssuanceService } from "../../../../configuration/issuance/issuance.service";
 import { Oid4vpService } from "../../../../../verifier/oid4vp/oid4vp.service";
 import {
@@ -33,6 +34,27 @@ import {
     resolveTokenBinding,
     DEFAULT_DPOP_SIGNING_ALG_VALUES_SUPPORTED,
 } from "../shared";
+
+type Oid4VpManagedAuthorizationServerConfig =
+    ManagedAuthorizationServerConfig & {
+        type: "oid4vp";
+        id: string;
+        presentationConfigId: string;
+        token?: ChainedAsTokenConfig;
+        requireDPoP?: boolean;
+    };
+
+type ExternalManagedAuthorizationServerConfig =
+    ManagedAuthorizationServerConfig & {
+        type: "external";
+        issuer: string;
+    };
+
+type ChainedManagedAuthorizationServerConfig =
+    ManagedAuthorizationServerConfig & {
+        type: "chained";
+        upstream: unknown;
+    };
 
 @Injectable()
 export class AuthorizationServersService {
@@ -79,18 +101,25 @@ export class AuthorizationServersService {
 
     async getEnabledAuthorizationServers(
         tenantId: string,
-    ): Promise<ManagedAuthorizationServerConfig[]> {
+    ): Promise<Oid4VpManagedAuthorizationServerConfig[]> {
         const issuanceConfig =
             await this.issuanceService.getIssuanceConfiguration(tenantId);
 
         return (issuanceConfig.authorizationServers ?? []).filter(
-            (config) =>
-                config.enabled !== false &&
-                config.type === "oid4vp" &&
-                typeof config.id === "string" &&
-                config.id.length > 0 &&
-                typeof config.presentationConfigId === "string" &&
-                config.presentationConfigId.length > 0,
+            (
+                config,
+            ): config is Oid4VpManagedAuthorizationServerConfig => {
+                const candidate =
+                    config as Partial<Oid4VpManagedAuthorizationServerConfig>;
+                return (
+                    config.enabled !== false &&
+                    config.type === "oid4vp" &&
+                    typeof candidate.id === "string" &&
+                    candidate.id.length > 0 &&
+                    typeof candidate.presentationConfigId === "string" &&
+                    candidate.presentationConfigId.length > 0
+                );
+            },
         );
     }
 
@@ -102,13 +131,20 @@ export class AuthorizationServersService {
 
         return (issuanceConfig.authorizationServers ?? [])
             .filter(
-                (config) =>
-                    config.enabled !== false &&
-                    config.type === "external" &&
-                    typeof config.issuer === "string" &&
-                    config.issuer.length > 0,
+                (
+                    config,
+                ): config is ExternalManagedAuthorizationServerConfig => {
+                    const candidate =
+                        config as Partial<ExternalManagedAuthorizationServerConfig>;
+                    return (
+                        config.enabled !== false &&
+                        config.type === "external" &&
+                        typeof candidate.issuer === "string" &&
+                        candidate.issuer.length > 0
+                    );
+                },
             )
-            .map((config) => config.issuer!)
+            .map((config) => config.issuer)
             .filter((url, index, arr) => arr.indexOf(url) === index);
     }
 
@@ -119,17 +155,22 @@ export class AuthorizationServersService {
             await this.issuanceService.getIssuanceConfiguration(tenantId);
 
         return (issuanceConfig.authorizationServers ?? []).some(
-            (config) =>
-                config.enabled !== false &&
-                config.type === "chained" &&
-                !!config.upstream,
+            (config): config is ChainedManagedAuthorizationServerConfig => {
+                const candidate =
+                    config as Partial<ChainedManagedAuthorizationServerConfig>;
+                return (
+                    config.enabled !== false &&
+                    config.type === "chained" &&
+                    !!candidate.upstream
+                );
+            },
         );
     }
 
     async getAuthorizationServerConfig(
         tenantId: string,
         authorizationServerId: string,
-    ): Promise<ManagedAuthorizationServerConfig> {
+    ): Promise<Oid4VpManagedAuthorizationServerConfig> {
         const config = (
             await this.getEnabledAuthorizationServers(tenantId)
         ).find((entry) => entry.id === authorizationServerId);
@@ -137,12 +178,6 @@ export class AuthorizationServersService {
         if (!config) {
             throw new NotFoundException(
                 `Authorization server '${authorizationServerId}' is not configured for this tenant`,
-            );
-        }
-
-        if (config.type !== "oid4vp") {
-            throw new BadRequestException(
-                `Unsupported authorization server type '${config.type}'`,
             );
         }
 
@@ -154,7 +189,7 @@ export class AuthorizationServersService {
     ): Promise<string[]> {
         const configs = await this.getEnabledAuthorizationServers(tenantId);
         return configs.map((config) =>
-            this.getAuthorizationServerBaseUrl(tenantId, config.id!),
+            this.getAuthorizationServerBaseUrl(tenantId, config.id),
         );
     }
 
@@ -192,7 +227,7 @@ export class AuthorizationServersService {
             return undefined;
         }
 
-        return this.getAuthorizationServerBaseUrl(tenantId, first.id!);
+        return this.getAuthorizationServerBaseUrl(tenantId, first.id);
     }
 
     async handlePar(
@@ -334,13 +369,13 @@ export class AuthorizationServersService {
         await this.sessionService.create({
             id: session.id,
             tenantId,
-            requestId: config.presentationConfigId!,
+            requestId: config.presentationConfigId,
             redirectUri: callbackUrl,
         });
 
         const publicUrl = this.configService.getOrThrow<string>("PUBLIC_URL");
         const offer = await this.oid4vpService.createRequest(
-            config.presentationConfigId!,
+            config.presentationConfigId,
             {
                 session: session.id,
                 redirectUri: callbackUrl,

--- a/apps/backend/src/issuer/issuance/oid4vci/authorization/authorization-servers/authorization-servers.service.ts
+++ b/apps/backend/src/issuer/issuance/oid4vci/authorization/authorization-servers/authorization-servers.service.ts
@@ -560,12 +560,9 @@ export class AuthorizationServersService {
 
         session.status = ChainedAsSessionStatus.TOKEN_ISSUED;
         session.accessTokenJti = jti;
-
-        const issuanceConfig =
-            await this.issuanceService.getIssuanceConfiguration(tenantId);
         const refreshToken = issueRefreshTokenIfEnabled(
             session,
-            issuanceConfig,
+            config.token ?? {},
         );
 
         await this.sessionRepository.save(session);
@@ -587,7 +584,7 @@ export class AuthorizationServersService {
         tenantId: string,
         authorizationServerId: string,
     ): Promise<Record<string, unknown>> {
-        await this.getAuthorizationServerConfig(
+        const config = await this.getAuthorizationServerConfig(
             tenantId,
             authorizationServerId,
         );
@@ -600,6 +597,7 @@ export class AuthorizationServersService {
             await this.issuanceService.getIssuanceConfiguration(tenantId);
         const walletAttestationRequired =
             issuanceConfig.walletAttestationRequired ?? false;
+        const refreshTokensEnabled = config.token?.refreshTokenEnabled ?? true;
 
         return buildAuthorizationServerMetadata({
             issuer: baseUrl,
@@ -607,7 +605,9 @@ export class AuthorizationServersService {
             tokenEndpoint: `${baseUrl}/token`,
             pushedAuthorizationRequestEndpoint: `${baseUrl}/par`,
             jwksUri: `${publicUrl}/.well-known/jwks.json/issuers/${tenantId}/authorization-servers/${authorizationServerId}`,
-            grantTypesSupported: ["authorization_code", "refresh_token"],
+            grantTypesSupported: refreshTokensEnabled
+                ? ["authorization_code", "refresh_token"]
+                : ["authorization_code"],
             dpopSigningAlgValuesSupported:
                 DEFAULT_DPOP_SIGNING_ALG_VALUES_SUPPORTED,
             ...buildWalletAttestationMetadata(walletAttestationRequired),

--- a/apps/backend/src/issuer/issuance/oid4vci/authorization/authorize/authorize.service.ts
+++ b/apps/backend/src/issuer/issuance/oid4vci/authorization/authorize/authorize.service.ts
@@ -52,8 +52,6 @@ interface ParsedAccessTokenRefreshTokenRequestGrant {
 @Injectable()
 export class AuthorizeService {
     private readonly logger = new Logger(AuthorizeService.name);
-    private static readonly AUTHORIZATION_SERVER_SELECTION_PREFIX =
-        "authorization-server:";
 
     constructor(
         private readonly configService: ConfigService,
@@ -210,8 +208,9 @@ export class AuthorizeService {
     }
 
     private resolveRefreshTokenConfig(issuanceConfig: {
-        preferredAuthServer?: string | null;
         authorizationServers?: Array<{
+            type?: string;
+            enabled?: boolean;
             id?: string;
             token?: {
                 refreshTokenEnabled?: boolean;
@@ -222,20 +221,17 @@ export class AuthorizeService {
         enabled: boolean;
         expiresInSeconds?: number;
     } {
-        const preferred = issuanceConfig.preferredAuthServer;
-        const prefix = AuthorizeService.AUTHORIZATION_SERVER_SELECTION_PREFIX;
-
-        if (typeof preferred === "string" && preferred.startsWith(prefix)) {
-            const serverId = preferred.slice(prefix.length);
-            const server = (issuanceConfig.authorizationServers ?? []).find(
-                (candidate) => candidate.id === serverId,
-            );
-            if (server?.token) {
-                return {
-                    enabled: server.token.refreshTokenEnabled ?? true,
-                    expiresInSeconds: server.token.refreshTokenExpiresInSeconds,
-                };
-            }
+        const server = (issuanceConfig.authorizationServers ?? []).find(
+            (candidate) =>
+                candidate.enabled !== false &&
+                candidate.type !== "external" &&
+                !!candidate.token,
+        );
+        if (server?.token) {
+            return {
+                enabled: server.token.refreshTokenEnabled ?? true,
+                expiresInSeconds: server.token.refreshTokenExpiresInSeconds,
+            };
         }
 
         // Built-in authorization server defaults.

--- a/apps/backend/src/issuer/issuance/oid4vci/authorization/authorize/authorize.service.ts
+++ b/apps/backend/src/issuer/issuance/oid4vci/authorization/authorize/authorize.service.ts
@@ -52,6 +52,8 @@ interface ParsedAccessTokenRefreshTokenRequestGrant {
 @Injectable()
 export class AuthorizeService {
     private readonly logger = new Logger(AuthorizeService.name);
+    private static readonly AUTHORIZATION_SERVER_SELECTION_PREFIX =
+        "authorization-server:";
 
     constructor(
         private readonly configService: ConfigService,
@@ -207,6 +209,39 @@ export class AuthorizeService {
         return `${this.configService.getOrThrow<string>("PUBLIC_URL")}/issuers/${tenantId}`;
     }
 
+    private resolveRefreshTokenConfig(issuanceConfig: {
+        preferredAuthServer?: string | null;
+        authorizationServers?: Array<{
+            id?: string;
+            token?: {
+                refreshTokenEnabled?: boolean;
+                refreshTokenExpiresInSeconds?: number;
+            };
+        }> | null;
+    }): {
+        enabled: boolean;
+        expiresInSeconds?: number;
+    } {
+        const preferred = issuanceConfig.preferredAuthServer;
+        const prefix = AuthorizeService.AUTHORIZATION_SERVER_SELECTION_PREFIX;
+
+        if (typeof preferred === "string" && preferred.startsWith(prefix)) {
+            const serverId = preferred.slice(prefix.length);
+            const server = (issuanceConfig.authorizationServers ?? []).find(
+                (candidate) => candidate.id === serverId,
+            );
+            if (server?.token) {
+                return {
+                    enabled: server.token.refreshTokenEnabled ?? true,
+                    expiresInSeconds: server.token.refreshTokenExpiresInSeconds,
+                };
+            }
+        }
+
+        // Built-in authorization server defaults.
+        return { enabled: true, expiresInSeconds: 2592000 };
+    }
+
     /**
      * Build the RFC 9396 `authorization_details` array that must be bound to the
      * issued access token, per OID4VCI Section 6 / 7. The list of authorized
@@ -289,6 +324,8 @@ export class AuthorizeService {
             await this.issuanceService.getIssuanceConfiguration(tenantId);
         const walletAttestationRequired =
             issuanceConfig.walletAttestationRequired ?? false;
+        const refreshTokenConfig =
+            this.resolveRefreshTokenConfig(issuanceConfig);
 
         const publicUrl = this.configService.getOrThrow<string>("PUBLIC_URL");
         const authServer = this.getAuthzIssuer(tenantId);
@@ -306,11 +343,16 @@ export class AuthorizeService {
             tokenEndpoint: `${authServer}/authorize/token`,
             pushedAuthorizationRequestEndpoint: `${authServer}/authorize/par`,
             jwksUri: `${publicUrl}/.well-known/jwks.json/issuers/${tenantId}`,
-            grantTypesSupported: [
-                "authorization_code",
-                "refresh_token",
-                "urn:ietf:params:oauth:grant-type:pre-authorized_code",
-            ],
+            grantTypesSupported: refreshTokenConfig.enabled
+                ? [
+                      "authorization_code",
+                      "refresh_token",
+                      "urn:ietf:params:oauth:grant-type:pre-authorized_code",
+                  ]
+                : [
+                      "authorization_code",
+                      "urn:ietf:params:oauth:grant-type:pre-authorized_code",
+                  ],
             dpopSigningAlgValuesSupported:
                 DEFAULT_DPOP_SIGNING_ALG_VALUES_SUPPORTED,
             ...buildWalletAttestationMetadata(walletAttestationRequired),
@@ -539,6 +581,8 @@ export class AuthorizeService {
 
         const issuanceConfig =
             await this.issuanceService.getIssuanceConfiguration(tenantId);
+        const refreshTokenConfig =
+            this.resolveRefreshTokenConfig(issuanceConfig);
 
         const authorizationServerMetadata = await this.authzMetadata(tenantId);
 
@@ -735,7 +779,7 @@ export class AuthorizeService {
                 authorizationServer: authorizationServerMetadata.issuer,
                 clientId: req.body.client_id,
                 dpop: dpopValue,
-                refreshToken: issuanceConfig.refreshTokenEnabled ? true : false,
+                refreshToken: refreshTokenConfig.enabled,
                 additionalAccessTokenPayload: authorizationDetails
                     ? { authorization_details: authorizationDetails }
                     : undefined,
@@ -756,12 +800,11 @@ export class AuthorizeService {
         if (tokenResponse.refresh_token) {
             // Calculate refresh token expiration based on configured lifetime
             let refreshTokenExpiresAt: Date | undefined;
-            if (issuanceConfig.refreshTokenExpiresInSeconds) {
+            if (refreshTokenConfig.expiresInSeconds) {
                 const now = new Date();
                 refreshTokenExpiresAt = new Date(
                     now.getTime() +
-                        (issuanceConfig.refreshTokenExpiresInSeconds || 0) *
-                            1000,
+                        (refreshTokenConfig.expiresInSeconds || 0) * 1000,
                 );
             }
 

--- a/apps/backend/src/issuer/issuance/oid4vci/authorization/chained-as-vp/chained-as-vp.service.ts
+++ b/apps/backend/src/issuer/issuance/oid4vci/authorization/chained-as-vp/chained-as-vp.service.ts
@@ -417,12 +417,9 @@ export class ChainedAsVpService {
 
         session.status = ChainedAsSessionStatus.TOKEN_ISSUED;
         session.accessTokenJti = jti;
-
-        const issuanceConfig =
-            await this.issuanceService.getIssuanceConfiguration(tenantId);
         const refreshToken = issueRefreshTokenIfEnabled(
             session,
-            issuanceConfig,
+            config.token ?? {},
         );
 
         await this.sessionRepository.save(session);
@@ -460,12 +457,14 @@ export class ChainedAsVpService {
     }
 
     async getMetadata(tenantId: string): Promise<Record<string, unknown>> {
+        const config = await this.getChainedAsVpConfig(tenantId);
         const baseUrl = this.getChainedAsVpBaseUrl(tenantId);
         const publicUrl = this.configService.getOrThrow<string>("PUBLIC_URL");
         const issuanceConfig =
             await this.issuanceService.getIssuanceConfiguration(tenantId);
         const walletAttestationRequired =
             issuanceConfig.walletAttestationRequired ?? false;
+        const refreshTokensEnabled = config.token?.refreshTokenEnabled ?? true;
 
         return buildAuthorizationServerMetadata({
             issuer: baseUrl,
@@ -473,7 +472,9 @@ export class ChainedAsVpService {
             tokenEndpoint: `${baseUrl}/token`,
             pushedAuthorizationRequestEndpoint: `${baseUrl}/par`,
             jwksUri: `${publicUrl}/.well-known/jwks.json/issuers/${tenantId}/chained-as-vp`,
-            grantTypesSupported: ["authorization_code", "refresh_token"],
+            grantTypesSupported: refreshTokensEnabled
+                ? ["authorization_code", "refresh_token"]
+                : ["authorization_code"],
             dpopSigningAlgValuesSupported:
                 DEFAULT_DPOP_SIGNING_ALG_VALUES_SUPPORTED,
             ...buildWalletAttestationMetadata(walletAttestationRequired),

--- a/apps/backend/src/issuer/issuance/oid4vci/authorization/chained-as/chained-as.service.ts
+++ b/apps/backend/src/issuer/issuance/oid4vci/authorization/chained-as/chained-as.service.ts
@@ -720,12 +720,9 @@ export class ChainedAsService {
 
         session.status = ChainedAsSessionStatus.TOKEN_ISSUED;
         session.accessTokenJti = jti;
-
-        const issuanceConfig =
-            await this.issuanceService.getIssuanceConfiguration(tenantId);
         const refreshToken = issueRefreshTokenIfEnabled(
             session,
-            issuanceConfig,
+            config.token ?? {},
         );
 
         await this.sessionRepository.save(session);
@@ -773,12 +770,14 @@ export class ChainedAsService {
      * Get authorization server metadata for the Chained AS.
      */
     async getMetadata(tenantId: string): Promise<Record<string, unknown>> {
+        const config = await this.getChainedAsConfig(tenantId);
         const baseUrl = this.getChainedAsBaseUrl(tenantId);
         const publicUrl = this.configService.getOrThrow<string>("PUBLIC_URL");
         const issuanceConfig =
             await this.issuanceService.getIssuanceConfiguration(tenantId);
         const walletAttestationRequired =
             issuanceConfig.walletAttestationRequired ?? false;
+        const refreshTokensEnabled = config.token?.refreshTokenEnabled ?? true;
 
         return buildAuthorizationServerMetadata({
             issuer: baseUrl,
@@ -786,7 +785,9 @@ export class ChainedAsService {
             tokenEndpoint: `${baseUrl}/token`,
             pushedAuthorizationRequestEndpoint: `${baseUrl}/par`,
             jwksUri: `${publicUrl}/.well-known/jwks.json/issuers/${tenantId}/chained-as`,
-            grantTypesSupported: ["authorization_code", "refresh_token"],
+            grantTypesSupported: refreshTokensEnabled
+                ? ["authorization_code", "refresh_token"]
+                : ["authorization_code"],
             dpopSigningAlgValuesSupported:
                 DEFAULT_DPOP_SIGNING_ALG_VALUES_SUPPORTED,
             ...buildWalletAttestationMetadata(walletAttestationRequired),

--- a/apps/backend/src/issuer/issuance/oid4vci/authorization/chained-as/chained-as.service.ts
+++ b/apps/backend/src/issuer/issuance/oid4vci/authorization/chained-as/chained-as.service.ts
@@ -111,14 +111,26 @@ export class ChainedAsService {
         const issuanceConfig =
             await this.issuanceService.getIssuanceConfiguration(tenantId);
 
+        type ChainedServerConfig = {
+            enabled?: boolean;
+            type: "chained";
+            upstream: ChainedAsConfig["upstream"];
+            token?: ChainedAsConfig["token"];
+            requireDPoP?: ChainedAsConfig["requireDPoP"];
+        };
+
         const chainedServer = (issuanceConfig.authorizationServers ?? []).find(
-            (server) =>
-                server.enabled !== false &&
-                server.type === "chained" &&
-                server.upstream,
+            (server): server is ChainedServerConfig => {
+                const candidate = server as Partial<ChainedServerConfig>;
+                return (
+                    server.enabled !== false &&
+                    server.type === "chained" &&
+                    !!candidate.upstream
+                );
+            },
         );
 
-        if (chainedServer?.upstream) {
+        if (chainedServer) {
             return {
                 enabled: true,
                 upstream: chainedServer.upstream,

--- a/apps/backend/src/issuer/issuance/oid4vci/oid4vci.service.ts
+++ b/apps/backend/src/issuer/issuance/oid4vci/oid4vci.service.ts
@@ -313,7 +313,8 @@ export class Oid4vciService {
     ): Promise<void> {
         const seenAuthServers = new Set<string>();
 
-        for (const configuredServer of issuanceConfig.authorizationServers ?? []) {
+        for (const configuredServer of issuanceConfig.authorizationServers ??
+            []) {
             const configuredServerWithVp =
                 configuredServer as ManagedAuthorizationServerConfig & {
                     vp?: { enabled?: boolean };
@@ -389,8 +390,7 @@ export class Oid4vciService {
                 }
 
                 if (configuredServerWithVp.vp?.enabled) {
-                    const chainedAsVpIssuer =
-                        `${credentialIssuer}/chained-as-vp`;
+                    const chainedAsVpIssuer = `${credentialIssuer}/chained-as-vp`;
                     if (seenAuthServers.has(chainedAsVpIssuer)) {
                         continue;
                     }

--- a/apps/backend/src/issuer/issuance/oid4vci/oid4vci.service.ts
+++ b/apps/backend/src/issuer/issuance/oid4vci/oid4vci.service.ts
@@ -58,6 +58,8 @@ import {
     IssuerRegistrationCertificateConfig,
     IssuerRegistrationCertificateMode,
 } from "../../configuration/issuance/dto/issuer-registration-certificate.dto";
+import { ManagedAuthorizationServerConfig } from "../../configuration/issuance/dto/authorization-server-config.dto";
+import { IssuanceConfig } from "../../configuration/issuance/entities/issuance-config.entity";
 import { IssuanceService } from "../../configuration/issuance/issuance.service";
 import { WebhookEndpointEntity } from "../../configuration/webhook-endpoint/entities/webhook-endpoint.entity";
 import { type RegistrationCertificateCreation } from "../../../registrar/generated";
@@ -141,24 +143,37 @@ export class Oid4vciService {
     private async getAuthorizationServer(tenantId: string): Promise<string> {
         const issuanceConfig =
             await this.issuanceService.getIssuanceConfiguration(tenantId);
-
-        const managedAuthorizationServer =
-            await this.authorizationServersService.getDefaultAuthorizationServerUrl(
-                tenantId,
-                issuanceConfig.preferredAuthServer,
-            );
-        if (managedAuthorizationServer) {
-            return managedAuthorizationServer;
-        }
-
         const publicUrl = this.configService.getOrThrow<string>("PUBLIC_URL");
 
-        if (
-            await this.authorizationServersService.hasEnabledChainedAuthorizationServer(
-                tenantId,
-            )
-        ) {
-            return `${publicUrl}/issuers/${tenantId}/chained-as`;
+        for (const server of issuanceConfig.authorizationServers ?? []) {
+            const serverWithVp = server as ManagedAuthorizationServerConfig & {
+                vp?: { enabled?: boolean };
+            };
+
+            if (server.enabled === false) {
+                continue;
+            }
+
+            if (
+                server.type === "oid4vp" &&
+                typeof server.id === "string" &&
+                server.id.length > 0
+            ) {
+                return this.authorizationServersService.getAuthorizationServerBaseUrl(
+                    tenantId,
+                    server.id,
+                );
+            }
+
+            if (server.type === "chained") {
+                if (server.upstream) {
+                    return `${publicUrl}/issuers/${tenantId}/chained-as`;
+                }
+
+                if (serverWithVp.vp?.enabled) {
+                    return `${publicUrl}/issuers/${tenantId}/chained-as-vp`;
+                }
+            }
         }
 
         return this.authzService.getAuthzIssuer(tenantId);
@@ -261,80 +276,135 @@ export class Oid4vciService {
         }
     }
 
-    private async appendInternalAuthorizationServers(
-        tenantId: string,
-        credentialIssuer: string,
-        authServers: string[],
-        authorizationServers: AuthorizationServerMetadata[],
-    ): Promise<void> {
-        if (
-            await this.authorizationServersService.hasEnabledChainedAuthorizationServer(
-                tenantId,
-            )
-        ) {
-            const chainedAsIssuer = `${credentialIssuer}/chained-as`;
-            authServers.push(chainedAsIssuer);
-            authorizationServers.push(
-                (await this.chainedAsService.getMetadata(
-                    tenantId,
-                )) as AuthorizationServerMetadata,
-            );
-        }
-
-        const managedAuthorizationServers =
-            await this.authorizationServersService.getEnabledAuthorizationServers(
-                tenantId,
-            );
-        for (const managedAuthorizationServer of managedAuthorizationServers) {
-            authServers.push(
-                this.authorizationServersService.getAuthorizationServerBaseUrl(
-                    tenantId,
-                    managedAuthorizationServer.id!,
-                ),
-            );
-            authorizationServers.push(
-                (await this.authorizationServersService.getMetadata(
-                    tenantId,
-                    managedAuthorizationServer.id!,
-                )) as AuthorizationServerMetadata,
-            );
-        }
-
-        authServers.push(this.authzService.getAuthzIssuer(tenantId));
-        authorizationServers.push(
-            await this.authzService.authzMetadata(tenantId),
+    private async fetchAuthorizationServerMetadata(
+        authServerUrl: string,
+    ): Promise<AuthorizationServerMetadata> {
+        return firstValueFrom(
+            this.httpService.get(
+                `${authServerUrl}/.well-known/oauth-authorization-server`,
+            ),
+        ).then(
+            (response) => response.data,
+            async () => {
+                // Retry fetching from OIDC metadata endpoint.
+                return await firstValueFrom(
+                    this.httpService.get(
+                        `${authServerUrl}/.well-known/openid-configuration`,
+                    ),
+                ).then(
+                    (response) => response.data,
+                    () => {
+                        throw new BadRequestException(
+                            "Failed to fetch authorization server metadata",
+                        );
+                    },
+                );
+            },
         );
     }
 
-    private resolvePreferredAuthorizationServer(
-        preferredAuthServer: string | undefined,
+    private async appendConfiguredAuthorizationServersInOrder(
         tenantId: string,
         credentialIssuer: string,
-    ): string | undefined {
-        if (!preferredAuthServer) {
-            return undefined;
-        }
+        issuanceConfig: IssuanceConfig,
+        federationTrustSource: FederationTrustSource | undefined,
+        authServers: string[],
+        authorizationServers: AuthorizationServerMetadata[],
+    ): Promise<void> {
+        const seenAuthServers = new Set<string>();
 
-        if (preferredAuthServer === "built-in") {
-            return this.authzService.getAuthzIssuer(tenantId);
-        }
+        for (const configuredServer of issuanceConfig.authorizationServers ?? []) {
+            const configuredServerWithVp =
+                configuredServer as ManagedAuthorizationServerConfig & {
+                    vp?: { enabled?: boolean };
+                };
 
-        if (preferredAuthServer === "chained-as") {
-            return `${credentialIssuer}/chained-as`;
-        }
+            if (configuredServer.enabled === false) {
+                continue;
+            }
 
-        if (
-            this.authorizationServersService.isSelectionValue(
-                preferredAuthServer,
-            )
-        ) {
-            return this.authorizationServersService.resolveSelectionToIssuer(
-                tenantId,
-                preferredAuthServer,
-            ) as unknown as string;
-        }
+            if (
+                configuredServer.type === "external" &&
+                typeof configuredServer.issuer === "string" &&
+                configuredServer.issuer.length > 0
+            ) {
+                const authServerUrl = configuredServer.issuer;
+                if (seenAuthServers.has(authServerUrl)) {
+                    continue;
+                }
 
-        return preferredAuthServer;
+                await this.assertFederationTrustForAuthorizationServer(
+                    authServerUrl,
+                    federationTrustSource,
+                );
+
+                seenAuthServers.add(authServerUrl);
+                authServers.push(authServerUrl);
+                authorizationServers.push(
+                    await this.fetchAuthorizationServerMetadata(authServerUrl),
+                );
+                continue;
+            }
+
+            if (
+                configuredServer.type === "oid4vp" &&
+                typeof configuredServer.id === "string" &&
+                configuredServer.id.length > 0
+            ) {
+                const authServerUrl =
+                    this.authorizationServersService.getAuthorizationServerBaseUrl(
+                        tenantId,
+                        configuredServer.id,
+                    );
+                if (seenAuthServers.has(authServerUrl)) {
+                    continue;
+                }
+
+                seenAuthServers.add(authServerUrl);
+                authServers.push(authServerUrl);
+                authorizationServers.push(
+                    (await this.authorizationServersService.getMetadata(
+                        tenantId,
+                        configuredServer.id,
+                    )) as AuthorizationServerMetadata,
+                );
+                continue;
+            }
+
+            if (configuredServer.type === "chained") {
+                if (configuredServer.upstream) {
+                    const chainedAsIssuer = `${credentialIssuer}/chained-as`;
+                    if (seenAuthServers.has(chainedAsIssuer)) {
+                        continue;
+                    }
+
+                    seenAuthServers.add(chainedAsIssuer);
+                    authServers.push(chainedAsIssuer);
+                    authorizationServers.push(
+                        (await this.chainedAsService.getMetadata(
+                            tenantId,
+                        )) as AuthorizationServerMetadata,
+                    );
+                    continue;
+                }
+
+                if (configuredServerWithVp.vp?.enabled) {
+                    const chainedAsVpIssuer =
+                        `${credentialIssuer}/chained-as-vp`;
+                    if (seenAuthServers.has(chainedAsVpIssuer)) {
+                        continue;
+                    }
+
+                    seenAuthServers.add(chainedAsVpIssuer);
+                    authServers.push(chainedAsVpIssuer);
+                    authorizationServers.push(
+                        (await this.chainedAsVpService.getMetadata(
+                            tenantId,
+                        )) as AuthorizationServerMetadata,
+                    );
+                }
+            }
+        }
     }
 
     /**
@@ -567,20 +637,6 @@ export class Oid4vciService {
         return resolved.jwt;
     }
 
-    private reorderPreferredAuthorizationServer(
-        authServers: string[],
-        authorizationServers: AuthorizationServerMetadata[],
-        preferred: string,
-    ): void {
-        const idx = authServers.indexOf(preferred);
-        if (idx > 0) {
-            const [url] = authServers.splice(idx, 1);
-            const [meta] = authorizationServers.splice(idx, 1);
-            authServers.unshift(url);
-            authorizationServers.unshift(meta);
-        }
-    }
-
     private async appendIssuerRegistrationCertificateInfo(
         tenantId: string,
         registrationCertificateConfig:
@@ -646,64 +702,20 @@ export class Oid4vciService {
                   } as FederationTrustSource)
                 : undefined;
 
-        for (const authServerUrl of await this.authorizationServersService.getExternalAuthorizationServerUrls(
-            tenantId,
-        )) {
-            await this.assertFederationTrustForAuthorizationServer(
-                authServerUrl,
-                federationTrustSource,
-            );
-
-            authServers.push(authServerUrl);
-            //TODO: check where this is needed to reduce calls
-            authorizationServers.push(
-                await firstValueFrom(
-                    this.httpService.get(
-                        `${authServerUrl}/.well-known/oauth-authorization-server`,
-                    ),
-                ).then(
-                    (response) => response.data,
-                    async () => {
-                        // Retry fetching from OIDC metadata endpoint
-                        return await firstValueFrom(
-                            this.httpService.get(
-                                `${authServerUrl}/.well-known/openid-configuration`,
-                            ),
-                        ).then(
-                            (response) => response.data,
-                            () => {
-                                throw new BadRequestException(
-                                    "Failed to fetch authorization server metadata",
-                                );
-                            },
-                        );
-                    },
-                ),
-            );
-        }
-
-        await this.appendInternalAuthorizationServers(
+        await this.appendConfiguredAuthorizationServersInOrder(
             tenantId,
             credential_issuer,
+            issuanceConfig,
+            federationTrustSource,
             authServers,
             authorizationServers,
         );
 
-        // Reorder so the preferred authorization server is first
-        const preferred = await Promise.resolve(
-            this.resolvePreferredAuthorizationServer(
-                issuanceConfig.preferredAuthServer,
-                tenantId,
-                credential_issuer,
-            ),
+        // The built-in authorization server is always available as fallback.
+        authServers.push(this.authzService.getAuthzIssuer(tenantId));
+        authorizationServers.push(
+            await this.authzService.authzMetadata(tenantId),
         );
-        if (preferred) {
-            this.reorderPreferredAuthorizationServer(
-                authServers,
-                authorizationServers,
-                preferred,
-            );
-        }
 
         const issuer_info: IssuerInfo[] = [];
         await this.appendIssuerRegistrationCertificateInfo(

--- a/apps/backend/src/issuer/issuance/oid4vci/oid4vci.service.ts
+++ b/apps/backend/src/issuer/issuance/oid4vci/oid4vci.service.ts
@@ -364,9 +364,12 @@ export class Oid4vciService {
 
         for (const configuredServer of issuanceConfig.authorizationServers ??
             []) {
-            const externalServer = configuredServer as Partial<ExternalServerConfig>;
-            const oid4vpServer = configuredServer as Partial<Oid4vpServerConfig>;
-            const chainedServer = configuredServer as Partial<ChainedServerConfig>;
+            const externalServer =
+                configuredServer as Partial<ExternalServerConfig>;
+            const oid4vpServer =
+                configuredServer as Partial<Oid4vpServerConfig>;
+            const chainedServer =
+                configuredServer as Partial<ChainedServerConfig>;
 
             if (configuredServer.enabled === false) {
                 continue;

--- a/apps/backend/src/issuer/issuance/oid4vci/oid4vci.service.ts
+++ b/apps/backend/src/issuer/issuance/oid4vci/oid4vci.service.ts
@@ -154,6 +154,10 @@ export class Oid4vciService {
                 continue;
             }
 
+            if (server.type === "external" && server.issuer) {
+                return server.issuer;
+            }
+
             if (
                 server.type === "oid4vp" &&
                 typeof server.id === "string" &&
@@ -163,6 +167,10 @@ export class Oid4vciService {
                     tenantId,
                     server.id,
                 );
+            }
+
+            if (server.type === "built-in") {
+                return this.authzService.getAuthzIssuer(tenantId);
             }
 
             if (server.type === "chained") {
@@ -176,7 +184,20 @@ export class Oid4vciService {
             }
         }
 
-        return this.authzService.getAuthzIssuer(tenantId);
+        throw new BadRequestException(
+            "No enabled authorization server configured",
+        );
+    }
+
+    private async isBuiltInAuthorizationServerConfigured(
+        tenantId: string,
+    ): Promise<boolean> {
+        const issuanceConfig =
+            await this.issuanceService.getIssuanceConfiguration(tenantId);
+
+        return (issuanceConfig.authorizationServers ?? []).some(
+            (server) => server.enabled !== false && server.type === "built-in",
+        );
     }
 
     private async resolveAuthorizationServerSelection(
@@ -188,6 +209,13 @@ export class Oid4vciService {
         }
 
         if (selectedAuthorizationServer === "built-in") {
+            const builtInConfigured =
+                await this.isBuiltInAuthorizationServerConfigured(tenantId);
+            if (!builtInConfigured) {
+                throw new BadRequestException(
+                    "Built-in authorization server is not configured",
+                );
+            }
             return this.authzService.getAuthzIssuer(tenantId);
         }
 
@@ -403,6 +431,19 @@ export class Oid4vciService {
                         )) as AuthorizationServerMetadata,
                     );
                 }
+            }
+
+            if (configuredServer.type === "built-in") {
+                const builtInIssuer = this.authzService.getAuthzIssuer(tenantId);
+                if (seenAuthServers.has(builtInIssuer)) {
+                    continue;
+                }
+
+                seenAuthServers.add(builtInIssuer);
+                authServers.push(builtInIssuer);
+                authorizationServers.push(
+                    await this.authzService.authzMetadata(tenantId),
+                );
             }
         }
     }
@@ -711,12 +752,6 @@ export class Oid4vciService {
             authorizationServers,
         );
 
-        // The built-in authorization server is always available as fallback.
-        authServers.push(this.authzService.getAuthzIssuer(tenantId));
-        authorizationServers.push(
-            await this.authzService.authzMetadata(tenantId),
-        );
-
         const issuer_info: IssuerInfo[] = [];
         await this.appendIssuerRegistrationCertificateInfo(
             tenantId,
@@ -793,7 +828,7 @@ export class Oid4vciService {
                 );
             const authServer =
                 selectedAuthorizationServer ??
-                this.authzService.getAuthzIssuer(tenantId);
+                (await this.getAuthorizationServer(tenantId));
 
             grants = {
                 [preAuthorizedCodeGrantIdentifier]: {

--- a/apps/backend/src/issuer/issuance/oid4vci/oid4vci.service.ts
+++ b/apps/backend/src/issuer/issuance/oid4vci/oid4vci.service.ts
@@ -434,7 +434,8 @@ export class Oid4vciService {
             }
 
             if (configuredServer.type === "built-in") {
-                const builtInIssuer = this.authzService.getAuthzIssuer(tenantId);
+                const builtInIssuer =
+                    this.authzService.getAuthzIssuer(tenantId);
                 if (seenAuthServers.has(builtInIssuer)) {
                     continue;
                 }

--- a/apps/backend/src/issuer/issuance/oid4vci/oid4vci.service.ts
+++ b/apps/backend/src/issuer/issuance/oid4vci/oid4vci.service.ts
@@ -100,6 +100,23 @@ type OAuth2TokenPayload = {
     cnf?: { jwk?: Jwk };
 };
 
+type Oid4vpServerConfig = ManagedAuthorizationServerConfig & {
+    type: "oid4vp";
+    id: string;
+    presentationConfigId: string;
+};
+
+type ExternalServerConfig = ManagedAuthorizationServerConfig & {
+    type: "external";
+    issuer: string;
+};
+
+type ChainedServerConfig = ManagedAuthorizationServerConfig & {
+    type: "chained";
+    upstream?: unknown;
+    vp?: { enabled?: boolean };
+};
+
 interface IssuerInfo {
     format: string;
     data: string;
@@ -146,26 +163,30 @@ export class Oid4vciService {
         const publicUrl = this.configService.getOrThrow<string>("PUBLIC_URL");
 
         for (const server of issuanceConfig.authorizationServers ?? []) {
-            const serverWithVp = server as ManagedAuthorizationServerConfig & {
-                vp?: { enabled?: boolean };
-            };
+            const externalServer = server as Partial<ExternalServerConfig>;
+            const oid4vpServer = server as Partial<Oid4vpServerConfig>;
+            const chainedServer = server as Partial<ChainedServerConfig>;
 
             if (server.enabled === false) {
                 continue;
             }
 
-            if (server.type === "external" && server.issuer) {
-                return server.issuer;
+            if (
+                server.type === "external" &&
+                typeof externalServer.issuer === "string" &&
+                externalServer.issuer.length > 0
+            ) {
+                return externalServer.issuer;
             }
 
             if (
                 server.type === "oid4vp" &&
-                typeof server.id === "string" &&
-                server.id.length > 0
+                typeof oid4vpServer.id === "string" &&
+                oid4vpServer.id.length > 0
             ) {
                 return this.authorizationServersService.getAuthorizationServerBaseUrl(
                     tenantId,
-                    server.id,
+                    oid4vpServer.id,
                 );
             }
 
@@ -174,11 +195,11 @@ export class Oid4vciService {
             }
 
             if (server.type === "chained") {
-                if (server.upstream) {
+                if (chainedServer.upstream) {
                     return `${publicUrl}/issuers/${tenantId}/chained-as`;
                 }
 
-                if (serverWithVp.vp?.enabled) {
+                if (chainedServer.vp?.enabled) {
                     return `${publicUrl}/issuers/${tenantId}/chained-as-vp`;
                 }
             }
@@ -343,10 +364,9 @@ export class Oid4vciService {
 
         for (const configuredServer of issuanceConfig.authorizationServers ??
             []) {
-            const configuredServerWithVp =
-                configuredServer as ManagedAuthorizationServerConfig & {
-                    vp?: { enabled?: boolean };
-                };
+            const externalServer = configuredServer as Partial<ExternalServerConfig>;
+            const oid4vpServer = configuredServer as Partial<Oid4vpServerConfig>;
+            const chainedServer = configuredServer as Partial<ChainedServerConfig>;
 
             if (configuredServer.enabled === false) {
                 continue;
@@ -354,10 +374,10 @@ export class Oid4vciService {
 
             if (
                 configuredServer.type === "external" &&
-                typeof configuredServer.issuer === "string" &&
-                configuredServer.issuer.length > 0
+                typeof externalServer.issuer === "string" &&
+                externalServer.issuer.length > 0
             ) {
-                const authServerUrl = configuredServer.issuer;
+                const authServerUrl = externalServer.issuer;
                 if (seenAuthServers.has(authServerUrl)) {
                     continue;
                 }
@@ -377,13 +397,13 @@ export class Oid4vciService {
 
             if (
                 configuredServer.type === "oid4vp" &&
-                typeof configuredServer.id === "string" &&
-                configuredServer.id.length > 0
+                typeof oid4vpServer.id === "string" &&
+                oid4vpServer.id.length > 0
             ) {
                 const authServerUrl =
                     this.authorizationServersService.getAuthorizationServerBaseUrl(
                         tenantId,
-                        configuredServer.id,
+                        oid4vpServer.id,
                     );
                 if (seenAuthServers.has(authServerUrl)) {
                     continue;
@@ -394,14 +414,14 @@ export class Oid4vciService {
                 authorizationServers.push(
                     (await this.authorizationServersService.getMetadata(
                         tenantId,
-                        configuredServer.id,
+                        oid4vpServer.id,
                     )) as AuthorizationServerMetadata,
                 );
                 continue;
             }
 
             if (configuredServer.type === "chained") {
-                if (configuredServer.upstream) {
+                if (chainedServer.upstream) {
                     const chainedAsIssuer = `${credentialIssuer}/chained-as`;
                     if (seenAuthServers.has(chainedAsIssuer)) {
                         continue;
@@ -417,7 +437,7 @@ export class Oid4vciService {
                     continue;
                 }
 
-                if (configuredServerWithVp.vp?.enabled) {
+                if (chainedServer.vp?.enabled) {
                     const chainedAsVpIssuer = `${credentialIssuer}/chained-as-vp`;
                     if (seenAuthServers.has(chainedAsVpIssuer)) {
                         continue;

--- a/apps/backend/test/fixtures/haip/issuance/issuance.json
+++ b/apps/backend/test/fixtures/haip/issuance/issuance.json
@@ -1,5 +1,9 @@
 {
-    "authorizationServers": [],
+    "authorizationServers": [
+        {
+            "type": "built-in"
+        }
+    ],
     "batchSize": 10,
     "dPopRequired": true,
     "credentialResponseEncryption": true,

--- a/apps/backend/test/issuance/issuance-chained-as.e2e-spec.ts
+++ b/apps/backend/test/issuance/issuance-chained-as.e2e-spec.ts
@@ -258,7 +258,6 @@ describe("Issuance - Chained AS Flow", () => {
             .set("Authorization", `Bearer ${authToken}`)
             .send({
                 ...currentConfig,
-                refreshTokenEnabled,
                 authorizationServers: [
                     {
                         type: "chained",
@@ -271,6 +270,7 @@ describe("Issuance - Chained AS Flow", () => {
                         },
                         token: {
                             lifetimeSeconds: 3600,
+                            refreshTokenEnabled,
                         },
                         requireDPoP: false,
                     },
@@ -296,7 +296,6 @@ describe("Issuance - Chained AS Flow", () => {
             .set("Authorization", `Bearer ${authToken}`)
             .send({
                 ...currentConfig,
-                refreshTokenEnabled,
                 authorizationServers: [
                     {
                         type: "chained",
@@ -307,6 +306,7 @@ describe("Issuance - Chained AS Flow", () => {
                         },
                         token: {
                             lifetimeSeconds: 3600,
+                            refreshTokenEnabled,
                         },
                         requireDPoP: false,
                     },

--- a/apps/backend/test/issuance/issuance-chained-as.e2e-spec.ts
+++ b/apps/backend/test/issuance/issuance-chained-as.e2e-spec.ts
@@ -297,7 +297,6 @@ describe("Issuance - Chained AS Flow", () => {
             .send({
                 ...currentConfig,
                 refreshTokenEnabled,
-                preferredAuthServer: "chained-as-vp",
                 authorizationServers: [
                     {
                         type: "chained",

--- a/apps/backend/test/issuance/issuance-config.e2e-spec.ts
+++ b/apps/backend/test/issuance/issuance-config.e2e-spec.ts
@@ -29,8 +29,33 @@ describe("Issuance - Configuration", () => {
         await app.close();
     });
 
+    const chainedAuthorizationServer = {
+        type: "chained",
+        enabled: true,
+        upstream: {
+            issuer: "https://auth.example.com/realms/test",
+            clientId: "test-client",
+            clientSecret: "test-secret",
+        },
+    };
+
+    async function ensureBaselineConfig() {
+        await request(app.getHttpServer())
+            .post("/issuer/config")
+            .trustLocalhost()
+            .set("Authorization", `Bearer ${authToken}`)
+            .send({
+                batchSize: 1,
+                authorizationServers: [chainedAuthorizationServer],
+            })
+            .expect(201);
+    }
+
     test("partial update should preserve existing config values", async () => {
-        // Step 1: Get the current configuration
+        // Step 1: Ensure a valid baseline configuration exists
+        await ensureBaselineConfig();
+
+        // Step 2: Get the current configuration
         const initialRes = await request(app.getHttpServer())
             .get("/issuer/config")
             .trustLocalhost()
@@ -41,7 +66,7 @@ describe("Issuance - Configuration", () => {
         expect(initialConfig.dPopRequired).toBeDefined();
         expect(initialConfig.display).toBeDefined();
 
-        // Step 2: Update only one field (batchSize), leaving others undefined
+        // Step 3: Update only one field (batchSize), leaving others undefined
         const partialUpdate: Partial<IssuanceDto> = {
             batchSize: 5,
         };
@@ -53,7 +78,7 @@ describe("Issuance - Configuration", () => {
             .send(partialUpdate)
             .expect(201);
 
-        // Step 3: Verify that other fields were preserved
+        // Step 4: Verify that other fields were preserved
         const updatedRes = await request(app.getHttpServer())
             .get("/issuer/config")
             .trustLocalhost()
@@ -70,21 +95,11 @@ describe("Issuance - Configuration", () => {
         expect(updatedConfig.display).toEqual(initialConfig.display);
     });
 
-    test("null values should explicitly clear existing config fields", async () => {
+    test("null authorizationServers should be rejected", async () => {
         // Step 1: Set up a configuration with a chained authorization server
         const setupConfig: Partial<IssuanceDto> = {
             batchSize: 10,
-            authorizationServers: [
-                {
-                    type: "chained",
-                    enabled: true,
-                    upstream: {
-                        issuer: "https://auth.example.com/realms/test",
-                        clientId: "test-client",
-                        clientSecret: "test-secret",
-                    },
-                },
-            ],
+            authorizationServers: [chainedAuthorizationServer],
         };
 
         await request(app.getHttpServer())
@@ -116,37 +131,14 @@ describe("Issuance - Configuration", () => {
             .trustLocalhost()
             .set("Authorization", `Bearer ${authToken}`)
             .send(updateWithNull)
-            .expect(201);
-
-        // Step 3: Verify that authorizationServers was cleared
-        const finalRes = await request(app.getHttpServer())
-            .get("/issuer/config")
-            .trustLocalhost()
-            .set("Authorization", `Bearer ${authToken}`)
-            .expect(200);
-
-        // batchSize should be updated
-        expect(finalRes.body.batchSize).toBe(5);
-
-        // authorizationServers should be cleared (null)
-        expect(finalRes.body.authorizationServers).toBeNull();
+            .expect(400);
     });
 
     test("authorizationServers config should not be lost on partial update", async () => {
         // Step 1: Set up a configuration with authorizationServers
         const configWithChainedAs: Partial<IssuanceDto> = {
             batchSize: 1,
-            authorizationServers: [
-                {
-                    type: "chained",
-                    enabled: true,
-                    upstream: {
-                        issuer: "https://auth.example.com/realms/test",
-                        clientId: "test-client",
-                        clientSecret: "test-secret",
-                    },
-                },
-            ],
+            authorizationServers: [chainedAuthorizationServer],
         };
 
         await request(app.getHttpServer())
@@ -192,5 +184,17 @@ describe("Issuance - Configuration", () => {
         expect(finalRes.body.authorizationServers[0].upstream.issuer).toBe(
             "https://auth.example.com/realms/test",
         );
+    });
+
+    test("should reject creating or updating config when no authorization servers are configured", async () => {
+        await request(app.getHttpServer())
+            .post("/issuer/config")
+            .trustLocalhost()
+            .set("Authorization", `Bearer ${authToken}`)
+            .send({
+                batchSize: 5,
+                authorizationServers: [],
+            })
+            .expect(400);
     });
 });

--- a/apps/backend/test/utils.ts
+++ b/apps/backend/test/utils.ts
@@ -529,7 +529,7 @@ export async function setupIssuanceTestApp(): Promise<IssuanceTestContext> {
             credentialRequestEncryption: false,
             walletAttestationRequired: false,
         } as IssuanceDto)
-        .expect(201);    
+        .expect(201);
 
     // Import the pid credential configuration
 

--- a/apps/backend/test/utils.ts
+++ b/apps/backend/test/utils.ts
@@ -529,7 +529,7 @@ export async function setupIssuanceTestApp(): Promise<IssuanceTestContext> {
             credentialRequestEncryption: false,
             walletAttestationRequired: false,
         } as IssuanceDto)
-        .expect(201);
+        .expect(201);    
 
     // Import the pid credential configuration
 

--- a/apps/client/src/app/issuance/credential-config/credential-config-create/credential-config-create.component.html
+++ b/apps/client/src/app/issuance/credential-config/credential-config-create/credential-config-create.component.html
@@ -778,10 +778,9 @@
                 Define the claims/attributes included in this credential. Each field maps to a
                 credential attribute with its type, default value, and disclosure settings. For
                 SD-JWT credentials, the <em>disclosable</em> flag controls selective disclosure. For
-                mDOC credentials, set the namespace explicitly per field and enter the claim name in
-                <em>Path</em>. For advanced nested/array mDOC claims, use <em>View as JSON</em> and
-                define path arrays directly (for example
-                <code>["driving_privileges", null, "vehicle_category_code"]</code>).
+                mDOC credentials, set the namespace explicitly per field. The form editor is ideal
+                for flat/simple claim structures. For complex nested objects/arrays,
+                <em>JSON View</em> is usually the better option.
               </mat-card-subtitle>
             </mat-card-header>
             <mat-card-content>

--- a/apps/client/src/app/issuance/credential-config/credential-config-create/credential-config-create.component.ts
+++ b/apps/client/src/app/issuance/credential-config/credential-config-create/credential-config-create.component.ts
@@ -516,8 +516,9 @@ export class CredentialConfigCreateComponent implements OnInit {
         (normalizedConfig.config as any)?.keyAttestationsRequired?.user_authentication || [],
     } as any);
 
+    const flatFields = this.flattenFieldDefinitionsForForm(normalizedConfig.fields || []);
     this.fields.clear();
-    for (const field of normalizedConfig.fields || []) {
+    for (const field of flatFields) {
       this.fields.push(this.createFieldGroup(field));
     }
 
@@ -700,11 +701,10 @@ export class CredentialConfigCreateComponent implements OnInit {
     const display = new FormArray(
       (field?.display || []).map((entry) => this.createFieldDisplayGroup(entry))
     );
-    const isMdoc = this.form.get('format')?.value === 'mso_mdoc';
-    const namespace = this.getFieldNamespaceForForm(field, isMdoc);
+    const namespace = this.getFieldNamespaceForForm(field);
 
     return new FormGroup({
-      path: new FormControl(this.normalizeFieldPathForForm(field, isMdoc), [Validators.required]),
+      path: new FormControl(this.normalizeFieldPathForForm(field), [Validators.required]),
       namespace: new FormControl(namespace),
       type: new FormControl(field?.type || 'string', [Validators.required]),
       defaultValue: new FormControl(this.stringifyField(field?.defaultValue)),
@@ -873,7 +873,7 @@ export class CredentialConfigCreateComponent implements OnInit {
       }),
     };
 
-    formValue.fields = this.buildFieldsPayload(formValue.fields || [], isMdoc);
+    formValue.fields = this.buildFieldsPayload(formValue.fields || []);
 
     // Convert empty strings to null to clear optional fields (for PATCH semantics)
     formValue.keyChainId = formValue.keyChainId || null;
@@ -956,10 +956,10 @@ export class CredentialConfigCreateComponent implements OnInit {
     return mode === 'extract' ? extractSchema(value) : parsed;
   }
 
-  private buildFieldsPayload(rawFields: any[], isMdoc: boolean): ClaimFieldDefinitionDto[] {
-    return rawFields
+  private buildFieldsPayload(rawFields: any[]): ClaimFieldDefinitionDto[] {
+    const flatFields = rawFields
       .map((rawField: any) => {
-        const path = this.parseFieldPath(rawField['path'], isMdoc);
+        const path = this.parseFieldPath(rawField['path']);
         const defaultValueRaw = rawField['defaultValue']?.trim();
         const namespace = rawField['namespace']?.trim() || undefined;
 
@@ -967,7 +967,7 @@ export class CredentialConfigCreateComponent implements OnInit {
           path,
           type: rawField['type'],
           mandatory: !!rawField['mandatory'],
-          ...(isMdoc ? {} : { disclosable: !!rawField['disclosable'] }),
+          disclosable: !!rawField['disclosable'],
           ...(namespace ? { namespace } : {}),
         };
 
@@ -990,64 +990,193 @@ export class CredentialConfigCreateComponent implements OnInit {
         return field;
       })
       .filter((field) => field.path.length > 0);
+
+    // Use one common nested field model for all formats.
+    return this.buildNestedFieldDefinitions(flatFields);
   }
 
-  private parseFieldPath(value: string, isMdoc: boolean): string[] {
+  private parseFieldPath(value: string): (string | number | null)[] {
     if (!value) {
       return [];
-    }
-
-    if (isMdoc) {
-      const trimmed = value.trim();
-      return trimmed ? [trimmed] : [];
     }
 
     return value
       .split('.')
       .map((segment) => segment.trim())
-      .filter(Boolean);
+      .filter((segment) => segment.length > 0)
+      .map((segment) => {
+        if (segment === '*') {
+          return null;
+        }
+
+        if (/^\d+$/.test(segment)) {
+          return Number(segment);
+        }
+
+        return segment;
+      });
   }
 
-  private getFieldNamespaceForForm(
-    field: ClaimFieldDefinitionDto | undefined,
-    isMdoc: boolean
-  ): string {
+  private getFieldNamespaceForForm(field: ClaimFieldDefinitionDto | undefined): string {
     const explicitNamespace = field?.namespace?.trim();
     if (explicitNamespace) {
       return explicitNamespace;
     }
 
-    if (!isMdoc) {
-      return '';
-    }
-
-    const firstSegment = field?.path?.[0];
-    if (typeof firstSegment === 'string' && field?.path && field.path.length > 1) {
-      return firstSegment;
-    }
-
     return '';
   }
 
-  private normalizeFieldPathForForm(
-    field: ClaimFieldDefinitionDto | undefined,
-    isMdoc: boolean
-  ): string {
+  private normalizeFieldPathForForm(field: ClaimFieldDefinitionDto | undefined): string {
     const path = field?.path || [];
-    if (!isMdoc || path.length === 0) {
-      return path.join('.') || '';
+    if (path.length === 0) {
+      return '';
     }
 
-    const namespace = this.getFieldNamespaceForForm(field, isMdoc);
-    if (namespace && path[0] === namespace) {
-      return path.slice(1).join('.');
+    return path
+      .map((segment) => {
+        if (segment === null) {
+          return '*';
+        }
+
+        return String(segment);
+      })
+      .join('.');
+  }
+
+  private resolveChildPathForForm(
+    parentPath: (string | number | null)[],
+    parentType: ClaimFieldDefinitionDto['type'],
+    childPath: (string | number | null)[]
+  ): (string | number | null)[] {
+    if (childPath.length >= parentPath.length) {
+      const startsWithParent = parentPath.every((seg, i) => seg === childPath[i]);
+      if (startsWithParent) {
+        return childPath;
+      }
     }
 
-    if (!field?.namespace && path.length > 1) {
-      return path.slice(1).join('.');
+    if (parentType === 'array' && childPath.length > 0) {
+      if (childPath[0] === null || typeof childPath[0] === 'number') {
+        return [...parentPath, ...childPath.slice(1)];
+      }
     }
 
-    return path.join('.');
+    return [...parentPath, ...childPath];
+  }
+
+  private flattenFieldDefinitionsForForm(
+    fields: ClaimFieldDefinitionDto[]
+  ): ClaimFieldDefinitionDto[] {
+    const result: ClaimFieldDefinitionDto[] = [];
+
+    const visit = (field: ClaimFieldDefinitionDto): void => {
+      const { children, ...fieldWithoutChildren } = field as ClaimFieldDefinitionDto & {
+        children?: ClaimFieldDefinitionDto[];
+      };
+
+      result.push(fieldWithoutChildren);
+
+      if (children?.length) {
+        const resolvedChildren = children.map((child) => ({
+          ...child,
+          path: this.resolveChildPathForForm(field.path, field.type, child.path),
+          namespace: child.namespace ?? field.namespace,
+        }));
+
+        resolvedChildren.forEach((child) => visit(child));
+      }
+    };
+
+    fields.forEach((field) => visit(field));
+    return result;
+  }
+
+  private buildNestedFieldDefinitions(
+    flatFields: ClaimFieldDefinitionDto[]
+  ): ClaimFieldDefinitionDto[] {
+    type MutableField = ClaimFieldDefinitionDto & { children?: MutableField[] };
+    interface IndexedNode {
+      absolutePath: (string | number | null)[];
+      node: MutableField;
+      namespace: string;
+    }
+
+    const byNamespace = new Map<string, MutableField[]>();
+
+    for (const field of flatFields) {
+      const key = field.namespace || '__global__';
+      const list = byNamespace.get(key) ?? [];
+      list.push({ ...field });
+      byNamespace.set(key, list);
+    }
+
+    const nested: MutableField[] = [];
+
+    for (const [, list] of byNamespace.entries()) {
+      list.sort((a, b) => a.path.length - b.path.length);
+
+      const roots: MutableField[] = [];
+      const inserted: IndexedNode[] = [];
+
+      for (const field of list) {
+        let parent: IndexedNode | undefined;
+
+        const absolutePath = [...field.path];
+        const namespace = field.namespace || '__global__';
+
+        for (const candidate of inserted) {
+          if (candidate.namespace !== namespace) {
+            continue;
+          }
+
+          if (candidate.absolutePath.length >= absolutePath.length) {
+            continue;
+          }
+
+          if (candidate.node.type !== 'object' && candidate.node.type !== 'array') {
+            continue;
+          }
+
+          const matchesPrefix = candidate.absolutePath.every(
+            (seg, idx) => seg === absolutePath[idx]
+          );
+          if (!matchesPrefix) {
+            continue;
+          }
+
+          if (!parent || candidate.absolutePath.length > parent.absolutePath.length) {
+            parent = candidate;
+          }
+        }
+
+        if (!parent) {
+          roots.push(field);
+          inserted.push({ absolutePath, node: field, namespace });
+          continue;
+        }
+
+        let relativePath = absolutePath.slice(parent.absolutePath.length);
+
+        // For array parents, child paths are stored relative without the wildcard
+        // marker. The derive layer will inject the item step when flattening.
+        if (parent.node.type === 'array' && relativePath[0] === null) {
+          relativePath = relativePath.slice(1);
+        }
+
+        const child: MutableField = {
+          ...field,
+          path: relativePath,
+        };
+
+        parent.node.children ??= [];
+        parent.node.children.push(child);
+        inserted.push({ absolutePath, node: child, namespace });
+      }
+
+      nested.push(...roots);
+    }
+
+    return nested;
   }
 
   /**

--- a/apps/client/src/app/issuance/issuance-config/issuance-config-create/issuance-config-create.component.html
+++ b/apps/client/src/app/issuance/issuance-config/issuance-config-create/issuance-config-create.component.html
@@ -156,8 +156,8 @@
 
       <mat-tab>
         <ng-template mat-tab-label>
-          <mat-icon class="tab-icon">settings_applications</mat-icon>
-          Business Logic
+          <mat-icon class="tab-icon">manage_accounts</mat-icon>
+          Authorize User
         </ng-template>
 
         <ng-template matTabContent>
@@ -175,161 +175,6 @@
                 >
               </mat-card-header>
               <mat-card-content fxLayout="column" fxLayoutGap="16px">
-                <div class="locale-chips">
-                  <strong>External Authorization Servers</strong>
-                </div>
-                <div formArrayName="authServers">
-                  @for (server of authServers.controls; track $index; let i = $index) {
-                    <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="8px">
-                      <mat-form-field fxFlex>
-                        <mat-label>External Authorization Server {{ i + 1 }}</mat-label>
-                        <input
-                          matInput
-                          [formControlName]="i"
-                          placeholder="https://auth.example.com"
-                          type="url"
-                        />
-                        <mat-icon matSuffix>link</mat-icon>
-                        @if (server.invalid && server.touched) {
-                          <mat-error>Please enter a valid URL</mat-error>
-                        }
-                      </mat-form-field>
-                      <button
-                        matIconButton
-                        type="button"
-                        color="warn"
-                        (click)="removeAuthServer(i)"
-                        matTooltip="Remove this authorization server"
-                      >
-                        <mat-icon>delete</mat-icon>
-                      </button>
-                    </div>
-                  }
-                </div>
-                <div fxLayout="row" fxLayoutAlign="center center">
-                  <button mat-raised-button type="button" (click)="addAuthServer()">
-                    <mat-icon>add</mat-icon> Add External Authorization Server
-                  </button>
-                </div>
-
-                <mat-divider></mat-divider>
-
-                <div class="locale-chips">
-                  <strong>Hosted Authorization Servers</strong>
-                </div>
-
-                <div formArrayName="authorizationServers" fxLayout="column" fxLayoutGap="16px">
-                  @for (server of authorizationServers.controls; track $index; let i = $index) {
-                    <div [formGroupName]="i" class="mat-elevation-z2 display-entry">
-                      <div
-                        fxLayout="row"
-                        fxLayoutAlign="space-between center"
-                        class="display-entry-header"
-                      >
-                        <h3>Hosted Authorization Server {{ i + 1 }}</h3>
-                        <button
-                          matIconButton
-                          type="button"
-                          color="warn"
-                          (click)="removeAuthorizationServer(i)"
-                          matTooltip="Remove this hosted authorization server"
-                        >
-                          <mat-icon>delete</mat-icon>
-                        </button>
-                      </div>
-
-                      <div fxLayout="column" fxLayoutGap="16px">
-                        <div fxLayout="row" fxLayoutGap="16px">
-                          <mat-form-field fxFlex>
-                            <mat-label>ID</mat-label>
-                            <input
-                              matInput
-                              id="managed-auth-server-id-{{ i }}"
-                              formControlName="id"
-                              placeholder="pid-auth"
-                            />
-                            <mat-hint>Used in the AS URL path</mat-hint>
-                          </mat-form-field>
-                          <mat-form-field fxFlex>
-                            <mat-label>Label</mat-label>
-                            <input
-                              matInput
-                              id="managed-auth-server-label-{{ i }}"
-                              formControlName="label"
-                              placeholder="PID Authorization Server"
-                            />
-                            <mat-hint>Shown in the UI offer selector</mat-hint>
-                          </mat-form-field>
-                        </div>
-
-                        <div fxLayout="row" fxLayoutGap="16px">
-                          <mat-form-field fxFlex>
-                            <mat-label>Type</mat-label>
-                            <mat-select formControlName="type">
-                              <mat-option value="oid4vp">OID4VP</mat-option>
-                            </mat-select>
-                          </mat-form-field>
-                          <mat-slide-toggle formControlName="requireDPoP">
-                            Require DPoP
-                          </mat-slide-toggle>
-                        </div>
-
-                        <div formGroupName="oid4vp" fxLayout="column" fxLayoutGap="16px">
-                          <mat-form-field>
-                            <mat-label>Presentation Configuration ID</mat-label>
-                            <mat-select formControlName="presentationConfigId">
-                              @if (availablePresentationConfigIds.length === 0) {
-                                <mat-option disabled value="">
-                                  No presentation configurations found
-                                </mat-option>
-                              }
-                              @for (configId of availablePresentationConfigIds; track configId) {
-                                <mat-option [value]="configId">{{ configId }}</mat-option>
-                              }
-                            </mat-select>
-                            <mat-hint
-                              >Presentation request used before returning the OAuth code</mat-hint
-                            >
-                          </mat-form-field>
-
-                          <mat-slide-toggle formControlName="immediateWalletRedirect">
-                            Immediately redirect to wallet
-                          </mat-slide-toggle>
-                        </div>
-
-                        <div formGroupName="token" fxLayout="row" fxLayoutGap="16px">
-                          <mat-form-field fxFlex>
-                            <mat-label>Token Lifetime (seconds)</mat-label>
-                            <input
-                              matInput
-                              id="managed-auth-server-lifetime-{{ i }}"
-                              type="number"
-                              formControlName="lifetimeSeconds"
-                              min="60"
-                              placeholder="3600"
-                            />
-                          </mat-form-field>
-                          <mat-form-field fxFlex>
-                            <mat-label>Signing Key ID (optional)</mat-label>
-                            <input
-                              matInput
-                              id="managed-auth-server-signing-key-{{ i }}"
-                              formControlName="signingKeyId"
-                              placeholder="Leave empty for default"
-                            />
-                          </mat-form-field>
-                        </div>
-                      </div>
-                    </div>
-                  }
-                </div>
-
-                <div fxLayout="row" fxLayoutAlign="center center">
-                  <button mat-raised-button type="button" (click)="addAuthorizationServer()">
-                    <mat-icon>add</mat-icon> Add Hosted Authorization Server
-                  </button>
-                </div>
-
                 <!-- Preferred Authorization Server -->
                 <mat-form-field>
                   <mat-label>Preferred Authorization Server</mat-label>
@@ -343,143 +188,259 @@
                   <mat-hint
                     >The preferred AS is placed first in the issuer metadata. Wallets typically use
                     the first AS for wallet-initiated flows. Values are external URLs,
-                    authorization-server:SERVER_ID, chained-as, or built-in.</mat-hint
+                    authorization-server:SERVER_ID, or built-in.</mat-hint
                   >
                 </mat-form-field>
 
                 <mat-divider></mat-divider>
 
-                <div class="locale-chips">
-                  <strong>Chained Authorization Server</strong>
+                <div formArrayName="authorizationServers">
+                  <mat-accordion>
+                    @for (server of authorizationServers.controls; track $index; let i = $index) {
+                      <mat-expansion-panel [formGroupName]="i">
+                        <mat-expansion-panel-header>
+                          <mat-panel-title>
+                            @if (server.get('type')?.value === 'external') {
+                              {{
+                                server.get('label')?.value ||
+                                  server.get('issuer')?.value ||
+                                  'External Authorization Server ' + (i + 1)
+                              }}
+                            } @else {
+                              {{
+                                server.get('label')?.value ||
+                                  server.get('id')?.value ||
+                                  'Authorization Server ' + (i + 1)
+                              }}
+                            }
+                          </mat-panel-title>
+                          <mat-panel-description>
+                            {{ server.get('type')?.value || 'oid4vp' }}
+                          </mat-panel-description>
+                        </mat-expansion-panel-header>
+
+                        @if (server.get('type')?.value === 'external') {
+                          <div fxLayout="column" fxLayoutGap="16px">
+                            <mat-form-field>
+                              <mat-label>External Authorization Server URL</mat-label>
+                              <input
+                                matInput
+                                formControlName="issuer"
+                                placeholder="https://auth.example.com"
+                                type="url"
+                              />
+                              <mat-icon matSuffix>link</mat-icon>
+                              @if (server.get('issuer')?.invalid && server.get('issuer')?.touched) {
+                                <mat-error>Please enter a valid URL</mat-error>
+                              }
+                            </mat-form-field>
+
+                            <mat-form-field>
+                              <mat-label>Label (optional)</mat-label>
+                              <input
+                                matInput
+                                formControlName="label"
+                                placeholder="Friendly name for preferred selector"
+                              />
+                            </mat-form-field>
+
+                            <div fxLayout="row" fxLayoutAlign="end center">
+                              <button
+                                matIconButton
+                                type="button"
+                                color="warn"
+                                (click)="removeAuthorizationServer(i)"
+                                matTooltip="Remove this authorization server"
+                              >
+                                <mat-icon>delete</mat-icon>
+                              </button>
+                            </div>
+                          </div>
+                        } @else {
+                          <div fxLayout="column" fxLayoutGap="16px">
+                            <div fxLayout="row" fxLayoutGap="16px">
+                              <mat-form-field fxFlex>
+                                <mat-label>ID</mat-label>
+                                <input
+                                  matInput
+                                  id="managed-auth-server-id-{{ i }}"
+                                  formControlName="id"
+                                  placeholder="auth-server-id"
+                                />
+                                <mat-hint>Used in the AS URL path and preferred selector</mat-hint>
+                              </mat-form-field>
+                              <mat-form-field fxFlex>
+                                <mat-label>Label</mat-label>
+                                <input
+                                  matInput
+                                  id="managed-auth-server-label-{{ i }}"
+                                  formControlName="label"
+                                  placeholder="Authorization Server"
+                                />
+                              </mat-form-field>
+                            </div>
+
+                            <div fxLayout="row" fxLayoutGap="16px" fxLayoutAlign="start center">
+                              <mat-form-field fxFlex>
+                                <mat-label>Type</mat-label>
+                                <mat-select formControlName="type">
+                                  <mat-option value="oid4vp">OID4VP</mat-option>
+                                  <mat-option value="chained">Chained</mat-option>
+                                </mat-select>
+                              </mat-form-field>
+                              <mat-slide-toggle formControlName="enabled">Enabled</mat-slide-toggle>
+                              <mat-slide-toggle formControlName="requireDPoP"
+                                >Require DPoP</mat-slide-toggle
+                              >
+                            </div>
+
+                            @if (server.get('type')?.value === 'oid4vp') {
+                              <div formGroupName="oid4vp" fxLayout="column" fxLayoutGap="16px">
+                                <mat-form-field>
+                                  <mat-label>Presentation Configuration ID</mat-label>
+                                  <mat-select formControlName="presentationConfigId">
+                                    @if (availablePresentationConfigIds.length === 0) {
+                                      <mat-option disabled value="">
+                                        No presentation configurations found
+                                      </mat-option>
+                                    }
+                                    @for (
+                                      configId of availablePresentationConfigIds;
+                                      track configId
+                                    ) {
+                                      <mat-option [value]="configId">{{ configId }}</mat-option>
+                                    }
+                                  </mat-select>
+                                </mat-form-field>
+
+                                <mat-slide-toggle formControlName="immediateWalletRedirect">
+                                  Immediately redirect to wallet
+                                </mat-slide-toggle>
+                              </div>
+                            }
+
+                            @if (server.get('type')?.value === 'chained') {
+                              <div formGroupName="chained" fxLayout="column" fxLayoutGap="16px">
+                                <mat-form-field>
+                                  <mat-label>Upstream Issuer URL</mat-label>
+                                  <input
+                                    matInput
+                                    formControlName="issuer"
+                                    placeholder="https://keycloak.example.com/realms/my-realm"
+                                    type="url"
+                                  />
+                                </mat-form-field>
+
+                                <div fxLayout="row" fxLayoutGap="16px">
+                                  <mat-form-field fxFlex>
+                                    <mat-label>Client ID</mat-label>
+                                    <input
+                                      matInput
+                                      formControlName="clientId"
+                                      placeholder="eudiplo-client"
+                                    />
+                                  </mat-form-field>
+                                  <mat-form-field fxFlex>
+                                    <mat-label>Client Secret</mat-label>
+                                    <input
+                                      matInput
+                                      formControlName="clientSecret"
+                                      type="password"
+                                      placeholder="••••••••"
+                                    />
+                                  </mat-form-field>
+                                </div>
+                              </div>
+                            }
+
+                            <div formGroupName="token" fxLayout="row" fxLayoutGap="16px">
+                              <mat-form-field fxFlex>
+                                <mat-label>Token Lifetime (seconds)</mat-label>
+                                <input
+                                  matInput
+                                  id="managed-auth-server-lifetime-{{ i }}"
+                                  type="number"
+                                  formControlName="lifetimeSeconds"
+                                  min="60"
+                                  placeholder="3600"
+                                />
+                              </mat-form-field>
+                              <mat-form-field fxFlex>
+                                <mat-label>Signing Key ID (optional)</mat-label>
+                                <input
+                                  matInput
+                                  id="managed-auth-server-signing-key-{{ i }}"
+                                  formControlName="signingKeyId"
+                                  placeholder="Leave empty for default"
+                                />
+                              </mat-form-field>
+                            </div>
+
+                            <div formGroupName="token" fxLayout="column" fxLayoutGap="16px">
+                              <mat-slide-toggle formControlName="refreshTokenEnabled">
+                                <div fxLayout="column">
+                                  <span><strong>Issue Refresh Tokens</strong></span>
+                                  <span class="toggle-description"
+                                    >Allow wallets to exchange refresh tokens for new access
+                                    tokens.</span
+                                  >
+                                </div>
+                              </mat-slide-toggle>
+
+                              @if (server.get('token.refreshTokenEnabled')?.value) {
+                                <mat-form-field>
+                                  <mat-label>Refresh Token Lifetime (seconds)</mat-label>
+                                  <input
+                                    matInput
+                                    type="number"
+                                    formControlName="refreshTokenExpiresInSeconds"
+                                    min="1"
+                                    placeholder="2592000"
+                                  />
+                                  <mat-icon matSuffix>timelapse</mat-icon>
+                                  <mat-hint>Default: 2592000 seconds (30 days)</mat-hint>
+                                </mat-form-field>
+                              }
+                            </div>
+
+                            <div fxLayout="row" fxLayoutAlign="end center">
+                              <button
+                                matIconButton
+                                type="button"
+                                color="warn"
+                                (click)="removeAuthorizationServer(i)"
+                                matTooltip="Remove this authorization server"
+                              >
+                                <mat-icon>delete</mat-icon>
+                              </button>
+                            </div>
+                          </div>
+                        }
+                      </mat-expansion-panel>
+                    }
+                  </mat-accordion>
                 </div>
 
-                <mat-card formGroupName="chainedAs">
-                  <mat-card-header>
-                    <mat-card-title>
-                      <mat-icon>account_tree</mat-icon>
-                      Chained Authorization Server
-                    </mat-card-title>
-                    <mat-card-subtitle
-                      >Delegate user authentication to an upstream OIDC provider while issuing
-                      EUDIPLO tokens</mat-card-subtitle
-                    >
-                  </mat-card-header>
-                  <mat-card-content fxLayout="column" fxLayoutGap="16px">
-                    <mat-slide-toggle formControlName="enabled">
-                      <div fxLayout="column">
-                        <span><strong>Enable Chained AS</strong></span>
-                        <span class="toggle-description"
-                          >When enabled, EUDIPLO acts as an OAuth AS facade, delegating
-                          authentication to an upstream OIDC provider (e.g., Keycloak)</span
-                        >
-                      </div>
-                    </mat-slide-toggle>
-
-                    @if (chainedAsEnabled) {
-                      <div
-                        formGroupName="upstream"
-                        fxLayout="column"
-                        fxLayoutGap="16px"
-                        class="chained-as-section"
-                      >
-                        <h4>
-                          <mat-icon>cloud</mat-icon>
-                          Upstream OIDC Provider
-                        </h4>
-                        <mat-form-field>
-                          <mat-label>Issuer URL</mat-label>
-                          <input
-                            matInput
-                            formControlName="issuer"
-                            placeholder="https://keycloak.example.com/realms/my-realm"
-                            type="url"
-                          />
-                          <mat-icon matSuffix>link</mat-icon>
-                          <mat-hint
-                            >The upstream OIDC provider URL (must support discovery)</mat-hint
-                          >
-                        </mat-form-field>
-
-                        <div fxLayout="row" fxLayoutGap="16px">
-                          <mat-form-field fxFlex>
-                            <mat-label>Client ID</mat-label>
-                            <input
-                              matInput
-                              id="chained-as-client-id"
-                              aria-label="Chained AS client ID"
-                              formControlName="clientId"
-                              placeholder="eudiplo-client"
-                            />
-                            <mat-icon matSuffix>fingerprint</mat-icon>
-                          </mat-form-field>
-                          <mat-form-field fxFlex>
-                            <mat-label>Client Secret</mat-label>
-                            <input
-                              matInput
-                              formControlName="clientSecret"
-                              type="password"
-                              placeholder="••••••••"
-                            />
-                            <mat-icon matSuffix>lock</mat-icon>
-                          </mat-form-field>
-                        </div>
-
-                        <p class="section-hint">
-                          <mat-icon>info</mat-icon>
-                          Configure your upstream OIDC provider with redirect URI:
-                          <code
-                            >https://your-eudiplo-url/&#123;tenant&#125;/chained-as/callback</code
-                          >
-                        </p>
-                      </div>
-
-                      <div
-                        formGroupName="token"
-                        fxLayout="column"
-                        fxLayoutGap="16px"
-                        class="chained-as-section"
-                      >
-                        <h4>
-                          <mat-icon>token</mat-icon>
-                          Token Configuration
-                        </h4>
-                        <div fxLayout="row" fxLayoutGap="16px">
-                          <mat-form-field fxFlex>
-                            <mat-label>Token Lifetime (seconds)</mat-label>
-                            <input
-                              matInput
-                              type="number"
-                              formControlName="lifetimeSeconds"
-                              placeholder="3600"
-                              min="60"
-                            />
-                            <mat-icon matSuffix>schedule</mat-icon>
-                            <mat-hint>Access token lifetime in seconds (default: 3600)</mat-hint>
-                          </mat-form-field>
-                          <mat-form-field fxFlex>
-                            <mat-label>Signing Key ID (optional)</mat-label>
-                            <input
-                              matInput
-                              formControlName="signingKeyId"
-                              placeholder="Leave empty for default"
-                            />
-                            <mat-icon matSuffix>key</mat-icon>
-                            <mat-hint>Key ID for token signing (uses default if empty)</mat-hint>
-                          </mat-form-field>
-                        </div>
-                      </div>
-
-                      <mat-slide-toggle formControlName="requireDPoP">
-                        <div fxLayout="column">
-                          <span><strong>Require DPoP</strong></span>
-                          <span class="toggle-description"
-                            >Require wallets to provide DPoP proof when requesting tokens</span
-                          >
-                        </div>
-                      </mat-slide-toggle>
-                    }
-                  </mat-card-content>
-                </mat-card>
+                <div fxLayout="row" fxLayoutGap="12px" fxLayoutAlign="start center">
+                  <button
+                    mat-raised-button
+                    type="button"
+                    (click)="addExternalAuthorizationServer()"
+                  >
+                    <mat-icon>add</mat-icon> Add External Authorization Server
+                  </button>
+                  <button
+                    mat-raised-button
+                    color="primary"
+                    type="button"
+                    (click)="addAuthorizationServer()"
+                  >
+                    <mat-icon>add</mat-icon> Add OID4VP Authorization Server
+                  </button>
+                  <button mat-raised-button type="button" (click)="addChainedAuthorizationServer()">
+                    <mat-icon>add</mat-icon> Add Chained Authorization Server
+                  </button>
+                </div>
               </mat-card-content>
             </mat-card>
           </div>
@@ -494,54 +455,6 @@
 
         <ng-template matTabContent>
           <div fxLayout="column" fxLayoutGap="24px" class="tab-content">
-            <mat-card>
-              <mat-card-header>
-                <mat-card-title>
-                  <mat-icon>refresh</mat-icon>
-                  Refresh Tokens
-                </mat-card-title>
-                <mat-card-subtitle
-                  >Configure whether wallets can refresh access tokens and for how long refresh
-                  tokens remain valid</mat-card-subtitle
-                >
-              </mat-card-header>
-              <mat-card-content fxLayout="column" fxLayoutGap="16px">
-                <mat-slide-toggle formControlName="refreshTokenEnabled">
-                  <div fxLayout="column">
-                    <span><strong>Issue Refresh Tokens</strong></span>
-                    <span class="toggle-description"
-                      >Allow wallets to exchange a refresh token for a new access token without
-                      restarting the issuance authorization flow.</span
-                    >
-                  </div>
-                </mat-slide-toggle>
-
-                @if (refreshTokenEnabled) {
-                  <mat-form-field>
-                    <mat-label>Refresh Token Lifetime (seconds)</mat-label>
-                    <input
-                      matInput
-                      type="number"
-                      formControlName="refreshTokenExpiresInSeconds"
-                      placeholder="2592000"
-                      min="1"
-                    />
-                    <mat-icon matSuffix>timelapse</mat-icon>
-                    <mat-hint>
-                      How long issued refresh tokens remain valid. Default: 2592000 seconds (30
-                      days).
-                    </mat-hint>
-                    @if (
-                      form.get('refreshTokenExpiresInSeconds')?.invalid &&
-                      form.get('refreshTokenExpiresInSeconds')?.touched
-                    ) {
-                      <mat-error>Refresh token lifetime must be at least 1 second</mat-error>
-                    }
-                  </mat-form-field>
-                }
-              </mat-card-content>
-            </mat-card>
-
             <!-- tx_code Brute-Force Protection Card -->
             <mat-card>
               <mat-card-header>
@@ -907,6 +820,8 @@
                       <input
                         matInput
                         type="url"
+                        id="registration-cert-privacy-policy"
+                        aria-label="Registration certificate privacy policy URL"
                         formControlName="privacyPolicy"
                         placeholder="https://issuer.example/privacy"
                       />

--- a/apps/client/src/app/issuance/issuance-config/issuance-config-create/issuance-config-create.component.html
+++ b/apps/client/src/app/issuance/issuance-config/issuance-config-create/issuance-config-create.component.html
@@ -171,27 +171,11 @@
                 </mat-card-title>
                 <mat-card-subtitle
                   >Configure external, hosted, and chained authorization servers in one place. Leave
-                  external empty to use only hosted/built-in options.</mat-card-subtitle
+                  external empty to use only hosted/built-in options. The first enabled server in
+                  this list is treated as the default (preferred) server.</mat-card-subtitle
                 >
               </mat-card-header>
               <mat-card-content fxLayout="column" fxLayoutGap="16px">
-                <!-- Preferred Authorization Server -->
-                <mat-form-field>
-                  <mat-label>Preferred Authorization Server</mat-label>
-                  <mat-select formControlName="preferredAuthServer">
-                    <mat-option value="">None (use default order)</mat-option>
-                    @for (option of availableAuthServerOptions; track option.value) {
-                      <mat-option [value]="option.value">{{ option.label }}</mat-option>
-                    }
-                  </mat-select>
-                  <mat-icon matSuffix>star</mat-icon>
-                  <mat-hint
-                    >The preferred AS is placed first in the issuer metadata. Wallets typically use
-                    the first AS for wallet-initiated flows. Values are external URLs,
-                    authorization-server:SERVER_ID, or built-in.</mat-hint
-                  >
-                </mat-form-field>
-
                 <mat-divider></mat-divider>
 
                 <div formArrayName="authorizationServers">
@@ -240,11 +224,29 @@
                               <input
                                 matInput
                                 formControlName="label"
-                                placeholder="Friendly name for preferred selector"
+                                placeholder="Friendly name"
                               />
                             </mat-form-field>
 
                             <div fxLayout="row" fxLayoutAlign="end center">
+                              <button
+                                matIconButton
+                                type="button"
+                                (click)="moveAuthorizationServer(i, 'up')"
+                                [disabled]="i === 0"
+                                matTooltip="Move up"
+                              >
+                                <mat-icon>arrow_upward</mat-icon>
+                              </button>
+                              <button
+                                matIconButton
+                                type="button"
+                                (click)="moveAuthorizationServer(i, 'down')"
+                                [disabled]="i === authorizationServers.length - 1"
+                                matTooltip="Move down"
+                              >
+                                <mat-icon>arrow_downward</mat-icon>
+                              </button>
                               <button
                                 matIconButton
                                 type="button"
@@ -267,7 +269,7 @@
                                   formControlName="id"
                                   placeholder="auth-server-id"
                                 />
-                                <mat-hint>Used in the AS URL path and preferred selector</mat-hint>
+                                <mat-hint>Used in the AS URL path</mat-hint>
                               </mat-form-field>
                               <mat-form-field fxFlex>
                                 <mat-label>Label</mat-label>
@@ -404,6 +406,24 @@
                             </div>
 
                             <div fxLayout="row" fxLayoutAlign="end center">
+                              <button
+                                matIconButton
+                                type="button"
+                                (click)="moveAuthorizationServer(i, 'up')"
+                                [disabled]="i === 0"
+                                matTooltip="Move up"
+                              >
+                                <mat-icon>arrow_upward</mat-icon>
+                              </button>
+                              <button
+                                matIconButton
+                                type="button"
+                                (click)="moveAuthorizationServer(i, 'down')"
+                                [disabled]="i === authorizationServers.length - 1"
+                                matTooltip="Move down"
+                              >
+                                <mat-icon>arrow_downward</mat-icon>
+                              </button>
                               <button
                                 matIconButton
                                 type="button"

--- a/apps/client/src/app/issuance/issuance-config/issuance-config-create/issuance-config-create.component.html
+++ b/apps/client/src/app/issuance/issuance-config/issuance-config-create/issuance-config-create.component.html
@@ -170,9 +170,9 @@
                   Authorization Servers
                 </mat-card-title>
                 <mat-card-subtitle
-                  >Configure external, hosted, and chained authorization servers in one place. Leave
-                  external empty to use only hosted/built-in options. The first enabled server in
-                  this list is treated as the default (preferred) server.</mat-card-subtitle
+                  >Configure external, hosted, chained, and built-in authorization servers in one
+                  place. The first enabled server in this list is treated as the default
+                  (preferred) server.</mat-card-subtitle
                 >
               </mat-card-header>
               <mat-card-content fxLayout="column" fxLayoutGap="16px">
@@ -257,16 +257,18 @@
                         } @else {
                           <div fxLayout="column" fxLayoutGap="16px">
                             <div fxLayout="row" fxLayoutGap="16px">
-                              <mat-form-field fxFlex>
-                                <mat-label>ID</mat-label>
-                                <input
-                                  matInput
-                                  id="managed-auth-server-id-{{ i }}"
-                                  formControlName="id"
-                                  placeholder="auth-server-id"
-                                />
-                                <mat-hint>Used in the AS URL path</mat-hint>
-                              </mat-form-field>
+                              @if (server.get('type')?.value !== 'built-in') {
+                                <mat-form-field fxFlex>
+                                  <mat-label>ID</mat-label>
+                                  <input
+                                    matInput
+                                    id="managed-auth-server-id-{{ i }}"
+                                    formControlName="id"
+                                    placeholder="auth-server-id"
+                                  />
+                                  <mat-hint>Used in the AS URL path</mat-hint>
+                                </mat-form-field>
+                              }
                               <mat-form-field fxFlex>
                                 <mat-label>Label</mat-label>
                                 <input
@@ -284,6 +286,7 @@
                                 <mat-select formControlName="type">
                                   <mat-option value="oid4vp">OID4VP</mat-option>
                                   <mat-option value="chained">Chained</mat-option>
+                                  <mat-option value="built-in">Built-in</mat-option>
                                 </mat-select>
                               </mat-form-field>
                               <mat-slide-toggle formControlName="enabled">Enabled</mat-slide-toggle>
@@ -348,6 +351,16 @@
                                     />
                                   </mat-form-field>
                                 </div>
+                              </div>
+                            }
+
+                            @if (server.get('type')?.value === 'built-in') {
+                              <div class="m-doc-hint">
+                                <mat-icon>info</mat-icon>
+                                <span>
+                                  Built-in AS uses issuer-local authorization endpoints and is only
+                                  included when explicitly configured.
+                                </span>
                               </div>
                             }
 
@@ -455,6 +468,9 @@
                   </button>
                   <button mat-raised-button type="button" (click)="addChainedAuthorizationServer()">
                     <mat-icon>add</mat-icon> Add Chained Authorization Server
+                  </button>
+                  <button mat-raised-button type="button" (click)="addBuiltInAuthorizationServer()">
+                    <mat-icon>add</mat-icon> Add Built-in Authorization Server
                   </button>
                 </div>
               </mat-card-content>

--- a/apps/client/src/app/issuance/issuance-config/issuance-config-create/issuance-config-create.component.html
+++ b/apps/client/src/app/issuance/issuance-config/issuance-config-create/issuance-config-create.component.html
@@ -171,8 +171,8 @@
                 </mat-card-title>
                 <mat-card-subtitle
                   >Configure external, hosted, chained, and built-in authorization servers in one
-                  place. The first enabled server in this list is treated as the default
-                  (preferred) server.</mat-card-subtitle
+                  place. The first enabled server in this list is treated as the default (preferred)
+                  server.</mat-card-subtitle
                 >
               </mat-card-header>
               <mat-card-content fxLayout="column" fxLayoutGap="16px">

--- a/apps/client/src/app/issuance/issuance-config/issuance-config-create/issuance-config-create.component.html
+++ b/apps/client/src/app/issuance/issuance-config/issuance-config-create/issuance-config-create.component.html
@@ -206,6 +206,19 @@
                         @if (server.get('type')?.value === 'external') {
                           <div fxLayout="column" fxLayoutGap="16px">
                             <mat-form-field>
+                              <mat-label>Type</mat-label>
+                              <mat-select
+                                formControlName="type"
+                                (selectionChange)="onAuthorizationServerTypeChange(i, $event.value)"
+                              >
+                                <mat-option value="external">External</mat-option>
+                                <mat-option value="oid4vp">OID4VP</mat-option>
+                                <mat-option value="chained">Chained</mat-option>
+                                <mat-option value="built-in">Built-in</mat-option>
+                              </mat-select>
+                            </mat-form-field>
+
+                            <mat-form-field>
                               <mat-label>External Authorization Server URL</mat-label>
                               <input
                                 matInput
@@ -283,7 +296,11 @@
                             <div fxLayout="row" fxLayoutGap="16px" fxLayoutAlign="start center">
                               <mat-form-field fxFlex>
                                 <mat-label>Type</mat-label>
-                                <mat-select formControlName="type">
+                                <mat-select
+                                  formControlName="type"
+                                  (selectionChange)="onAuthorizationServerTypeChange(i, $event.value)"
+                                >
+                                  <mat-option value="external">External</mat-option>
                                   <mat-option value="oid4vp">OID4VP</mat-option>
                                   <mat-option value="chained">Chained</mat-option>
                                   <mat-option value="built-in">Built-in</mat-option>
@@ -451,26 +468,8 @@
                 </div>
 
                 <div fxLayout="row" fxLayoutGap="12px" fxLayoutAlign="start center">
-                  <button
-                    mat-raised-button
-                    type="button"
-                    (click)="addExternalAuthorizationServer()"
-                  >
-                    <mat-icon>add</mat-icon> Add External Authorization Server
-                  </button>
-                  <button
-                    mat-raised-button
-                    color="primary"
-                    type="button"
-                    (click)="addAuthorizationServer()"
-                  >
-                    <mat-icon>add</mat-icon> Add OID4VP Authorization Server
-                  </button>
-                  <button mat-raised-button type="button" (click)="addChainedAuthorizationServer()">
-                    <mat-icon>add</mat-icon> Add Chained Authorization Server
-                  </button>
-                  <button mat-raised-button type="button" (click)="addBuiltInAuthorizationServer()">
-                    <mat-icon>add</mat-icon> Add Built-in Authorization Server
+                  <button mat-raised-button color="primary" type="button" (click)="addAuthorizationServer()">
+                    <mat-icon>add</mat-icon> Add Authorization Server
                   </button>
                 </div>
               </mat-card-content>

--- a/apps/client/src/app/issuance/issuance-config/issuance-config-create/issuance-config-create.component.html
+++ b/apps/client/src/app/issuance/issuance-config/issuance-config-create/issuance-config-create.component.html
@@ -221,11 +221,7 @@
 
                             <mat-form-field>
                               <mat-label>Label (optional)</mat-label>
-                              <input
-                                matInput
-                                formControlName="label"
-                                placeholder="Friendly name"
-                              />
+                              <input matInput formControlName="label" placeholder="Friendly name" />
                             </mat-form-field>
 
                             <div fxLayout="row" fxLayoutAlign="end center">

--- a/apps/client/src/app/issuance/issuance-config/issuance-config-create/issuance-config-create.component.html
+++ b/apps/client/src/app/issuance/issuance-config/issuance-config-create/issuance-config-create.component.html
@@ -214,7 +214,15 @@
                                 <mat-option value="external">External</mat-option>
                                 <mat-option value="oid4vp">OID4VP</mat-option>
                                 <mat-option value="chained">Chained</mat-option>
-                                <mat-option value="built-in">Built-in</mat-option>
+                                <mat-option
+                                  value="built-in"
+                                  [disabled]="
+                                    server.get('type')?.value !== 'built-in' &&
+                                    hasBuiltInAuthorizationServer(i)
+                                  "
+                                >
+                                  Built-in
+                                </mat-option>
                               </mat-select>
                             </mat-form-field>
 
@@ -298,12 +306,22 @@
                                 <mat-label>Type</mat-label>
                                 <mat-select
                                   formControlName="type"
-                                  (selectionChange)="onAuthorizationServerTypeChange(i, $event.value)"
+                                  (selectionChange)="
+                                    onAuthorizationServerTypeChange(i, $event.value)
+                                  "
                                 >
                                   <mat-option value="external">External</mat-option>
                                   <mat-option value="oid4vp">OID4VP</mat-option>
                                   <mat-option value="chained">Chained</mat-option>
-                                  <mat-option value="built-in">Built-in</mat-option>
+                                  <mat-option
+                                    value="built-in"
+                                    [disabled]="
+                                      server.get('type')?.value !== 'built-in' &&
+                                      hasBuiltInAuthorizationServer(i)
+                                    "
+                                  >
+                                    Built-in
+                                  </mat-option>
                                 </mat-select>
                               </mat-form-field>
                               <mat-slide-toggle formControlName="enabled">Enabled</mat-slide-toggle>
@@ -468,7 +486,12 @@
                 </div>
 
                 <div fxLayout="row" fxLayoutGap="12px" fxLayoutAlign="start center">
-                  <button mat-raised-button color="primary" type="button" (click)="addAuthorizationServer()">
+                  <button
+                    mat-raised-button
+                    color="primary"
+                    type="button"
+                    (click)="addAuthorizationServer()"
+                  >
                     <mat-icon>add</mat-icon> Add Authorization Server
                   </button>
                 </div>

--- a/apps/client/src/app/issuance/issuance-config/issuance-config-create/issuance-config-create.component.ts
+++ b/apps/client/src/app/issuance/issuance-config/issuance-config-create/issuance-config-create.component.ts
@@ -715,8 +715,16 @@ export class IssuanceConfigCreateComponent implements OnInit {
     type: 'external' | 'oid4vp' | 'chained' | 'built-in'
   ): void {
     const current = this.authorizationServers.at(index)?.value;
-    if (!current || current.type === type) {
+    if (!current) {
       return;
+    }
+
+    if (type === 'built-in' && this.hasBuiltInAuthorizationServer(index)) {
+      this.snackBar.open('Only one built-in authorization server can be configured', 'Close', {
+        duration: 3000,
+      });
+      this.authorizationServers.at(index).get('type')?.setValue('oid4vp', { emitEvent: false });
+      type = 'oid4vp';
     }
 
     const nextValue: any = {
@@ -738,6 +746,15 @@ export class IssuanceConfigCreateComponent implements OnInit {
     }
 
     this.authorizationServers.setControl(index, this.createAuthorizationServerGroup(nextValue));
+  }
+
+  hasBuiltInAuthorizationServer(excludeIndex?: number): boolean {
+    return this.authorizationServers.controls.some((control, index) => {
+      if (excludeIndex !== undefined && index === excludeIndex) {
+        return false;
+      }
+      return control.get('type')?.value === 'built-in';
+    });
   }
 
   removeAuthorizationServer(index: number): void {

--- a/apps/client/src/app/issuance/issuance-config/issuance-config-create/issuance-config-create.component.ts
+++ b/apps/client/src/app/issuance/issuance-config/issuance-config-create/issuance-config-create.component.ts
@@ -199,7 +199,9 @@ export class IssuanceConfigCreateComponent implements OnInit {
                   presentationConfigId:
                     server.presentationConfigId ?? server.oid4vp?.presentationConfigId ?? '',
                   immediateWalletRedirect:
-                    server.immediateWalletRedirect ?? server.oid4vp?.immediateWalletRedirect ?? true,
+                    server.immediateWalletRedirect ??
+                    server.oid4vp?.immediateWalletRedirect ??
+                    true,
                 },
                 chained: {
                   issuer: server.upstream?.issuer ?? '',
@@ -710,7 +712,7 @@ export class IssuanceConfigCreateComponent implements OnInit {
 
   /**
    * Build the list of available authorization server options for the preferred AS dropdown.
-  * Includes external auth servers, managed auth servers, and the built-in AS.
+   * Includes external auth servers, managed auth servers, and the built-in AS.
    */
   get availableAuthServerOptions(): { value: string; label: string }[] {
     const options: { value: string; label: string }[] = [];

--- a/apps/client/src/app/issuance/issuance-config/issuance-config-create/issuance-config-create.component.ts
+++ b/apps/client/src/app/issuance/issuance-config/issuance-config-create/issuance-config-create.component.ts
@@ -1,4 +1,4 @@
-import { Component, type OnInit, type OnDestroy, ChangeDetectionStrategy } from '@angular/core';
+import { Component, type OnInit, ChangeDetectionStrategy } from '@angular/core';
 import {
   FormArray,
   FormControl,
@@ -7,7 +7,6 @@ import {
   Validators,
   FormBuilder,
 } from '@angular/forms';
-import { Subscription } from 'rxjs';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatChipsModule } from '@angular/material/chips';
@@ -61,12 +60,11 @@ import { PresentationManagementService } from '../../../presentation/presentatio
   changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './issuance-config-create.component.scss',
 })
-export class IssuanceConfigCreateComponent implements OnInit, OnDestroy {
+export class IssuanceConfigCreateComponent implements OnInit {
   public form: FormGroup;
   public loading = false;
   public availablePresentationConfigIds: string[] = [];
   public availableSchemaMetadata: SchemaMetadataResponseDto[] = [];
-  private chainedAsEnabledSub?: Subscription;
   private readonly federationModes = ['federation-only', 'hybrid'] as const;
   private readonly managedAuthorizationServerPrefix = 'authorization-server:';
 
@@ -91,32 +89,15 @@ export class IssuanceConfigCreateComponent implements OnInit, OnDestroy {
   ) {
     this.form = new FormGroup({
       display: this.fb.array([]),
-      authServers: this.fb.array([]),
       authorizationServers: this.fb.array([]),
       preferredAuthServer: new FormControl(''),
       batchSize: new FormControl(1, [Validators.min(1)]),
       dPopRequired: new FormControl(false),
-      refreshTokenEnabled: new FormControl(true),
-      refreshTokenExpiresInSeconds: new FormControl(2592000, [Validators.min(1)]),
       txCodeMaxAttempts: new FormControl<number | null>(null, [Validators.min(1)]),
       credentialResponseEncryption: new FormControl(false),
       credentialRequestEncryption: new FormControl(false),
       walletAttestationRequired: new FormControl(false),
       walletProviderTrustLists: this.fb.array([]),
-      chainedAs: this.fb.group({
-        enabled: [false],
-        upstream: this.fb.group({
-          issuer: [''],
-          clientId: [''],
-          clientSecret: [''],
-          scopes: [['openid', 'profile', 'email']],
-        }),
-        token: this.fb.group({
-          lifetimeSeconds: [3600],
-          signingKeyId: [''],
-        }),
-        requireDPoP: [false],
-      }),
       federation: this.fb.group({
         enabled: [false],
         role: ['leaf'],
@@ -138,49 +119,12 @@ export class IssuanceConfigCreateComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    this.setupChainedAsValidation();
-
     // Defer network/config hydration so tab navigation is interactive immediately.
     setTimeout(() => {
       this.loadPresentationConfigs();
       this.loadSchemaMetadata();
       void this.loadConfigForEdit();
     }, 0);
-  }
-
-  ngOnDestroy(): void {
-    this.chainedAsEnabledSub?.unsubscribe();
-  }
-
-  /**
-   * Dynamically add/remove required validators on chained AS upstream fields
-   * based on the enabled toggle.
-   */
-  private setupChainedAsValidation(): void {
-    const enabledControl = this.chainedAs.get('enabled');
-    const upstreamGroup = this.chainedAs.get('upstream') as FormGroup;
-    const issuerControl = upstreamGroup.get('issuer')!;
-    const clientIdControl = upstreamGroup.get('clientId')!;
-
-    const updateValidators = (enabled: boolean) => {
-      if (enabled) {
-        issuerControl.setValidators([Validators.required]);
-        clientIdControl.setValidators([Validators.required]);
-      } else {
-        issuerControl.clearValidators();
-        clientIdControl.clearValidators();
-      }
-      issuerControl.updateValueAndValidity();
-      clientIdControl.updateValueAndValidity();
-    };
-
-    // Set initial state
-    updateValidators(enabledControl?.value ?? false);
-
-    // React to toggle changes
-    this.chainedAsEnabledSub = enabledControl?.valueChanges.subscribe((enabled: boolean) => {
-      updateValidators(enabled);
-    });
   }
 
   private async loadConfigForEdit(): Promise<void> {
@@ -225,51 +169,54 @@ export class IssuanceConfigCreateComponent implements OnInit, OnDestroy {
 
       await this.yieldToUi();
 
-      // Load auth servers
-      const authServersArray = this.form.get('authServers') as FormArray;
-      authServersArray.clear();
-      let externalServers: string[] = [];
-      if (Array.isArray((config as any).authorizationServers)) {
-        externalServers = (config as any).authorizationServers
-          .filter(
-            (server: any) => server?.type === 'external' && typeof server?.issuer === 'string'
-          )
-          .map((server: any) => server.issuer);
-      }
-      for (const server of externalServers) {
-        authServersArray.push(new FormControl(server, [Validators.required]));
-      }
-
-      await this.yieldToUi();
-
-      const managedAuthorizationServersArray = this.form.get('authorizationServers') as FormArray;
-      managedAuthorizationServersArray.clear();
+      const authorizationServersArray = this.form.get('authorizationServers') as FormArray;
+      authorizationServersArray.clear();
       if (
         (config as any).authorizationServers &&
         Array.isArray((config as any).authorizationServers)
       ) {
-        const hostedServers = (config as any).authorizationServers.filter(
-          (entry: any) => entry?.type === 'oid4vp'
-        );
-        for (const [index, server] of hostedServers.entries()) {
-          managedAuthorizationServersArray.push(
-            this.createManagedAuthorizationServerGroup({
-              id: server.id ?? '',
-              label: server.label ?? '',
-              type: server.type ?? 'oid4vp',
-              requireDPoP: server.requireDPoP ?? false,
-              oid4vp: {
-                presentationConfigId:
-                  server.presentationConfigId ?? server.oid4vp?.presentationConfigId ?? '',
-                immediateWalletRedirect:
-                  server.immediateWalletRedirect ?? server.oid4vp?.immediateWalletRedirect ?? true,
-              },
-              token: {
-                lifetimeSeconds: server.token?.lifetimeSeconds ?? 3600,
-                signingKeyId: server.token?.signingKeyId ?? '',
-              },
-            })
-          );
+        const allServers = (config as any).authorizationServers;
+        for (const [index, server] of allServers.entries()) {
+          if (server?.type === 'external') {
+            authorizationServersArray.push(
+              this.createAuthorizationServerGroup({
+                type: 'external',
+                issuer: server.issuer ?? '',
+                label: server.label ?? server.issuer ?? '',
+              })
+            );
+          } else if (server?.type === 'oid4vp' || server?.type === 'chained') {
+            authorizationServersArray.push(
+              this.createAuthorizationServerGroup({
+                id: server.id ?? `${server.type || 'auth'}-${index + 1}`,
+                label:
+                  server.label ??
+                  `${server.type === 'chained' ? 'Chained' : 'Hosted'} AS ${index + 1}`,
+                type: server.type ?? 'oid4vp',
+                enabled: server.enabled ?? true,
+                requireDPoP: server.requireDPoP ?? false,
+                oid4vp: {
+                  presentationConfigId:
+                    server.presentationConfigId ?? server.oid4vp?.presentationConfigId ?? '',
+                  immediateWalletRedirect:
+                    server.immediateWalletRedirect ?? server.oid4vp?.immediateWalletRedirect ?? true,
+                },
+                chained: {
+                  issuer: server.upstream?.issuer ?? '',
+                  clientId: server.upstream?.clientId ?? '',
+                  clientSecret: server.upstream?.clientSecret ?? '',
+                  scopes: server.upstream?.scopes ?? ['openid', 'profile', 'email'],
+                },
+                token: {
+                  lifetimeSeconds: server.token?.lifetimeSeconds ?? 3600,
+                  signingKeyId: server.token?.signingKeyId ?? '',
+                  refreshTokenEnabled: server.token?.refreshTokenEnabled ?? true,
+                  refreshTokenExpiresInSeconds:
+                    server.token?.refreshTokenExpiresInSeconds ?? 2592000,
+                },
+              })
+            );
+          }
 
           if (index > 0 && index % 5 === 0) {
             await this.yieldToUi();
@@ -278,12 +225,6 @@ export class IssuanceConfigCreateComponent implements OnInit, OnDestroy {
       }
 
       await this.yieldToUi();
-
-      const unifiedChainedServer = Array.isArray((config as any).authorizationServers)
-        ? (config as any).authorizationServers.find(
-            (entry: any) => entry?.type === 'chained' && entry?.enabled !== false
-          )
-        : undefined;
 
       // Load wallet provider trust lists
       const walletTrustListsArray = this.form.get('walletProviderTrustLists') as FormArray;
@@ -301,8 +242,6 @@ export class IssuanceConfigCreateComponent implements OnInit, OnDestroy {
       this.form.patchValue({
         batchSize: config.batchSize,
         dPopRequired: config.dPopRequired,
-        refreshTokenEnabled: config.refreshTokenEnabled ?? true,
-        refreshTokenExpiresInSeconds: config.refreshTokenExpiresInSeconds ?? 2592000,
         credentialResponseEncryption:
           (config as { credentialResponseEncryption?: boolean }).credentialResponseEncryption ??
           false,
@@ -321,26 +260,6 @@ export class IssuanceConfigCreateComponent implements OnInit, OnDestroy {
           supportUri: registrationCertificate?.supportUri ?? '',
         },
       });
-
-      // Load Chained AS config if present
-      if (unifiedChainedServer) {
-        this.form.patchValue({
-          chainedAs: {
-            enabled: true,
-            upstream: {
-              issuer: unifiedChainedServer.upstream?.issuer ?? '',
-              clientId: unifiedChainedServer.upstream?.clientId ?? '',
-              clientSecret: unifiedChainedServer.upstream?.clientSecret ?? '',
-              scopes: unifiedChainedServer.upstream?.scopes ?? ['openid', 'profile', 'email'],
-            },
-            token: {
-              lifetimeSeconds: unifiedChainedServer.token?.lifetimeSeconds ?? 3600,
-              signingKeyId: unifiedChainedServer.token?.signingKeyId ?? '',
-            },
-            requireDPoP: unifiedChainedServer.requireDPoP ?? false,
-          },
-        });
-      }
 
       // Load Federation config if present
       if (config && (config as any)['federation']) {
@@ -413,56 +332,61 @@ export class IssuanceConfigCreateComponent implements OnInit, OnDestroy {
   }
 
   private buildUnifiedAuthorizationServers(formValue: any): any[] {
-    let chainedAuthorizationServer: Record<string, unknown> | undefined;
-    if (formValue.chainedAs?.enabled) {
-      chainedAuthorizationServer = {
-        type: 'chained',
-        label: 'Chained Authorization Server',
-        enabled: true,
-        upstream: {
-          issuer: formValue.chainedAs.upstream.issuer,
-          clientId: formValue.chainedAs.upstream.clientId,
-          clientSecret: formValue.chainedAs.upstream.clientSecret,
-          scopes: formValue.chainedAs.upstream.scopes,
-        },
-        token: {
-          lifetimeSeconds: formValue.chainedAs.token.lifetimeSeconds || 3600,
-          signingKeyId: formValue.chainedAs.token.signingKeyId || undefined,
-        },
-        requireDPoP: formValue.chainedAs.requireDPoP,
-      };
-    }
+    const authorizationServers = formValue.authorizationServers?.length
+      ? formValue.authorizationServers
+          .filter((server: any) => {
+            if (server?.type === 'external') {
+              return typeof server?.issuer === 'string' && server.issuer.trim().length > 0;
+            }
+            return typeof server?.id === 'string' && server.id.trim().length > 0;
+          })
+          .map((server: any) => {
+            if (server.type === 'external') {
+              const issuer = server.issuer.trim();
+              return {
+                type: 'external',
+                issuer,
+                label: server.label?.trim() || issuer,
+              };
+            }
 
-    const managedAuthorizationServers = formValue.authorizationServers?.length
-      ? formValue.authorizationServers.map((server: any) => ({
-          id: server.id,
-          label: server.label,
-          type: 'oid4vp',
-          requireDPoP: server.requireDPoP ?? false,
-          presentationConfigId: server.oid4vp.presentationConfigId,
-          immediateWalletRedirect: server.oid4vp.immediateWalletRedirect ?? true,
-          token: {
-            lifetimeSeconds: server.token?.lifetimeSeconds || 3600,
-            signingKeyId: server.token?.signingKeyId || undefined,
-          },
-        }))
+            const base = {
+              id: server.id,
+              label: server.label,
+              type: server.type,
+              enabled: server.enabled ?? true,
+              requireDPoP: server.requireDPoP ?? false,
+              token: {
+                lifetimeSeconds: server.token?.lifetimeSeconds || 3600,
+                signingKeyId: server.token?.signingKeyId || undefined,
+                refreshTokenEnabled: server.token?.refreshTokenEnabled ?? true,
+                refreshTokenExpiresInSeconds: server.token?.refreshTokenEnabled
+                  ? server.token?.refreshTokenExpiresInSeconds || 2592000
+                  : undefined,
+              },
+            } as Record<string, unknown>;
+
+            if (server.type === 'chained') {
+              return {
+                ...base,
+                upstream: {
+                  issuer: server.chained?.issuer,
+                  clientId: server.chained?.clientId,
+                  clientSecret: server.chained?.clientSecret,
+                  scopes: server.chained?.scopes,
+                },
+              };
+            }
+
+            return {
+              ...base,
+              presentationConfigId: server.oid4vp?.presentationConfigId,
+              immediateWalletRedirect: server.oid4vp?.immediateWalletRedirect ?? true,
+            };
+          })
       : [];
 
-    const externalAuthorizationServers = formValue.authServers?.length
-      ? formValue.authServers
-          .filter((server: string) => typeof server === 'string' && server.trim().length > 0)
-          .map((server: string) => ({
-            type: 'external',
-            issuer: server.trim(),
-            label: server.trim(),
-          }))
-      : [];
-
-    return [
-      ...externalAuthorizationServers,
-      ...managedAuthorizationServers,
-      ...(chainedAuthorizationServer ? [chainedAuthorizationServer] : []),
-    ];
+    return authorizationServers;
   }
 
   private buildRegistrationCertificatePayload(
@@ -592,10 +516,6 @@ export class IssuanceConfigCreateComponent implements OnInit, OnDestroy {
       batchSize: formValue.batchSize,
       display: formValue.display,
       dPopRequired: formValue.dPopRequired,
-      refreshTokenEnabled: formValue.refreshTokenEnabled,
-      refreshTokenExpiresInSeconds: formValue.refreshTokenEnabled
-        ? formValue.refreshTokenExpiresInSeconds || 2592000
-        : undefined,
       credentialResponseEncryption: formValue.credentialResponseEncryption ?? false,
       credentialRequestEncryption: formValue.credentialRequestEncryption ?? false,
       txCodeMaxAttempts: formValue.txCodeMaxAttempts ?? undefined,
@@ -681,41 +601,66 @@ export class IssuanceConfigCreateComponent implements OnInit, OnDestroy {
     this.displays.removeAt(index);
   }
 
-  get authServers(): FormArray {
-    return this.form.get('authServers') as FormArray;
-  }
-
   get authorizationServers(): FormArray {
     return this.form.get('authorizationServers') as FormArray;
   }
 
-  private createManagedAuthorizationServerGroup(value?: any): FormGroup {
+  private createAuthorizationServerGroup(value?: any): FormGroup {
+    if (value?.type === 'external') {
+      return this.fb.group({
+        type: ['external', Validators.required],
+        issuer: [value?.issuer ?? '', Validators.required],
+        label: [value?.label ?? ''],
+      });
+    }
+
     return this.fb.group({
       id: [value?.id ?? '', Validators.required],
       label: [value?.label ?? '', Validators.required],
       type: [value?.type ?? 'oid4vp', Validators.required],
+      enabled: [value?.enabled ?? true],
       requireDPoP: [value?.requireDPoP ?? false],
       oid4vp: this.fb.group({
-        presentationConfigId: [value?.oid4vp?.presentationConfigId ?? '', Validators.required],
+        presentationConfigId: [value?.oid4vp?.presentationConfigId ?? ''],
         immediateWalletRedirect: [value?.oid4vp?.immediateWalletRedirect ?? true],
+      }),
+      chained: this.fb.group({
+        issuer: [value?.chained?.issuer ?? ''],
+        clientId: [value?.chained?.clientId ?? ''],
+        clientSecret: [value?.chained?.clientSecret ?? ''],
+        scopes: [value?.chained?.scopes ?? ['openid', 'profile', 'email']],
       }),
       token: this.fb.group({
         lifetimeSeconds: [value?.token?.lifetimeSeconds ?? 3600, Validators.min(60)],
         signingKeyId: [value?.token?.signingKeyId ?? ''],
+        refreshTokenEnabled: [value?.token?.refreshTokenEnabled ?? true],
+        refreshTokenExpiresInSeconds: [
+          value?.token?.refreshTokenExpiresInSeconds ?? 2592000,
+          Validators.min(1),
+        ],
       }),
     });
   }
 
-  addAuthServer(): void {
-    this.authServers.push(new FormControl('', [Validators.required]));
+  addExternalAuthorizationServer(): void {
+    this.authorizationServers.push(
+      this.createAuthorizationServerGroup({
+        type: 'external',
+      })
+    );
   }
 
   addAuthorizationServer(): void {
-    this.authorizationServers.push(this.createManagedAuthorizationServerGroup());
+    this.authorizationServers.push(this.createAuthorizationServerGroup());
   }
 
-  removeAuthServer(index: number): void {
-    this.authServers.removeAt(index);
+  addChainedAuthorizationServer(): void {
+    this.authorizationServers.push(
+      this.createAuthorizationServerGroup({
+        type: 'chained',
+        label: 'Chained Authorization Server',
+      })
+    );
   }
 
   removeAuthorizationServer(index: number): void {
@@ -724,18 +669,6 @@ export class IssuanceConfigCreateComponent implements OnInit, OnDestroy {
 
   get walletProviderTrustLists(): FormArray {
     return this.form.get('walletProviderTrustLists') as FormArray;
-  }
-
-  get chainedAs(): FormGroup {
-    return this.form.get('chainedAs') as FormGroup;
-  }
-
-  get chainedAsEnabled(): boolean {
-    return this.chainedAs.get('enabled')?.value ?? false;
-  }
-
-  get refreshTokenEnabled(): boolean {
-    return this.form.get('refreshTokenEnabled')?.value ?? true;
   }
 
   get federation(): FormGroup {
@@ -777,27 +710,26 @@ export class IssuanceConfigCreateComponent implements OnInit, OnDestroy {
 
   /**
    * Build the list of available authorization server options for the preferred AS dropdown.
-   * Includes external auth servers, chained AS (if enabled), and the built-in AS.
+  * Includes external auth servers, managed auth servers, and the built-in AS.
    */
   get availableAuthServerOptions(): { value: string; label: string }[] {
     const options: { value: string; label: string }[] = [];
-    const servers = this.authServers.value as string[];
-    for (const url of servers) {
-      if (url) {
-        options.push({ value: url, label: url });
+    const servers = this.authorizationServers.value as any[];
+    for (const server of servers) {
+      if (server?.type === 'external' && typeof server?.issuer === 'string') {
+        const issuer = server.issuer.trim();
+        if (issuer) {
+          options.push({ value: issuer, label: server.label || issuer });
+        }
       }
     }
-    const managedServers = this.authorizationServers.value as any[];
-    for (const server of managedServers) {
-      if (server?.id) {
+    for (const server of servers) {
+      if (server?.type !== 'external' && server?.id && server?.enabled !== false) {
         options.push({
           value: `${this.managedAuthorizationServerPrefix}${server.id}`,
           label: server.label || server.id,
         });
       }
-    }
-    if (this.chainedAsEnabled) {
-      options.push({ value: 'chained-as', label: 'Chained Authorization Server' });
     }
     options.push({ value: 'built-in', label: 'Built-in Authorization Server' });
     return options;

--- a/apps/client/src/app/issuance/issuance-config/issuance-config-create/issuance-config-create.component.ts
+++ b/apps/client/src/app/issuance/issuance-config/issuance-config-create/issuance-config-create.component.ts
@@ -216,6 +216,22 @@ export class IssuanceConfigCreateComponent implements OnInit {
                 },
               })
             );
+          } else if (server?.type === 'built-in') {
+            authorizationServersArray.push(
+              this.createAuthorizationServerGroup({
+                type: 'built-in',
+                label: server.label ?? 'Built-in Authorization Server',
+                enabled: server.enabled ?? true,
+                requireDPoP: server.requireDPoP ?? false,
+                token: {
+                  lifetimeSeconds: server.token?.lifetimeSeconds ?? 3600,
+                  signingKeyId: server.token?.signingKeyId ?? '',
+                  refreshTokenEnabled: server.token?.refreshTokenEnabled ?? true,
+                  refreshTokenExpiresInSeconds:
+                    server.token?.refreshTokenExpiresInSeconds ?? 2592000,
+                },
+              })
+            );
           }
 
           if (index > 0 && index % 5 === 0) {
@@ -337,6 +353,9 @@ export class IssuanceConfigCreateComponent implements OnInit {
             if (server?.type === 'external') {
               return typeof server?.issuer === 'string' && server.issuer.trim().length > 0;
             }
+            if (server?.type === 'built-in') {
+              return true;
+            }
             return typeof server?.id === 'string' && server.id.trim().length > 0;
           })
           .map((server: any) => {
@@ -346,6 +365,23 @@ export class IssuanceConfigCreateComponent implements OnInit {
                 type: 'external',
                 issuer,
                 label: server.label?.trim() || issuer,
+              };
+            }
+
+            if (server.type === 'built-in') {
+              return {
+                type: 'built-in',
+                label: server.label?.trim() || 'Built-in Authorization Server',
+                enabled: server.enabled ?? true,
+                requireDPoP: server.requireDPoP ?? false,
+                token: {
+                  lifetimeSeconds: server.token?.lifetimeSeconds || 3600,
+                  signingKeyId: server.token?.signingKeyId || undefined,
+                  refreshTokenEnabled: server.token?.refreshTokenEnabled ?? true,
+                  refreshTokenExpiresInSeconds: server.token?.refreshTokenEnabled
+                    ? server.token?.refreshTokenExpiresInSeconds || 2592000
+                    : undefined,
+                },
               };
             }
 
@@ -612,6 +648,24 @@ export class IssuanceConfigCreateComponent implements OnInit {
       });
     }
 
+    if (value?.type === 'built-in') {
+      return this.fb.group({
+        type: ['built-in', Validators.required],
+        label: [value?.label ?? 'Built-in Authorization Server', Validators.required],
+        enabled: [value?.enabled ?? true],
+        requireDPoP: [value?.requireDPoP ?? false],
+        token: this.fb.group({
+          lifetimeSeconds: [value?.token?.lifetimeSeconds ?? 3600, Validators.min(60)],
+          signingKeyId: [value?.token?.signingKeyId ?? ''],
+          refreshTokenEnabled: [value?.token?.refreshTokenEnabled ?? true],
+          refreshTokenExpiresInSeconds: [
+            value?.token?.refreshTokenExpiresInSeconds ?? 2592000,
+            Validators.min(1),
+          ],
+        }),
+      });
+    }
+
     return this.fb.group({
       id: [value?.id ?? '', Validators.required],
       label: [value?.label ?? '', Validators.required],
@@ -657,6 +711,15 @@ export class IssuanceConfigCreateComponent implements OnInit {
       this.createAuthorizationServerGroup({
         type: 'chained',
         label: 'Chained Authorization Server',
+      })
+    );
+  }
+
+  addBuiltInAuthorizationServer(): void {
+    this.authorizationServers.push(
+      this.createAuthorizationServerGroup({
+        type: 'built-in',
+        label: 'Built-in Authorization Server',
       })
     );
   }

--- a/apps/client/src/app/issuance/issuance-config/issuance-config-create/issuance-config-create.component.ts
+++ b/apps/client/src/app/issuance/issuance-config/issuance-config-create/issuance-config-create.component.ts
@@ -66,7 +66,6 @@ export class IssuanceConfigCreateComponent implements OnInit {
   public availablePresentationConfigIds: string[] = [];
   public availableSchemaMetadata: SchemaMetadataResponseDto[] = [];
   private readonly federationModes = ['federation-only', 'hybrid'] as const;
-  private readonly managedAuthorizationServerPrefix = 'authorization-server:';
 
   private asRecord(value: unknown): Record<string, unknown> {
     return value && typeof value === 'object' ? (value as Record<string, unknown>) : {};
@@ -90,7 +89,6 @@ export class IssuanceConfigCreateComponent implements OnInit {
     this.form = new FormGroup({
       display: this.fb.array([]),
       authorizationServers: this.fb.array([]),
-      preferredAuthServer: new FormControl(''),
       batchSize: new FormControl(1, [Validators.min(1)]),
       dPopRequired: new FormControl(false),
       txCodeMaxAttempts: new FormControl<number | null>(null, [Validators.min(1)]),
@@ -251,7 +249,6 @@ export class IssuanceConfigCreateComponent implements OnInit {
           (config as { credentialRequestEncryption?: boolean }).credentialRequestEncryption ??
           false,
         walletAttestationRequired: config.walletAttestationRequired ?? false,
-        preferredAuthServer: config.preferredAuthServer ?? '',
         txCodeMaxAttempts: config.txCodeMaxAttempts ?? null,
         registrationCertificate: {
           enabled: registrationCertificate?.enabled ?? false,
@@ -523,7 +520,6 @@ export class IssuanceConfigCreateComponent implements OnInit {
       txCodeMaxAttempts: formValue.txCodeMaxAttempts ?? undefined,
       authorizationServers:
         unifiedAuthorizationServers.length > 0 ? unifiedAuthorizationServers : undefined,
-      preferredAuthServer: formValue.preferredAuthServer || undefined,
       walletAttestationRequired: formValue.walletAttestationRequired,
       walletProviderTrustLists:
         formValue.walletProviderTrustLists?.length > 0
@@ -669,6 +665,18 @@ export class IssuanceConfigCreateComponent implements OnInit {
     this.authorizationServers.removeAt(index);
   }
 
+  moveAuthorizationServer(index: number, direction: 'up' | 'down'): void {
+    const targetIndex = direction === 'up' ? index - 1 : index + 1;
+    if (targetIndex < 0 || targetIndex >= this.authorizationServers.length) {
+      return;
+    }
+
+    const current = this.authorizationServers.at(index);
+    const target = this.authorizationServers.at(targetIndex);
+    this.authorizationServers.setControl(index, target);
+    this.authorizationServers.setControl(targetIndex, current);
+  }
+
   get walletProviderTrustLists(): FormArray {
     return this.form.get('walletProviderTrustLists') as FormArray;
   }
@@ -708,33 +716,6 @@ export class IssuanceConfigCreateComponent implements OnInit {
 
   removeTrustAnchor(index: number): void {
     this.trustAnchors.removeAt(index);
-  }
-
-  /**
-   * Build the list of available authorization server options for the preferred AS dropdown.
-   * Includes external auth servers, managed auth servers, and the built-in AS.
-   */
-  get availableAuthServerOptions(): { value: string; label: string }[] {
-    const options: { value: string; label: string }[] = [];
-    const servers = this.authorizationServers.value as any[];
-    for (const server of servers) {
-      if (server?.type === 'external' && typeof server?.issuer === 'string') {
-        const issuer = server.issuer.trim();
-        if (issuer) {
-          options.push({ value: issuer, label: server.label || issuer });
-        }
-      }
-    }
-    for (const server of servers) {
-      if (server?.type !== 'external' && server?.id && server?.enabled !== false) {
-        options.push({
-          value: `${this.managedAuthorizationServerPrefix}${server.id}`,
-          label: server.label || server.id,
-        });
-      }
-    }
-    options.push({ value: 'built-in', label: 'Built-in Authorization Server' });
-    return options;
   }
 
   addWalletProviderTrustList(): void {

--- a/apps/client/src/app/issuance/issuance-config/issuance-config-create/issuance-config-create.component.ts
+++ b/apps/client/src/app/issuance/issuance-config/issuance-config-create/issuance-config-create.component.ts
@@ -695,11 +695,7 @@ export class IssuanceConfigCreateComponent implements OnInit {
   }
 
   addExternalAuthorizationServer(): void {
-    this.authorizationServers.push(
-      this.createAuthorizationServerGroup({
-        type: 'external',
-      })
-    );
+    this.addAuthorizationServer();
   }
 
   addAuthorizationServer(): void {
@@ -707,21 +703,41 @@ export class IssuanceConfigCreateComponent implements OnInit {
   }
 
   addChainedAuthorizationServer(): void {
-    this.authorizationServers.push(
-      this.createAuthorizationServerGroup({
-        type: 'chained',
-        label: 'Chained Authorization Server',
-      })
-    );
+    this.addAuthorizationServer();
   }
 
   addBuiltInAuthorizationServer(): void {
-    this.authorizationServers.push(
-      this.createAuthorizationServerGroup({
-        type: 'built-in',
-        label: 'Built-in Authorization Server',
-      })
-    );
+    this.addAuthorizationServer();
+  }
+
+  onAuthorizationServerTypeChange(
+    index: number,
+    type: 'external' | 'oid4vp' | 'chained' | 'built-in'
+  ): void {
+    const current = this.authorizationServers.at(index)?.value;
+    if (!current || current.type === type) {
+      return;
+    }
+
+    const nextValue: any = {
+      ...current,
+      type,
+    };
+
+    if (type === 'external') {
+      nextValue.issuer = current.issuer ?? '';
+      nextValue.label = current.label ?? '';
+    }
+
+    if (type === 'chained' && !nextValue.label) {
+      nextValue.label = 'Chained Authorization Server';
+    }
+
+    if (type === 'built-in' && !nextValue.label) {
+      nextValue.label = 'Built-in Authorization Server';
+    }
+
+    this.authorizationServers.setControl(index, this.createAuthorizationServerGroup(nextValue));
   }
 
   removeAuthorizationServer(index: number): void {

--- a/apps/client/src/app/issuance/issuance-config/issuance-config-show/issuance-config-show.component.html
+++ b/apps/client/src/app/issuance/issuance-config/issuance-config-show/issuance-config-show.component.html
@@ -122,7 +122,7 @@
                     </ng-container>
 
                     <ng-container matColumnDef="preferred">
-                      <th mat-header-cell *matHeaderCellDef>Preferred</th>
+                      <th mat-header-cell *matHeaderCellDef>Default</th>
                       <td mat-cell *matCellDef="let row">{{ row.preferred ? 'yes' : 'no' }}</td>
                     </ng-container>
 

--- a/apps/client/src/app/issuance/issuance-config/issuance-config-show/issuance-config-show.component.html
+++ b/apps/client/src/app/issuance/issuance-config/issuance-config-show/issuance-config-show.component.html
@@ -98,7 +98,10 @@
             </mat-card-header>
             <mat-card-content>
               @if (authorizationServerRows.length === 0) {
-                <p class="warning-text">No authorization servers configured.</p>
+                <p class="warning-text">
+                  No authorization servers configured. Add at least one external, oid4vp, chained,
+                  or built-in authorization server before using this issuer.
+                </p>
               } @else {
                 <div class="table-container">
                   <table

--- a/apps/client/src/app/issuance/issuance-config/issuance-config-show/issuance-config-show.component.html
+++ b/apps/client/src/app/issuance/issuance-config/issuance-config-show/issuance-config-show.component.html
@@ -84,8 +84,8 @@
 
       <mat-tab>
         <ng-template mat-tab-label>
-          <mat-icon class="tab-icon">settings_applications</mat-icon>
-          Business Logic
+          <mat-icon class="tab-icon">manage_accounts</mat-icon>
+          Authorize User
         </ng-template>
 
         <div fxLayout="column" fxLayoutGap="24px" class="tab-content">
@@ -93,151 +93,70 @@
             <mat-card-header>
               <mat-card-title>
                 <mat-icon>sync_alt</mat-icon>
-                Issuance Behavior
+                Authorization Servers
               </mat-card-title>
             </mat-card-header>
             <mat-card-content>
-              <mat-list class="config-list">
-                <mat-list-item>
-                  <mat-icon matListItemIcon>dns</mat-icon>
-                  <span matListItemTitle>External Authorization Servers</span>
-                  <span matListItemLine>
-                    @if (externalAuthorizationServers.length > 0) {
-                      {{ externalAuthorizationServers.length }} configured
-                    } @else {
-                      None configured
-                    }
-                  </span>
-                </mat-list-item>
-                <mat-list-item>
-                  <mat-icon matListItemIcon>hub</mat-icon>
-                  <span matListItemTitle>Hosted Authorization Servers</span>
-                  <span matListItemLine>
-                    @if (hostedAuthorizationServers.length > 0) {
-                      {{ hostedAuthorizationServers.length }} configured
-                    } @else {
-                      None configured
-                    }
-                  </span>
-                </mat-list-item>
-                <mat-list-item>
-                  <mat-icon
-                    matListItemIcon
-                    [class]="chainedAuthorizationServer ? 'icon-chained-as' : 'icon-disabled'"
+              @if (authorizationServerRows.length === 0) {
+                <p class="warning-text">No authorization servers configured.</p>
+              } @else {
+                <div class="table-container">
+                  <table
+                    mat-table
+                    [dataSource]="authorizationServerRows"
+                    class="mat-elevation-z1 auth-server-table"
                   >
-                    {{ chainedAuthorizationServer ? 'account_tree' : 'link_off' }}
-                  </mat-icon>
-                  <span matListItemTitle>Chained Authorization Server</span>
-                  <span matListItemLine>{{
-                    chainedAuthorizationServer ? 'Enabled' : 'Disabled'
-                  }}</span>
-                </mat-list-item>
-              </mat-list>
+                    <ng-container matColumnDef="label">
+                      <th mat-header-cell *matHeaderCellDef>Label</th>
+                      <td mat-cell *matCellDef="let row">{{ row.label }}</td>
+                    </ng-container>
 
-              @if (externalAuthorizationServers.length > 0) {
-                <mat-divider></mat-divider>
-                <div class="locale-chips">
-                  <strong>External Authorization Server Details</strong>
-                </div>
-                <mat-list class="config-list">
-                  @for (server of externalAuthorizationServers; track server; let i = $index) {
-                    <mat-list-item>
-                      <mat-icon matListItemIcon>link</mat-icon>
-                      <span matListItemTitle>Server {{ i + 1 }}</span>
-                      <span matListItemLine>
-                        {{ server }}
-                        @if (config.preferredAuthServer === server) {
-                          (preferred)
-                        }
-                      </span>
-                    </mat-list-item>
-                  }
-                </mat-list>
-              }
+                    <ng-container matColumnDef="id">
+                      <th mat-header-cell *matHeaderCellDef>ID</th>
+                      <td mat-cell *matCellDef="let row">{{ row.id }}</td>
+                    </ng-container>
 
-              @if (hostedAuthorizationServers.length > 0) {
-                <mat-divider></mat-divider>
-                <div class="locale-chips">
-                  <strong>Hosted Authorization Server Details</strong>
-                </div>
-                <mat-list class="config-list">
-                  @for (server of hostedAuthorizationServers; track server.id; let i = $index) {
-                    <mat-list-item>
-                      <mat-icon matListItemIcon>account_tree</mat-icon>
-                      <span matListItemTitle>
-                        {{ server.label || server.id || 'Server ' + (i + 1) }}
-                      </span>
-                      <span matListItemLine>
-                        ID: {{ server.id || 'n/a' }} | Type: {{ server.type || 'oid4vp' }} |
-                        Presentation ID:
-                        {{
-                          server.presentationConfigId ||
-                            server.oid4vp?.presentationConfigId ||
-                            'Not set'
-                        }}
-                        @if (config.preferredAuthServer === 'authorization-server:' + server.id) {
-                          | preferred
-                        }
-                      </span>
-                    </mat-list-item>
-                  }
-                </mat-list>
-              }
+                    <ng-container matColumnDef="type">
+                      <th mat-header-cell *matHeaderCellDef>Type</th>
+                      <td mat-cell *matCellDef="let row">{{ row.type }}</td>
+                    </ng-container>
 
-              @if (chainedAuthorizationServer) {
-                <mat-divider></mat-divider>
-                <div class="locale-chips">
-                  <strong>Chained Authorization Server Details</strong>
+                    <ng-container matColumnDef="preferred">
+                      <th mat-header-cell *matHeaderCellDef>Preferred</th>
+                      <td mat-cell *matCellDef="let row">{{ row.preferred ? 'yes' : 'no' }}</td>
+                    </ng-container>
+
+                    <ng-container matColumnDef="enabled">
+                      <th mat-header-cell *matHeaderCellDef>Enabled</th>
+                      <td mat-cell *matCellDef="let row">{{ row.enabled ? 'yes' : 'no' }}</td>
+                    </ng-container>
+
+                    <ng-container matColumnDef="dpop">
+                      <th mat-header-cell *matHeaderCellDef>DPoP</th>
+                      <td mat-cell *matCellDef="let row">{{ row.dpop }}</td>
+                    </ng-container>
+
+                    <ng-container matColumnDef="token">
+                      <th mat-header-cell *matHeaderCellDef>Token</th>
+                      <td mat-cell *matCellDef="let row">
+                        {{ row.tokenLifetime > 0 ? row.tokenLifetime + 's' : '-' }}
+                      </td>
+                    </ng-container>
+
+                    <ng-container matColumnDef="refresh">
+                      <th mat-header-cell *matHeaderCellDef>Refresh</th>
+                      <td mat-cell *matCellDef="let row">{{ row.refresh }}</td>
+                    </ng-container>
+
+                    <ng-container matColumnDef="details">
+                      <th mat-header-cell *matHeaderCellDef>Details</th>
+                      <td mat-cell *matCellDef="let row">{{ row.details }}</td>
+                    </ng-container>
+
+                    <tr mat-header-row *matHeaderRowDef="authServerDisplayedColumns"></tr>
+                    <tr mat-row *matRowDef="let row; columns: authServerDisplayedColumns"></tr>
+                  </table>
                 </div>
-                <mat-list class="config-list">
-                  <mat-list-item>
-                    <mat-icon matListItemIcon>cloud</mat-icon>
-                    <span matListItemTitle>Upstream Issuer</span>
-                    <span matListItemLine
-                      >{{ chainedAuthorizationServer.upstream?.issuer || 'Not configured' }}
-                      @if (config.preferredAuthServer === 'chained-as') {
-                        | preferred
-                      }
-                    </span>
-                  </mat-list-item>
-                  <mat-list-item>
-                    <mat-icon matListItemIcon>fingerprint</mat-icon>
-                    <span matListItemTitle>Client ID</span>
-                    <span matListItemLine>{{
-                      chainedAuthorizationServer.upstream?.clientId || 'Not configured'
-                    }}</span>
-                  </mat-list-item>
-                  <mat-list-item>
-                    <mat-icon matListItemIcon>schedule</mat-icon>
-                    <span matListItemTitle>Token Lifetime</span>
-                    <span matListItemLine
-                      >{{ chainedAuthorizationServer.token?.lifetimeSeconds || 3600 }} seconds</span
-                    >
-                  </mat-list-item>
-                  <mat-list-item>
-                    <mat-icon
-                      matListItemIcon
-                      [class]="chainedAuthorizationServer.requireDPoP ? '' : 'icon-disabled'"
-                    >
-                      {{
-                        chainedAuthorizationServer.requireDPoP ? 'verified_user' : 'no_encryption'
-                      }}
-                    </mat-icon>
-                    <span matListItemTitle>DPoP Requirement</span>
-                    <span matListItemLine>{{
-                      chainedAuthorizationServer.requireDPoP ? 'Required' : 'Not required'
-                    }}</span>
-                  </mat-list-item>
-                  @if ((chainedAuthorizationServer.upstream?.scopes?.length ?? 0) > 0) {
-                    <mat-list-item>
-                      <mat-icon matListItemIcon>list</mat-icon>
-                      <span matListItemTitle>Requested Scopes</span>
-                      <span matListItemLine>{{
-                        chainedAuthorizationServer.upstream?.scopes?.join(', ') || 'Not configured'
-                      }}</span>
-                    </mat-list-item>
-                  }
-                </mat-list>
               }
             </mat-card-content>
           </mat-card>
@@ -251,40 +170,6 @@
         </ng-template>
 
         <div fxLayout="column" fxLayoutGap="24px" class="tab-content">
-          <mat-card>
-            <mat-card-header>
-              <mat-card-title>
-                <mat-icon>refresh</mat-icon>
-                Refresh Tokens
-              </mat-card-title>
-            </mat-card-header>
-            <mat-card-content>
-              <mat-list class="config-list">
-                <mat-list-item>
-                  <mat-icon
-                    matListItemIcon
-                    [class]="config.refreshTokenEnabled ? '' : 'icon-disabled'"
-                  >
-                    {{ config.refreshTokenEnabled ? 'refresh' : 'sync_disabled' }}
-                  </mat-icon>
-                  <span matListItemTitle>Status</span>
-                  <span matListItemLine>
-                    {{ config.refreshTokenEnabled ? 'Enabled' : 'Disabled' }}
-                  </span>
-                </mat-list-item>
-                @if (config.refreshTokenEnabled) {
-                  <mat-list-item>
-                    <mat-icon matListItemIcon>timelapse</mat-icon>
-                    <span matListItemTitle>Lifetime</span>
-                    <span matListItemLine>
-                      {{ config.refreshTokenExpiresInSeconds || 2592000 }} seconds
-                    </span>
-                  </mat-list-item>
-                }
-              </mat-list>
-            </mat-card-content>
-          </mat-card>
-
           <!-- tx_code Brute-Force Protection Card -->
           <mat-card>
             <mat-card-header>

--- a/apps/client/src/app/issuance/issuance-config/issuance-config-show/issuance-config-show.component.scss
+++ b/apps/client/src/app/issuance/issuance-config/issuance-config-show/issuance-config-show.component.scss
@@ -191,3 +191,12 @@ mat-expansion-panel {
     }
   }
 }
+
+.table-container {
+  overflow-x: auto;
+}
+
+.auth-server-table {
+  width: 100%;
+  min-width: 960px;
+}

--- a/apps/client/src/app/issuance/issuance-config/issuance-config-show/issuance-config-show.component.ts
+++ b/apps/client/src/app/issuance/issuance-config/issuance-config-show/issuance-config-show.component.ts
@@ -147,7 +147,9 @@ export class IssuanceConfigShowComponent implements OnInit {
         if (server?.type === 'external') {
           return typeof server?.issuer === 'string' && server.issuer.length > 0;
         }
-        return server?.type === 'oid4vp' || server?.type === 'chained';
+        return (
+          server?.type === 'oid4vp' || server?.type === 'chained' || server?.type === 'built-in'
+        );
       })
       .map((server) => {
         if (server?.type === 'external') {
@@ -167,6 +169,7 @@ export class IssuanceConfigShowComponent implements OnInit {
         const refreshEnabled = server?.token?.refreshTokenEnabled ?? true;
         const refreshLifetime = server?.token?.refreshTokenExpiresInSeconds || 2592000;
         const isOid4vp = server?.type === 'oid4vp';
+        const isBuiltIn = server?.type === 'built-in';
         return {
           label: server.label || server.id || 'Authorization Server',
           id: server.id || '-',
@@ -176,7 +179,9 @@ export class IssuanceConfigShowComponent implements OnInit {
           dpop: server.requireDPoP ? 'required' : 'optional',
           tokenLifetime: server?.token?.lifetimeSeconds || 3600,
           refresh: refreshEnabled ? `${refreshLifetime}s` : 'disabled',
-          details: isOid4vp
+          details: isBuiltIn
+            ? 'issuer-local authorization server'
+            : isOid4vp
             ? `presentation=${server.presentationConfigId || server.oid4vp?.presentationConfigId || 'n/a'}`
             : `issuer=${server.upstream?.issuer || 'n/a'}, client=${server.upstream?.clientId || 'n/a'}`,
         };

--- a/apps/client/src/app/issuance/issuance-config/issuance-config-show/issuance-config-show.component.ts
+++ b/apps/client/src/app/issuance/issuance-config/issuance-config-show/issuance-config-show.component.ts
@@ -182,8 +182,8 @@ export class IssuanceConfigShowComponent implements OnInit {
           details: isBuiltIn
             ? 'issuer-local authorization server'
             : isOid4vp
-            ? `presentation=${server.presentationConfigId || server.oid4vp?.presentationConfigId || 'n/a'}`
-            : `issuer=${server.upstream?.issuer || 'n/a'}, client=${server.upstream?.clientId || 'n/a'}`,
+              ? `presentation=${server.presentationConfigId || server.oid4vp?.presentationConfigId || 'n/a'}`
+              : `issuer=${server.upstream?.issuer || 'n/a'}, client=${server.upstream?.clientId || 'n/a'}`,
         };
       });
 

--- a/apps/client/src/app/issuance/issuance-config/issuance-config-show/issuance-config-show.component.ts
+++ b/apps/client/src/app/issuance/issuance-config/issuance-config-show/issuance-config-show.component.ts
@@ -142,25 +142,28 @@ export class IssuanceConfigShowComponent implements OnInit {
 
   get authorizationServerRows(): AuthorizationServerRow[] {
     const servers = ((this.config as any)?.authorizationServers ?? []) as any[];
-    const preferred = this.config?.preferredAuthServer;
-
-    const externalRows = servers
-      .filter((server) => server?.type === 'external' && typeof server?.issuer === 'string')
-      .map((server) => ({
-        label: server.label || server.issuer,
-        id: '-',
-        type: 'external',
-        preferred: preferred === server.issuer,
-        enabled: server.enabled !== false,
-        dpop: '-',
-        tokenLifetime: 0,
-        refresh: '-',
-        details: server.issuer,
-      }));
-
-    const managedRows = servers
-      .filter((server) => server?.type === 'oid4vp' || server?.type === 'chained')
+    const rows = servers
+      .filter((server) => {
+        if (server?.type === 'external') {
+          return typeof server?.issuer === 'string' && server.issuer.length > 0;
+        }
+        return server?.type === 'oid4vp' || server?.type === 'chained';
+      })
       .map((server) => {
+        if (server?.type === 'external') {
+          return {
+            label: server.label || server.issuer,
+            id: '-',
+            type: 'external',
+            preferred: false,
+            enabled: server.enabled !== false,
+            dpop: '-',
+            tokenLifetime: 0,
+            refresh: '-',
+            details: server.issuer,
+          };
+        }
+
         const refreshEnabled = server?.token?.refreshTokenEnabled ?? true;
         const refreshLifetime = server?.token?.refreshTokenExpiresInSeconds || 2592000;
         const isOid4vp = server?.type === 'oid4vp';
@@ -168,9 +171,7 @@ export class IssuanceConfigShowComponent implements OnInit {
           label: server.label || server.id || 'Authorization Server',
           id: server.id || '-',
           type: server.type,
-          preferred:
-            preferred === `authorization-server:${server.id}` ||
-            preferred === (server.id ? `authorization-server:${server.id}` : undefined),
+          preferred: false,
           enabled: server.enabled !== false,
           dpop: server.requireDPoP ? 'required' : 'optional',
           tokenLifetime: server?.token?.lifetimeSeconds || 3600,
@@ -181,7 +182,12 @@ export class IssuanceConfigShowComponent implements OnInit {
         };
       });
 
-    return [...externalRows, ...managedRows];
+    const preferredIndex = rows.findIndex((row) => row.enabled);
+    if (preferredIndex >= 0) {
+      rows[preferredIndex].preferred = true;
+    }
+
+    return rows;
   }
 
   copyToClipboard(value: string, label: string): void {

--- a/apps/client/src/app/issuance/issuance-config/issuance-config-show/issuance-config-show.component.ts
+++ b/apps/client/src/app/issuance/issuance-config/issuance-config-show/issuance-config-show.component.ts
@@ -8,6 +8,7 @@ import { MatExpansionModule } from '@angular/material/expansion';
 import { MatIconModule } from '@angular/material/icon';
 import { MatListModule } from '@angular/material/list';
 import { MatTabsModule } from '@angular/material/tabs';
+import { MatTableModule } from '@angular/material/table';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { RouterModule } from '@angular/router';
@@ -25,8 +26,22 @@ interface ChainedAuthorizationServerView {
   };
   token?: {
     lifetimeSeconds?: number;
+    refreshTokenEnabled?: boolean;
+    refreshTokenExpiresInSeconds?: number;
   };
   requireDPoP?: boolean;
+}
+
+interface AuthorizationServerRow {
+  label: string;
+  id: string;
+  type: string;
+  preferred: boolean;
+  enabled: boolean;
+  dpop: string;
+  tokenLifetime: number;
+  refresh: string;
+  details: string;
 }
 
 @Component({
@@ -41,6 +56,7 @@ interface ChainedAuthorizationServerView {
     MatDividerModule,
     MatListModule,
     MatTabsModule,
+    MatTableModule,
     FlexLayoutModule,
     RouterModule,
     ClipboardModule,
@@ -51,6 +67,17 @@ interface ChainedAuthorizationServerView {
 })
 export class IssuanceConfigShowComponent implements OnInit {
   config?: IssuanceConfig;
+  readonly authServerDisplayedColumns = [
+    'label',
+    'id',
+    'type',
+    'preferred',
+    'enabled',
+    'dpop',
+    'token',
+    'refresh',
+    'details',
+  ];
 
   constructor(
     private readonly issuanceConfigService: IssuanceConfigService,
@@ -98,6 +125,8 @@ export class IssuanceConfigShowComponent implements OnInit {
           },
           token: {
             lifetimeSeconds: chained.token?.lifetimeSeconds,
+            refreshTokenEnabled: chained.token?.refreshTokenEnabled,
+            refreshTokenExpiresInSeconds: chained.token?.refreshTokenExpiresInSeconds,
           },
           requireDPoP: chained.requireDPoP,
         };
@@ -109,6 +138,50 @@ export class IssuanceConfigShowComponent implements OnInit {
 
   get registrationCertificateConfig(): any {
     return (this.config as any)?.registrationCertificate;
+  }
+
+  get authorizationServerRows(): AuthorizationServerRow[] {
+    const servers = ((this.config as any)?.authorizationServers ?? []) as any[];
+    const preferred = this.config?.preferredAuthServer;
+
+    const externalRows = servers
+      .filter((server) => server?.type === 'external' && typeof server?.issuer === 'string')
+      .map((server) => ({
+        label: server.label || server.issuer,
+        id: '-',
+        type: 'external',
+        preferred: preferred === server.issuer,
+        enabled: server.enabled !== false,
+        dpop: '-',
+        tokenLifetime: 0,
+        refresh: '-',
+        details: server.issuer,
+      }));
+
+    const managedRows = servers
+      .filter((server) => server?.type === 'oid4vp' || server?.type === 'chained')
+      .map((server) => {
+        const refreshEnabled = server?.token?.refreshTokenEnabled ?? true;
+        const refreshLifetime = server?.token?.refreshTokenExpiresInSeconds || 2592000;
+        const isOid4vp = server?.type === 'oid4vp';
+        return {
+          label: server.label || server.id || 'Authorization Server',
+          id: server.id || '-',
+          type: server.type,
+          preferred:
+            preferred === `authorization-server:${server.id}` ||
+            preferred === (server.id ? `authorization-server:${server.id}` : undefined),
+          enabled: server.enabled !== false,
+          dpop: server.requireDPoP ? 'required' : 'optional',
+          tokenLifetime: server?.token?.lifetimeSeconds || 3600,
+          refresh: refreshEnabled ? `${refreshLifetime}s` : 'disabled',
+          details: isOid4vp
+            ? `presentation=${server.presentationConfigId || server.oid4vp?.presentationConfigId || 'n/a'}`
+            : `issuer=${server.upstream?.issuer || 'n/a'}, client=${server.upstream?.clientId || 'n/a'}`,
+        };
+      });
+
+    return [...externalRows, ...managedRows];
   }
 
   copyToClipboard(value: string, label: string): void {

--- a/apps/client/src/app/issuance/issuance-offer/issuance-offer.component.html
+++ b/apps/client/src/app/issuance/issuance-offer/issuance-offer.component.html
@@ -381,8 +381,8 @@
                 <div class="validation-error">
                   <mat-icon>error</mat-icon>
                   <span>
-                    No Authorization Servers configured. Please configure Chained AS or add an
-                    external AS in the issuance configuration.
+                    No Authorization Servers configured. Add at least one external, oid4vp, chained,
+                    or built-in authorization server in the issuance configuration.
                   </span>
                 </div>
               }

--- a/apps/client/src/app/issuance/issuance-offer/issuance-offer.component.spec.ts
+++ b/apps/client/src/app/issuance/issuance-offer/issuance-offer.component.spec.ts
@@ -101,29 +101,34 @@ describe('IssuanceOfferComponent', () => {
     });
   });
 
-  it('includes internal and external authorization server options for pre-authorized flow', () => {
-    component.availableManagedAuthorizationServers = [
-      { value: 'authorization-server:pid-auth', label: 'PID Auth Server' },
-    ];
-    component.availableAuthServers = ['https://auth.example.com'];
-    component.hasChainedAuthorizationServer = true;
+  it('includes configured authorization server options in order for pre-authorized flow', () => {
+    component.issuanceConfig = {
+      authorizationServers: [
+        { type: 'oid4vp', id: 'pid-auth', label: 'PID Auth Server', enabled: true },
+        { type: 'external', issuer: 'https://auth.example.com', enabled: true },
+        { type: 'chained', enabled: true, upstream: { issuer: 'https://upstream.example.com' } },
+        { type: 'built-in', enabled: true, label: 'Issuer Local AS' },
+      ],
+    } as any;
 
     expect(component.preAuthAuthorizationServerOptions).toEqual([
       { value: 'authorization-server:pid-auth', label: 'PID Auth Server' },
       { value: 'https://auth.example.com', label: 'https://auth.example.com' },
       { value: 'chained-as', label: 'Chained Authorization Server' },
-      { value: 'built-in', label: 'Built-in Authorization Server' },
+      { value: 'built-in', label: 'Issuer Local AS' },
     ]);
   });
 
-  it('defaults pre-authorized flow authorization server to built-in', () => {
-    component.availableManagedAuthorizationServers = [
-      { value: 'authorization-server:pid-auth', label: 'PID Auth Server' },
-    ];
-    component.availableAuthServers = ['https://auth.example.com'];
+  it('defaults pre-authorized flow authorization server to first configured server', () => {
+    component.issuanceConfig = {
+      authorizationServers: [
+        { type: 'external', issuer: 'https://auth.example.com', enabled: true },
+        { type: 'built-in', enabled: true },
+      ],
+    } as any;
 
     const defaultServer = (component as any).getDefaultAuthServerForFlow('pre_authorized_code');
 
-    expect(defaultServer).toBe('built-in');
+    expect(defaultServer).toBe('https://auth.example.com');
   });
 });

--- a/apps/client/src/app/issuance/issuance-offer/issuance-offer.component.ts
+++ b/apps/client/src/app/issuance/issuance-offer/issuance-offer.component.ts
@@ -433,54 +433,59 @@ export class IssuanceOfferComponent implements OnInit {
 
   get preAuthAuthorizationServerOptions(): { value: string; label: string }[] {
     return [
-      ...this.availableManagedAuthorizationServers,
-      ...this.availableAuthServers.map((server) => ({ value: server, label: server })),
-      ...(this.hasChainedAuthorizationServer ? [this.chainedAuthorizationServerOption] : []),
+      ...this.authCodeAuthorizationServerOptions,
       this.builtInAuthorizationServerOption,
     ];
   }
 
   get authCodeAuthorizationServerOptions(): { value: string; label: string }[] {
-    return [
-      ...this.availableManagedAuthorizationServers,
-      ...this.availableAuthServers.map((server) => ({ value: server, label: server })),
-      ...(this.hasChainedAuthorizationServer ? [this.chainedAuthorizationServerOption] : []),
-    ];
+    const servers = ((this.issuanceConfig as any)?.authorizationServers ?? []) as any[];
+
+    return servers
+      .filter((server) => server?.enabled !== false)
+      .map((server) => {
+        if (server?.type === 'external' && typeof server?.issuer === 'string') {
+          return {
+            value: server.issuer,
+            label: server.label || server.issuer,
+          };
+        }
+
+        if (server?.type === 'oid4vp' && server?.id) {
+          return {
+            value: `authorization-server:${server.id}`,
+            label: server.label || server.id,
+          };
+        }
+
+        if (server?.type === 'chained') {
+          return this.chainedAuthorizationServerOption;
+        }
+
+        return undefined;
+      })
+      .filter((option): option is { value: string; label: string } => !!option);
   }
 
   get authCodeAuthorizationServerGroups(): {
     label: string;
     options: { value: string; label: string }[];
   }[] {
-    const groups: { label: string; options: { value: string; label: string }[] }[] = [];
-
-    if (this.availableManagedAuthorizationServers.length > 0) {
-      groups.push({
-        label: 'Hosted Authorization Servers',
-        options: this.availableManagedAuthorizationServers,
-      });
+    const options = this.authCodeAuthorizationServerOptions;
+    if (options.length === 0) {
+      return [];
     }
 
-    if (this.availableAuthServers.length > 0) {
-      groups.push({
-        label: 'External Authorization Servers',
-        options: this.availableAuthServers.map((server) => ({ value: server, label: server })),
-      });
-    }
-
-    if (this.hasChainedAuthorizationServer) {
-      groups.push({
-        label: 'Chained Authorization Server',
-        options: [this.chainedAuthorizationServerOption],
-      });
-    }
-
-    return groups;
+    return [
+      {
+        label: 'Configured Authorization Servers (in priority order)',
+        options,
+      },
+    ];
   }
 
   /**
-   * Returns the preferred auth server URL if it's in the available list,
-   * otherwise falls back to the first available auth server.
+   * Returns the first configured authorization server for auth-code flow.
    */
   private getDefaultAuthServerForFlow(flow: string): string {
     if (flow === 'pre_authorized_code') {
@@ -496,10 +501,6 @@ export class IssuanceOfferComponent implements OnInit {
       return '';
     }
 
-    const preferred = this.issuanceConfig?.preferredAuthServer;
-    if (preferred && options.some((option) => option.value === preferred)) {
-      return preferred;
-    }
     return options[0]?.value || '';
   }
 

--- a/apps/client/src/app/issuance/issuance-offer/issuance-offer.component.ts
+++ b/apps/client/src/app/issuance/issuance-offer/issuance-offer.component.ts
@@ -432,10 +432,7 @@ export class IssuanceOfferComponent implements OnInit {
   }
 
   get preAuthAuthorizationServerOptions(): { value: string; label: string }[] {
-    return [
-      ...this.authCodeAuthorizationServerOptions,
-      this.builtInAuthorizationServerOption,
-    ];
+    return [...this.authCodeAuthorizationServerOptions, this.builtInAuthorizationServerOption];
   }
 
   get authCodeAuthorizationServerOptions(): { value: string; label: string }[] {

--- a/apps/client/src/app/issuance/issuance-offer/issuance-offer.component.ts
+++ b/apps/client/src/app/issuance/issuance-offer/issuance-offer.component.ts
@@ -122,10 +122,6 @@ export class IssuanceOfferComponent implements OnInit {
     value: 'chained-as',
     label: 'Chained Authorization Server',
   };
-  private readonly builtInAuthorizationServerOption = {
-    value: 'built-in',
-    label: 'Built-in Authorization Server',
-  };
   availableAttributeProviders: AttributeProviderEntity[] = [];
 
   // IAE status tracking for selected credential configs
@@ -432,7 +428,7 @@ export class IssuanceOfferComponent implements OnInit {
   }
 
   get preAuthAuthorizationServerOptions(): { value: string; label: string }[] {
-    return [...this.authCodeAuthorizationServerOptions, this.builtInAuthorizationServerOption];
+    return this.authCodeAuthorizationServerOptions;
   }
 
   get authCodeAuthorizationServerOptions(): { value: string; label: string }[] {
@@ -457,6 +453,13 @@ export class IssuanceOfferComponent implements OnInit {
 
         if (server?.type === 'chained') {
           return this.chainedAuthorizationServerOption;
+        }
+
+        if (server?.type === 'built-in') {
+          return {
+            value: 'built-in',
+            label: server.label || 'Built-in Authorization Server',
+          };
         }
 
         return undefined;
@@ -485,12 +488,8 @@ export class IssuanceOfferComponent implements OnInit {
    * Returns the first configured authorization server for auth-code flow.
    */
   private getDefaultAuthServerForFlow(flow: string): string {
-    if (flow === 'pre_authorized_code') {
-      return this.builtInAuthorizationServerOption.value;
-    }
-
     let options: { value: string; label: string }[] = [];
-    if (flow === 'authorization_code_external') {
+    if (flow === 'authorization_code_external' || flow === 'pre_authorized_code') {
       options = this.authCodeAuthorizationServerOptions;
     }
 

--- a/apps/client/src/app/utils/schemas.json
+++ b/apps/client/src/app/utils/schemas.json
@@ -1,7 +1,9 @@
 [
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/GrafanaConfigDto.schema.json",
-    "fileMatch": ["a://b/GrafanaConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/GrafanaConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/GrafanaConfigDto.schema.json",
@@ -24,13 +26,18 @@
           "example": "loki"
         }
       },
-      "required": ["tempoUid", "lokiUid"],
+      "required": [
+        "tempoUid",
+        "lokiUid"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FrontendConfigResponseDto.schema.json",
-    "fileMatch": ["a://b/FrontendConfigResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/FrontendConfigResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FrontendConfigResponseDto.schema.json",
@@ -46,13 +53,17 @@
           ]
         }
       },
-      "required": ["grafana"],
+      "required": [
+        "grafana"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RoleDto.schema.json",
-    "fileMatch": ["a://b/RoleDto*.schema.json"],
+    "fileMatch": [
+      "a://b/RoleDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RoleDto.schema.json",
@@ -75,13 +86,17 @@
           "example": "issuance:manage"
         }
       },
-      "required": ["role"],
+      "required": [
+        "role"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientCredentialsDto.schema.json",
-    "fileMatch": ["a://b/ClientCredentialsDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ClientCredentialsDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientCredentialsDto.schema.json",
@@ -99,13 +114,18 @@
           "type": "string"
         }
       },
-      "required": ["client_id", "client_secret"],
+      "required": [
+        "client_id",
+        "client_secret"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TokenResponse.schema.json",
-    "fileMatch": ["a://b/TokenResponse*.schema.json"],
+    "fileMatch": [
+      "a://b/TokenResponse*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TokenResponse.schema.json",
@@ -128,13 +148,20 @@
           "type": "string"
         }
       },
-      "required": ["access_token", "token_type", "expires_in", "state"],
+      "required": [
+        "access_token",
+        "token_type",
+        "expires_in",
+        "state"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ImportTenantDto.schema.json",
-    "fileMatch": ["a://b/ImportTenantDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ImportTenantDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ImportTenantDto.schema.json",
@@ -150,13 +177,17 @@
           "description": "The description of the tenant."
         }
       },
-      "required": ["name"],
+      "required": [
+        "name"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SessionStorageConfig.schema.json",
-    "fileMatch": ["a://b/SessionStorageConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/SessionStorageConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SessionStorageConfig.schema.json",
@@ -172,7 +203,10 @@
         "cleanupMode": {
           "type": "string",
           "description": "Cleanup mode: 'full' deletes everything, 'anonymize' keeps metadata but removes PII.",
-          "enum": ["full", "anonymize"],
+          "enum": [
+            "full",
+            "anonymize"
+          ],
           "default": "full"
         }
       },
@@ -181,7 +215,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListConfig.schema.json",
-    "fileMatch": ["a://b/StatusListConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/StatusListConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListConfig.schema.json",
@@ -197,7 +233,12 @@
         "bits": {
           "type": "number",
           "description": "Bits per status entry: 1 (valid/revoked), 2 (with suspended), 4/8 (extended). If not set, uses global STATUS_BITS.",
-          "enum": [1, 2, 4, 8],
+          "enum": [
+            1,
+            2,
+            4,
+            8
+          ],
           "default": 1
         },
         "ttl": {
@@ -222,7 +263,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TenantEntity.schema.json",
-    "fileMatch": ["a://b/TenantEntity*.schema.json"],
+    "fileMatch": [
+      "a://b/TenantEntity*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TenantEntity.schema.json",
@@ -273,13 +316,20 @@
           }
         }
       },
-      "required": ["id", "name", "status", "clients"],
+      "required": [
+        "id",
+        "name",
+        "status",
+        "clients"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientEntity.schema.json",
-    "fileMatch": ["a://b/ClientEntity*.schema.json"],
+    "fileMatch": [
+      "a://b/ClientEntity*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientEntity.schema.json",
@@ -289,7 +339,10 @@
         "allowedPresentationConfigs": {
           "nullable": true,
           "description": "List of presentation config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": ["age-verification", "kyc-basic"],
+          "example": [
+            "age-verification",
+            "kyc-basic"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -298,7 +351,10 @@
         "allowedIssuanceConfigs": {
           "nullable": true,
           "description": "List of issuance config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": ["pid", "mdl"],
+          "example": [
+            "pid",
+            "mdl"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -346,13 +402,18 @@
           ]
         }
       },
-      "required": ["clientId", "roles"],
+      "required": [
+        "clientId",
+        "roles"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateTenantDto.schema.json",
-    "fileMatch": ["a://b/CreateTenantDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CreateTenantDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateTenantDto.schema.json",
@@ -406,13 +467,18 @@
           }
         }
       },
-      "required": ["id", "name"],
+      "required": [
+        "id",
+        "name"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateTenantDto.schema.json",
-    "fileMatch": ["a://b/UpdateTenantDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateTenantDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateTenantDto.schema.json",
@@ -467,7 +533,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuditLogResponseDto.schema.json",
-    "fileMatch": ["a://b/AuditLogResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/AuditLogResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuditLogResponseDto.schema.json",
@@ -504,7 +572,11 @@
           "type": "string"
         },
         "actorType": {
-          "enum": ["user", "client", "system"],
+          "enum": [
+            "user",
+            "client",
+            "system"
+          ],
           "type": "string"
         },
         "actorId": {
@@ -535,13 +607,21 @@
           "type": "string"
         }
       },
-      "required": ["id", "tenantId", "actionType", "actorType", "timestamp"],
+      "required": [
+        "id",
+        "tenantId",
+        "actionType",
+        "actorType",
+        "timestamp"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientSecretResponseDto.schema.json",
-    "fileMatch": ["a://b/ClientSecretResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ClientSecretResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientSecretResponseDto.schema.json",
@@ -552,13 +632,17 @@
           "type": "string"
         }
       },
-      "required": ["secret"],
+      "required": [
+        "secret"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateClientDto.schema.json",
-    "fileMatch": ["a://b/UpdateClientDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateClientDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateClientDto.schema.json",
@@ -568,7 +652,10 @@
         "allowedPresentationConfigs": {
           "nullable": true,
           "description": "List of presentation config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": ["age-verification", "kyc-basic"],
+          "example": [
+            "age-verification",
+            "kyc-basic"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -577,7 +664,10 @@
         "allowedIssuanceConfigs": {
           "nullable": true,
           "description": "List of issuance config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": ["pid", "mdl"],
+          "example": [
+            "pid",
+            "mdl"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -605,13 +695,17 @@
           }
         }
       },
-      "required": ["roles"],
+      "required": [
+        "roles"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateClientDto.schema.json",
-    "fileMatch": ["a://b/CreateClientDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CreateClientDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateClientDto.schema.json",
@@ -621,7 +715,10 @@
         "allowedPresentationConfigs": {
           "nullable": true,
           "description": "List of presentation config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": ["age-verification", "kyc-basic"],
+          "example": [
+            "age-verification",
+            "kyc-basic"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -630,7 +727,10 @@
         "allowedIssuanceConfigs": {
           "nullable": true,
           "description": "List of issuance config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": ["pid", "mdl"],
+          "example": [
+            "pid",
+            "mdl"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -666,13 +766,18 @@
           }
         }
       },
-      "required": ["clientId", "roles"],
+      "required": [
+        "clientId",
+        "roles"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListImportDto.schema.json",
-    "fileMatch": ["a://b/StatusListImportDto*.schema.json"],
+    "fileMatch": [
+      "a://b/StatusListImportDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListImportDto.schema.json",
@@ -702,18 +807,27 @@
         },
         "bits": {
           "description": "Bits per status value. If not provided, uses tenant or global defaults.",
-          "enum": [1, 2, 4, 8],
+          "enum": [
+            1,
+            2,
+            4,
+            8
+          ],
           "type": "number",
           "example": 1
         }
       },
-      "required": ["id"],
+      "required": [
+        "id"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListAggregationDto.schema.json",
-    "fileMatch": ["a://b/StatusListAggregationDto*.schema.json"],
+    "fileMatch": [
+      "a://b/StatusListAggregationDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListAggregationDto.schema.json",
@@ -732,13 +846,17 @@
           }
         }
       },
-      "required": ["status_lists"],
+      "required": [
+        "status_lists"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateStatusListConfigDto.schema.json",
-    "fileMatch": ["a://b/UpdateStatusListConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateStatusListConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateStatusListConfigDto.schema.json",
@@ -755,7 +873,12 @@
         "bits": {
           "nullable": true,
           "description": "Bits per status entry. Set to null to reset to global default.",
-          "enum": [1, 2, 4, 8],
+          "enum": [
+            1,
+            2,
+            4,
+            8
+          ],
           "type": "number"
         },
         "ttl": {
@@ -781,7 +904,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListResponseDto.schema.json",
-    "fileMatch": ["a://b/StatusListResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/StatusListResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListResponseDto.schema.json",
@@ -812,7 +937,12 @@
         },
         "bits": {
           "description": "Bits per status value",
-          "enum": [1, 2, 4, 8],
+          "enum": [
+            1,
+            2,
+            4,
+            8
+          ],
           "type": "number",
           "example": 1
         },
@@ -865,7 +995,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateStatusListDto.schema.json",
-    "fileMatch": ["a://b/CreateStatusListDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CreateStatusListDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateStatusListDto.schema.json",
@@ -884,7 +1016,12 @@
         },
         "bits": {
           "description": "Bits per status value. More bits allow more status states. Defaults to tenant configuration.",
-          "enum": [1, 2, 4, 8],
+          "enum": [
+            1,
+            2,
+            4,
+            8
+          ],
           "type": "number",
           "example": 1
         },
@@ -900,7 +1037,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateStatusListDto.schema.json",
-    "fileMatch": ["a://b/UpdateStatusListDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateStatusListDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateStatusListDto.schema.json",
@@ -925,7 +1064,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthorizeQueries.schema.json",
-    "fileMatch": ["a://b/AuthorizeQueries*.schema.json"],
+    "fileMatch": [
+      "a://b/AuthorizeQueries*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthorizeQueries.schema.json",
@@ -978,7 +1119,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/OfferRequestDto.schema.json",
-    "fileMatch": ["a://b/OfferRequestDto*.schema.json"],
+    "fileMatch": [
+      "a://b/OfferRequestDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/OfferRequestDto.schema.json",
@@ -986,7 +1129,10 @@
       "type": "object",
       "properties": {
         "response_type": {
-          "enum": ["uri", "dc-api"],
+          "enum": [
+            "uri",
+            "dc-api"
+          ],
           "type": "string",
           "examples": [
             {
@@ -1004,14 +1150,19 @@
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": ["inline"]
+                    "enum": [
+                      "inline"
+                    ]
                   },
                   "claims": {
                     "type": "object",
                     "additionalProperties": true
                   }
                 },
-                "required": ["type", "claims"],
+                "required": [
+                  "type",
+                  "claims"
+                ],
                 "additionalProperties": false
               },
               {
@@ -1019,13 +1170,18 @@
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": ["attributeProvider"]
+                    "enum": [
+                      "attributeProvider"
+                    ]
                   },
                   "attributeProviderId": {
                     "type": "string"
                   }
                 },
-                "required": ["type", "attributeProviderId"],
+                "required": [
+                  "type",
+                  "attributeProviderId"
+                ],
                 "additionalProperties": false
               },
               {
@@ -1033,7 +1189,9 @@
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": ["webhook"]
+                    "enum": [
+                      "webhook"
+                    ]
                   },
                   "webhook": {
                     "type": "object",
@@ -1045,11 +1203,16 @@
                         "type": "object"
                       }
                     },
-                    "required": ["url"],
+                    "required": [
+                      "url"
+                    ],
                     "additionalProperties": false
                   }
                 },
-                "required": ["type", "webhook"],
+                "required": [
+                  "type",
+                  "webhook"
+                ],
                 "additionalProperties": false
               }
             ]
@@ -1067,7 +1230,10 @@
         },
         "flow": {
           "description": "The flow type for the offer request.",
-          "enum": ["authorization_code", "pre_authorized_code"],
+          "enum": [
+            "authorization_code",
+            "pre_authorized_code"
+          ],
           "type": "string"
         },
         "tx_code": {
@@ -1094,13 +1260,19 @@
           "description": "ID of the webhook endpoint to notify about the status of the issuance process."
         }
       },
-      "required": ["response_type", "flow", "credentialConfigurationIds"],
+      "required": [
+        "response_type",
+        "flow",
+        "credentialConfigurationIds"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebHookAuthConfigNone.schema.json",
-    "fileMatch": ["a://b/WebHookAuthConfigNone*.schema.json"],
+    "fileMatch": [
+      "a://b/WebHookAuthConfigNone*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebHookAuthConfigNone.schema.json",
@@ -1110,16 +1282,22 @@
         "type": {
           "type": "string",
           "description": "The type of authentication used for the webhook.",
-          "enum": ["none"]
+          "enum": [
+            "none"
+          ]
         }
       },
-      "required": ["type"],
+      "required": [
+        "type"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ApiKeyConfig.schema.json",
-    "fileMatch": ["a://b/ApiKeyConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/ApiKeyConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ApiKeyConfig.schema.json",
@@ -1135,13 +1313,18 @@
           "description": "The value of the API key to be sent in the header."
         }
       },
-      "required": ["headerName", "value"],
+      "required": [
+        "headerName",
+        "value"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebHookAuthConfigHeader.schema.json",
-    "fileMatch": ["a://b/WebHookAuthConfigHeader*.schema.json"],
+    "fileMatch": [
+      "a://b/WebHookAuthConfigHeader*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebHookAuthConfigHeader.schema.json",
@@ -1151,7 +1334,9 @@
         "type": {
           "type": "string",
           "description": "The type of authentication used for the webhook.",
-          "enum": ["apiKey"]
+          "enum": [
+            "apiKey"
+          ]
         },
         "config": {
           "description": "Configuration for API key authentication.\nThis is required if the type is 'apiKey'.",
@@ -1162,13 +1347,18 @@
           ]
         }
       },
-      "required": ["type", "config"],
+      "required": [
+        "type",
+        "config"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebhookConfig.schema.json",
-    "fileMatch": ["a://b/WebhookConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/WebhookConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebhookConfig.schema.json",
@@ -1198,13 +1388,18 @@
           "description": "The URL to which the webhook will send notifications."
         }
       },
-      "required": ["auth", "url"],
+      "required": [
+        "auth",
+        "url"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TransactionData.schema.json",
-    "fileMatch": ["a://b/TransactionData*.schema.json"],
+    "fileMatch": [
+      "a://b/TransactionData*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TransactionData.schema.json",
@@ -1221,13 +1416,18 @@
           }
         }
       },
-      "required": ["type", "credential_ids"],
+      "required": [
+        "type",
+        "credential_ids"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Session.schema.json",
-    "fileMatch": ["a://b/Session*.schema.json"],
+    "fileMatch": [
+      "a://b/Session*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Session.schema.json",
@@ -1236,7 +1436,13 @@
       "properties": {
         "status": {
           "description": "Status of the session.",
-          "enum": ["active", "fetched", "completed", "expired", "failed"],
+          "enum": [
+            "active",
+            "fetched",
+            "completed",
+            "expired",
+            "failed"
+          ],
           "type": "string"
         },
         "id": {
@@ -1426,7 +1632,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PaginatedSessionResponseDto.schema.json",
-    "fileMatch": ["a://b/PaginatedSessionResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/PaginatedSessionResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PaginatedSessionResponseDto.schema.json",
@@ -1457,13 +1665,21 @@
           "description": "Total number of pages"
         }
       },
-      "required": ["items", "total", "page", "pageSize", "totalPages"],
+      "required": [
+        "items",
+        "total",
+        "page",
+        "pageSize",
+        "totalPages"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SessionLogEntryResponseDto.schema.json",
-    "fileMatch": ["a://b/SessionLogEntryResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/SessionLogEntryResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SessionLogEntryResponseDto.schema.json",
@@ -1486,7 +1702,11 @@
         "level": {
           "type": "string",
           "description": "Log level",
-          "enum": ["info", "warn", "error"]
+          "enum": [
+            "info",
+            "warn",
+            "error"
+          ]
         },
         "stage": {
           "type": "string",
@@ -1502,13 +1722,21 @@
           "description": "Additional structured detail"
         }
       },
-      "required": ["id", "sessionId", "timestamp", "level", "message"],
+      "required": [
+        "id",
+        "sessionId",
+        "timestamp",
+        "level",
+        "message"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusUpdateDto.schema.json",
-    "fileMatch": ["a://b/StatusUpdateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/StatusUpdateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusUpdateDto.schema.json",
@@ -1528,13 +1756,18 @@
           "description": "The status of the credential\n0 = valid, 1 = revoked, 2 = suspended"
         }
       },
-      "required": ["sessionId", "status"],
+      "required": [
+        "sessionId",
+        "status"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateSessionConfigDto.schema.json",
-    "fileMatch": ["a://b/UpdateSessionConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateSessionConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateSessionConfigDto.schema.json",
@@ -1550,7 +1783,10 @@
         },
         "cleanupMode": {
           "description": "Cleanup mode: 'full' deletes everything, 'anonymize' keeps metadata but removes PII.",
-          "enum": ["full", "anonymize"],
+          "enum": [
+            "full",
+            "anonymize"
+          ],
           "type": "string",
           "default": "full"
         }
@@ -1560,7 +1796,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ManagedUserDto.schema.json",
-    "fileMatch": ["a://b/ManagedUserDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ManagedUserDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ManagedUserDto.schema.json",
@@ -1609,13 +1847,20 @@
           "description": "One-time temporary password returned only on user creation."
         }
       },
-      "required": ["id", "username", "enabled", "roles"],
+      "required": [
+        "id",
+        "username",
+        "enabled",
+        "roles"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateUserDto.schema.json",
-    "fileMatch": ["a://b/CreateUserDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CreateUserDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateUserDto.schema.json",
@@ -1657,13 +1902,18 @@
           "example": true
         }
       },
-      "required": ["username", "roles"],
+      "required": [
+        "username",
+        "roles"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateUserDto.schema.json",
-    "fileMatch": ["a://b/UpdateUserDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateUserDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateUserDto.schema.json",
@@ -1715,7 +1965,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodNone.schema.json",
-    "fileMatch": ["a://b/AuthenticationMethodNone*.schema.json"],
+    "fileMatch": [
+      "a://b/AuthenticationMethodNone*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodNone.schema.json",
@@ -1724,16 +1976,22 @@
       "properties": {
         "method": {
           "type": "string",
-          "enum": ["none"]
+          "enum": [
+            "none"
+          ]
         }
       },
-      "required": ["method"],
+      "required": [
+        "method"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationUrlConfig.schema.json",
-    "fileMatch": ["a://b/AuthenticationUrlConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/AuthenticationUrlConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationUrlConfig.schema.json",
@@ -1753,13 +2011,17 @@
           ]
         }
       },
-      "required": ["url"],
+      "required": [
+        "url"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodAuth.schema.json",
-    "fileMatch": ["a://b/AuthenticationMethodAuth*.schema.json"],
+    "fileMatch": [
+      "a://b/AuthenticationMethodAuth*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodAuth.schema.json",
@@ -1768,19 +2030,26 @@
       "properties": {
         "method": {
           "type": "string",
-          "enum": ["auth"]
+          "enum": [
+            "auth"
+          ]
         },
         "config": {
           "$ref": "./AuthenticationUrlConfig.schema.json"
         }
       },
-      "required": ["method", "config"],
+      "required": [
+        "method",
+        "config"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationDuringIssuanceConfig.schema.json",
-    "fileMatch": ["a://b/PresentationDuringIssuanceConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/PresentationDuringIssuanceConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationDuringIssuanceConfig.schema.json",
@@ -1792,13 +2061,17 @@
           "description": "Link to the presentation configuration that is relevant for the issuance process"
         }
       },
-      "required": ["type"],
+      "required": [
+        "type"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodPresentation.schema.json",
-    "fileMatch": ["a://b/AuthenticationMethodPresentation*.schema.json"],
+    "fileMatch": [
+      "a://b/AuthenticationMethodPresentation*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodPresentation.schema.json",
@@ -1807,56 +2080,108 @@
       "properties": {
         "method": {
           "type": "string",
-          "enum": ["presentationDuringIssuance"]
+          "enum": [
+            "presentationDuringIssuance"
+          ]
         },
         "config": {
           "$ref": "./PresentationDuringIssuanceConfig.schema.json"
         }
       },
-      "required": ["method", "config"],
+      "required": [
+        "method",
+        "config"
+      ],
       "additionalProperties": false
     }
   },
   {
-    "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpstreamOidcConfig.schema.json",
-    "fileMatch": ["a://b/UpstreamOidcConfig*.schema.json"],
+    "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ManagedAuthorizationServerConfig.schema.json",
+    "fileMatch": [
+      "a://b/ManagedAuthorizationServerConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpstreamOidcConfig.schema.json",
-      "title": "UpstreamOidcConfig",
+      "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ManagedAuthorizationServerConfig.schema.json",
+      "title": "ManagedAuthorizationServerConfig",
       "type": "object",
       "properties": {
-        "issuer": {
+        "type": {
+          "enum": [
+            "external",
+            "oid4vp",
+            "chained",
+            "built-in"
+          ],
           "type": "string",
-          "description": "The OIDC issuer URL of the upstream provider",
-          "example": "https://auth.example.com/realms/myrealm",
-          "format": "uri"
+          "description": "Authorization server implementation type",
+          "example": "external"
         },
-        "clientId": {
+        "label": {
           "type": "string",
-          "description": "The client ID registered with the upstream provider",
-          "example": "eudiplo-chained-as"
+          "description": "Human-friendly label for the UI",
+          "example": "PID Authorization Server"
         },
-        "clientSecret": {
-          "type": "string",
-          "description": "The client secret for confidential clients"
-        },
-        "scopes": {
-          "description": "Scopes to request from the upstream provider",
-          "default": ["openid", "profile"],
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether this managed authorization server is enabled",
+          "default": true
         }
       },
-      "required": ["issuer", "clientId"],
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExternalAuthorizationServerConfig.schema.json",
+    "fileMatch": [
+      "a://b/ExternalAuthorizationServerConfig*.schema.json"
+    ],
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExternalAuthorizationServerConfig.schema.json",
+      "title": "ExternalAuthorizationServerConfig",
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "external"
+          ],
+          "type": "string",
+          "description": "Authorization server implementation type",
+          "example": "external"
+        },
+        "label": {
+          "type": "string",
+          "description": "Human-friendly label for the UI",
+          "example": "PID Authorization Server"
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether this managed authorization server is enabled",
+          "default": true
+        },
+        "issuer": {
+          "type": "string",
+          "format": "uri",
+          "description": "Issuer URL for external authorization servers",
+          "example": "https://auth.example.com"
+        }
+      },
+      "required": [
+        "type",
+        "issuer"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenConfig.schema.json",
-    "fileMatch": ["a://b/ChainedAsTokenConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/ChainedAsTokenConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenConfig.schema.json",
@@ -1889,48 +2214,38 @@
     }
   },
   {
-    "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ManagedAuthorizationServerConfig.schema.json",
-    "fileMatch": ["a://b/ManagedAuthorizationServerConfig*.schema.json"],
+    "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Oid4VpAuthorizationServerConfig.schema.json",
+    "fileMatch": [
+      "a://b/Oid4VpAuthorizationServerConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ManagedAuthorizationServerConfig.schema.json",
-      "title": "ManagedAuthorizationServerConfig",
+      "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Oid4VpAuthorizationServerConfig.schema.json",
+      "title": "Oid4VpAuthorizationServerConfig",
       "type": "object",
       "properties": {
-        "id": {
+        "type": {
+          "enum": [
+            "oid4vp"
+          ],
           "type": "string",
-          "description": "Stable identifier used in the AS URL path",
-          "example": "pid-auth"
+          "description": "Authorization server implementation type",
+          "example": "oid4vp"
         },
         "label": {
           "type": "string",
           "description": "Human-friendly label for the UI",
           "example": "PID Authorization Server"
         },
-        "type": {
-          "enum": ["external", "oid4vp", "chained", "built-in"],
-          "type": "string",
-          "description": "Authorization server implementation type",
-          "example": "external"
-        },
-        "issuer": {
-          "type": "string",
-          "format": "uri",
-          "description": "Issuer URL for external authorization servers",
-          "example": "https://auth.example.com"
-        },
-        "upstream": {
-          "description": "Upstream OIDC provider configuration for chained mode",
-          "allOf": [
-            {
-              "$ref": "./UpstreamOidcConfig.schema.json"
-            }
-          ]
-        },
         "enabled": {
           "type": "boolean",
           "description": "Whether this managed authorization server is enabled",
           "default": true
+        },
+        "id": {
+          "type": "string",
+          "description": "Stable identifier used in the AS URL path",
+          "example": "pid-auth"
         },
         "presentationConfigId": {
           "type": "string",
@@ -1956,13 +2271,171 @@
           "default": false
         }
       },
-      "required": ["type"],
+      "required": [
+        "type",
+        "id",
+        "presentationConfigId"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpstreamOidcConfig.schema.json",
+    "fileMatch": [
+      "a://b/UpstreamOidcConfig*.schema.json"
+    ],
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpstreamOidcConfig.schema.json",
+      "title": "UpstreamOidcConfig",
+      "type": "object",
+      "properties": {
+        "issuer": {
+          "type": "string",
+          "description": "The OIDC issuer URL of the upstream provider",
+          "example": "https://auth.example.com/realms/myrealm",
+          "format": "uri"
+        },
+        "clientId": {
+          "type": "string",
+          "description": "The client ID registered with the upstream provider",
+          "example": "eudiplo-chained-as"
+        },
+        "clientSecret": {
+          "type": "string",
+          "description": "The client secret for confidential clients"
+        },
+        "scopes": {
+          "description": "Scopes to request from the upstream provider",
+          "default": [
+            "openid",
+            "profile"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "issuer",
+        "clientId"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAuthorizationServerConfig.schema.json",
+    "fileMatch": [
+      "a://b/ChainedAuthorizationServerConfig*.schema.json"
+    ],
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAuthorizationServerConfig.schema.json",
+      "title": "ChainedAuthorizationServerConfig",
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "chained"
+          ],
+          "type": "string",
+          "description": "Authorization server implementation type",
+          "example": "chained"
+        },
+        "label": {
+          "type": "string",
+          "description": "Human-friendly label for the UI",
+          "example": "PID Authorization Server"
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether this managed authorization server is enabled",
+          "default": true
+        },
+        "upstream": {
+          "description": "Upstream OIDC provider configuration for chained mode",
+          "allOf": [
+            {
+              "$ref": "./UpstreamOidcConfig.schema.json"
+            }
+          ]
+        },
+        "token": {
+          "description": "Token configuration for this authorization server",
+          "allOf": [
+            {
+              "$ref": "./ChainedAsTokenConfig.schema.json"
+            }
+          ]
+        },
+        "requireDPoP": {
+          "type": "boolean",
+          "description": "Require DPoP for token requests issued by this authorization server",
+          "default": false
+        }
+      },
+      "required": [
+        "type",
+        "upstream"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/BuiltInAuthorizationServerConfig.schema.json",
+    "fileMatch": [
+      "a://b/BuiltInAuthorizationServerConfig*.schema.json"
+    ],
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/BuiltInAuthorizationServerConfig.schema.json",
+      "title": "BuiltInAuthorizationServerConfig",
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "built-in"
+          ],
+          "type": "string",
+          "description": "Authorization server implementation type",
+          "example": "built-in"
+        },
+        "label": {
+          "type": "string",
+          "description": "Human-friendly label for the UI",
+          "example": "PID Authorization Server"
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether this managed authorization server is enabled",
+          "default": true
+        },
+        "token": {
+          "description": "Token configuration for this authorization server",
+          "allOf": [
+            {
+              "$ref": "./ChainedAsTokenConfig.schema.json"
+            }
+          ]
+        },
+        "requireDPoP": {
+          "type": "boolean",
+          "description": "Require DPoP for token requests issued by this authorization server",
+          "default": false
+        }
+      },
+      "required": [
+        "type"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FederationTrustAnchorConfig.schema.json",
-    "fileMatch": ["a://b/FederationTrustAnchorConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/FederationTrustAnchorConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FederationTrustAnchorConfig.schema.json",
@@ -1980,13 +2453,18 @@
           "example": "https://ta.example.org/.well-known/openid-federation"
         }
       },
-      "required": ["entityId", "entityConfigurationUri"],
+      "required": [
+        "entityId",
+        "entityConfigurationUri"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FederationConfig.schema.json",
-    "fileMatch": ["a://b/FederationConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/FederationConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FederationConfig.schema.json",
@@ -1994,13 +2472,20 @@
       "type": "object",
       "properties": {
         "role": {
-          "enum": ["trust_anchor", "intermediate", "leaf"],
+          "enum": [
+            "trust_anchor",
+            "intermediate",
+            "leaf"
+          ],
           "type": "string",
           "description": "Role this tenant plays in the OpenID Federation topology.",
           "default": "leaf"
         },
         "mode": {
-          "enum": ["federation-only", "hybrid"],
+          "enum": [
+            "federation-only",
+            "hybrid"
+          ],
           "type": "string",
           "description": "Trust decision strategy when both LoTE trust lists and OpenID Federation are configured.",
           "default": "hybrid"
@@ -2028,13 +2513,17 @@
           }
         }
       },
-      "required": ["trustAnchors"],
+      "required": [
+        "trustAnchors"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerProvidedAttestation.schema.json",
-    "fileMatch": ["a://b/IssuerProvidedAttestation*.schema.json"],
+    "fileMatch": [
+      "a://b/IssuerProvidedAttestation*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerProvidedAttestation.schema.json",
@@ -2057,7 +2546,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerRegistrationCertificateConfig.schema.json",
-    "fileMatch": ["a://b/IssuerRegistrationCertificateConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/IssuerRegistrationCertificateConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerRegistrationCertificateConfig.schema.json",
@@ -2070,7 +2561,10 @@
           "default": false
         },
         "mode": {
-          "enum": ["import", "generate"],
+          "enum": [
+            "import",
+            "generate"
+          ],
           "type": "string",
           "description": "import: use an existing JWT, generate: create via registrar from provided attestations and selected credential configurations.",
           "default": "import"
@@ -2109,7 +2603,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerRegistrationCertificateCache.schema.json",
-    "fileMatch": ["a://b/IssuerRegistrationCertificateCache*.schema.json"],
+    "fileMatch": [
+      "a://b/IssuerRegistrationCertificateCache*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerRegistrationCertificateCache.schema.json",
@@ -2142,7 +2638,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayLogo.schema.json",
-    "fileMatch": ["a://b/DisplayLogo*.schema.json"],
+    "fileMatch": [
+      "a://b/DisplayLogo*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayLogo.schema.json",
@@ -2156,13 +2654,17 @@
           "type": "string"
         }
       },
-      "required": ["uri"],
+      "required": [
+        "uri"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayInfo.schema.json",
-    "fileMatch": ["a://b/DisplayInfo*.schema.json"],
+    "fileMatch": [
+      "a://b/DisplayInfo*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayInfo.schema.json",
@@ -2184,7 +2686,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuanceConfig.schema.json",
-    "fileMatch": ["a://b/IssuanceConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/IssuanceConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuanceConfig.schema.json",
@@ -2196,11 +2700,33 @@
           "description": "Key ID for signing access tokens. If unset, the default signing key is used."
         },
         "authorizationServers": {
-          "nullable": true,
-          "description": "Dedicated managed authorization servers hosted by this issuer.\nEach entry creates a distinct AS endpoint and can be bound to a different\npresentation configuration.",
           "type": "array",
+          "description": "Dedicated managed authorization servers hosted by this issuer. At least one entry is required.",
+          "minItems": 1,
           "items": {
-            "$ref": "./ManagedAuthorizationServerConfig.schema.json"
+            "oneOf": [
+              {
+                "$ref": "./ExternalAuthorizationServerConfig.schema.json"
+              },
+              {
+                "$ref": "./Oid4VpAuthorizationServerConfig.schema.json"
+              },
+              {
+                "$ref": "./ChainedAuthorizationServerConfig.schema.json"
+              },
+              {
+                "$ref": "./BuiltInAuthorizationServerConfig.schema.json"
+              }
+            ],
+            "discriminator": {
+              "propertyName": "type",
+              "mapping": {
+                "external": "#/components/schemas/ExternalAuthorizationServerConfig",
+                "oid4vp": "#/components/schemas/Oid4VpAuthorizationServerConfig",
+                "chained": "#/components/schemas/ChainedAuthorizationServerConfig",
+                "built-in": "#/components/schemas/BuiltInAuthorizationServerConfig"
+              }
+            }
           }
         },
         "federation": {
@@ -2294,13 +2820,21 @@
           "description": "The timestamp when the VP request was last updated."
         }
       },
-      "required": ["tenant", "display", "createdAt", "updatedAt"],
+      "required": [
+        "authorizationServers",
+        "tenant",
+        "display",
+        "createdAt",
+        "updatedAt"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuanceDto.schema.json",
-    "fileMatch": ["a://b/IssuanceDto*.schema.json"],
+    "fileMatch": [
+      "a://b/IssuanceDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuanceDto.schema.json",
@@ -2312,11 +2846,33 @@
           "description": "Key ID for signing access tokens. If unset, the default signing key is used."
         },
         "authorizationServers": {
-          "nullable": true,
-          "description": "Dedicated managed authorization servers hosted by this issuer.\nEach entry creates a distinct AS endpoint and can be bound to a different\npresentation configuration.",
           "type": "array",
+          "description": "Dedicated managed authorization servers hosted by this issuer. At least one entry is required.",
+          "minItems": 1,
           "items": {
-            "$ref": "./ManagedAuthorizationServerConfig.schema.json"
+            "oneOf": [
+              {
+                "$ref": "./ExternalAuthorizationServerConfig.schema.json"
+              },
+              {
+                "$ref": "./Oid4VpAuthorizationServerConfig.schema.json"
+              },
+              {
+                "$ref": "./ChainedAuthorizationServerConfig.schema.json"
+              },
+              {
+                "$ref": "./BuiltInAuthorizationServerConfig.schema.json"
+              }
+            ],
+            "discriminator": {
+              "propertyName": "type",
+              "mapping": {
+                "external": "#/components/schemas/ExternalAuthorizationServerConfig",
+                "oid4vp": "#/components/schemas/Oid4VpAuthorizationServerConfig",
+                "chained": "#/components/schemas/ChainedAuthorizationServerConfig",
+                "built-in": "#/components/schemas/BuiltInAuthorizationServerConfig"
+              }
+            }
           }
         },
         "federation": {
@@ -2392,13 +2948,18 @@
           }
         }
       },
-      "required": ["display"],
+      "required": [
+        "authorizationServers",
+        "display"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClaimsQuery.schema.json",
-    "fileMatch": ["a://b/ClaimsQuery*.schema.json"],
+    "fileMatch": [
+      "a://b/ClaimsQuery*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClaimsQuery.schema.json",
@@ -2421,13 +2982,17 @@
           }
         }
       },
-      "required": ["path"],
+      "required": [
+        "path"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustedAuthorityQuery.schema.json",
-    "fileMatch": ["a://b/TrustedAuthorityQuery*.schema.json"],
+    "fileMatch": [
+      "a://b/TrustedAuthorityQuery*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustedAuthorityQuery.schema.json",
@@ -2436,7 +3001,10 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["etsi_tl", "openid_federation"]
+          "enum": [
+            "etsi_tl",
+            "openid_federation"
+          ]
         },
         "values": {
           "type": "array",
@@ -2445,13 +3013,18 @@
           }
         }
       },
-      "required": ["type", "values"],
+      "required": [
+        "type",
+        "values"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialQuery.schema.json",
-    "fileMatch": ["a://b/CredentialQuery*.schema.json"],
+    "fileMatch": [
+      "a://b/CredentialQuery*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialQuery.schema.json",
@@ -2494,13 +3067,19 @@
           }
         }
       },
-      "required": ["id", "format", "meta"],
+      "required": [
+        "id",
+        "format",
+        "meta"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialSetQuery.schema.json",
-    "fileMatch": ["a://b/CredentialSetQuery*.schema.json"],
+    "fileMatch": [
+      "a://b/CredentialSetQuery*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialSetQuery.schema.json",
@@ -2520,13 +3099,17 @@
           "type": "boolean"
         }
       },
-      "required": ["options"],
+      "required": [
+        "options"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PolicyCredential.schema.json",
-    "fileMatch": ["a://b/PolicyCredential*.schema.json"],
+    "fileMatch": [
+      "a://b/PolicyCredential*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PolicyCredential.schema.json",
@@ -2552,13 +3135,17 @@
           }
         }
       },
-      "required": ["credentials"],
+      "required": [
+        "credentials"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AttestationBasedPolicy.schema.json",
-    "fileMatch": ["a://b/AttestationBasedPolicy*.schema.json"],
+    "fileMatch": [
+      "a://b/AttestationBasedPolicy*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AttestationBasedPolicy.schema.json",
@@ -2567,7 +3154,9 @@
       "properties": {
         "policy": {
           "type": "string",
-          "enum": ["attestationBased"]
+          "enum": [
+            "attestationBased"
+          ]
         },
         "values": {
           "type": "array",
@@ -2576,13 +3165,18 @@
           }
         }
       },
-      "required": ["policy", "values"],
+      "required": [
+        "policy",
+        "values"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/NoneTrustPolicy.schema.json",
-    "fileMatch": ["a://b/NoneTrustPolicy*.schema.json"],
+    "fileMatch": [
+      "a://b/NoneTrustPolicy*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/NoneTrustPolicy.schema.json",
@@ -2591,16 +3185,22 @@
       "properties": {
         "policy": {
           "type": "string",
-          "enum": ["none"]
+          "enum": [
+            "none"
+          ]
         }
       },
-      "required": ["policy"],
+      "required": [
+        "policy"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AllowListPolicy.schema.json",
-    "fileMatch": ["a://b/AllowListPolicy*.schema.json"],
+    "fileMatch": [
+      "a://b/AllowListPolicy*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AllowListPolicy.schema.json",
@@ -2609,7 +3209,9 @@
       "properties": {
         "policy": {
           "type": "string",
-          "enum": ["allowList"]
+          "enum": [
+            "allowList"
+          ]
         },
         "values": {
           "type": "array",
@@ -2618,13 +3220,18 @@
           }
         }
       },
-      "required": ["policy", "values"],
+      "required": [
+        "policy",
+        "values"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RootOfTrustPolicy.schema.json",
-    "fileMatch": ["a://b/RootOfTrustPolicy*.schema.json"],
+    "fileMatch": [
+      "a://b/RootOfTrustPolicy*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RootOfTrustPolicy.schema.json",
@@ -2633,19 +3240,26 @@
       "properties": {
         "policy": {
           "type": "string",
-          "enum": ["rootOfTrust"]
+          "enum": [
+            "rootOfTrust"
+          ]
         },
         "values": {
           "type": "string"
         }
       },
-      "required": ["policy", "values"],
+      "required": [
+        "policy",
+        "values"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/VCT.schema.json",
-    "fileMatch": ["a://b/VCT*.schema.json"],
+    "fileMatch": [
+      "a://b/VCT*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/VCT.schema.json",
@@ -2679,7 +3293,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IaeActionOpenid4vpPresentation.schema.json",
-    "fileMatch": ["a://b/IaeActionOpenid4vpPresentation*.schema.json"],
+    "fileMatch": [
+      "a://b/IaeActionOpenid4vpPresentation*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IaeActionOpenid4vpPresentation.schema.json",
@@ -2687,7 +3303,9 @@
       "type": "object",
       "properties": {
         "type": {
-          "enum": ["openid4vp_presentation"],
+          "enum": [
+            "openid4vp_presentation"
+          ],
           "type": "string",
           "description": "Action type discriminator",
           "example": "openid4vp_presentation"
@@ -2703,13 +3321,18 @@
           "example": "pid-presentation-config"
         }
       },
-      "required": ["type", "presentationConfigId"],
+      "required": [
+        "type",
+        "presentationConfigId"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IaeActionRedirectToWeb.schema.json",
-    "fileMatch": ["a://b/IaeActionRedirectToWeb*.schema.json"],
+    "fileMatch": [
+      "a://b/IaeActionRedirectToWeb*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IaeActionRedirectToWeb.schema.json",
@@ -2717,7 +3340,9 @@
       "type": "object",
       "properties": {
         "type": {
-          "enum": ["redirect_to_web"],
+          "enum": [
+            "redirect_to_web"
+          ],
           "type": "string",
           "description": "Action type discriminator",
           "example": "redirect_to_web"
@@ -2745,13 +3370,18 @@
           "example": "Please complete the identity verification form"
         }
       },
-      "required": ["type", "url"],
+      "required": [
+        "type",
+        "url"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebhookEndpointEntity.schema.json",
-    "fileMatch": ["a://b/WebhookEndpointEntity*.schema.json"],
+    "fileMatch": [
+      "a://b/WebhookEndpointEntity*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebhookEndpointEntity.schema.json",
@@ -2789,13 +3419,22 @@
           "type": "string"
         }
       },
-      "required": ["id", "auth", "tenantId", "tenant", "name", "url"],
+      "required": [
+        "id",
+        "auth",
+        "tenantId",
+        "tenant",
+        "name",
+        "url"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaUriEntry.schema.json",
-    "fileMatch": ["a://b/SchemaUriEntry*.schema.json"],
+    "fileMatch": [
+      "a://b/SchemaUriEntry*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaUriEntry.schema.json",
@@ -2827,7 +3466,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustAuthorityEntry.schema.json",
-    "fileMatch": ["a://b/TrustAuthorityEntry*.schema.json"],
+    "fileMatch": [
+      "a://b/TrustAuthorityEntry*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustAuthorityEntry.schema.json",
@@ -2839,7 +3480,11 @@
           "description": "Trust list ID to resolve from the database. When set, frameworkType, value, and verificationMethod are derived automatically."
         },
         "frameworkType": {
-          "enum": ["aki", "etsi_tl", "openid_federation"],
+          "enum": [
+            "aki",
+            "etsi_tl",
+            "openid_federation"
+          ],
           "type": "string",
           "description": "Trust framework type (ignored when trustListId is set)"
         },
@@ -2870,7 +3515,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetaConfig.schema.json",
-    "fileMatch": ["a://b/SchemaMetaConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/SchemaMetaConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetaConfig.schema.json",
@@ -2903,7 +3550,12 @@
           "description": "Attestation Level of Security"
         },
         "bindingType": {
-          "enum": ["claim", "key", "biometric", "none"],
+          "enum": [
+            "claim",
+            "key",
+            "biometric",
+            "none"
+          ],
           "type": "string",
           "description": "Cryptographic binding type"
         },
@@ -2927,7 +3579,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EmbeddedDisclosurePolicy.schema.json",
-    "fileMatch": ["a://b/EmbeddedDisclosurePolicy*.schema.json"],
+    "fileMatch": [
+      "a://b/EmbeddedDisclosurePolicy*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EmbeddedDisclosurePolicy.schema.json",
@@ -2938,13 +3592,17 @@
           "type": "string"
         }
       },
-      "required": ["policy"],
+      "required": [
+        "policy"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyAttestationsRequired.schema.json",
-    "fileMatch": ["a://b/KeyAttestationsRequired*.schema.json"],
+    "fileMatch": [
+      "a://b/KeyAttestationsRequired*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyAttestationsRequired.schema.json",
@@ -2953,7 +3611,10 @@
       "properties": {
         "key_storage": {
           "description": "List of required key storage types (e.g., iso_18045_high, iso_18045_moderate)",
-          "example": ["iso_18045_high", "iso_18045_moderate"],
+          "example": [
+            "iso_18045_high",
+            "iso_18045_moderate"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -2961,7 +3622,10 @@
         },
         "user_authentication": {
           "description": "List of required user authentication types (e.g., iso_18045_high, iso_18045_moderate)",
-          "example": ["iso_18045_high", "iso_18045_moderate"],
+          "example": [
+            "iso_18045_high",
+            "iso_18045_moderate"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -2973,7 +3637,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayImage.schema.json",
-    "fileMatch": ["a://b/DisplayImage*.schema.json"],
+    "fileMatch": [
+      "a://b/DisplayImage*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayImage.schema.json",
@@ -2984,13 +3650,17 @@
           "type": "string"
         }
       },
-      "required": ["uri"],
+      "required": [
+        "uri"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Display.schema.json",
-    "fileMatch": ["a://b/Display*.schema.json"],
+    "fileMatch": [
+      "a://b/Display*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Display.schema.json",
@@ -3019,13 +3689,19 @@
           "$ref": "./DisplayImage.schema.json"
         }
       },
-      "required": ["name", "description", "locale"],
+      "required": [
+        "name",
+        "description",
+        "locale"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerMetadataCredentialConfig.schema.json",
-    "fileMatch": ["a://b/IssuerMetadataCredentialConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/IssuerMetadataCredentialConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerMetadataCredentialConfig.schema.json",
@@ -3042,7 +3718,10 @@
         },
         "format": {
           "type": "string",
-          "enum": ["mso_mdoc", "dc+sd-jwt"]
+          "enum": [
+            "mso_mdoc",
+            "dc+sd-jwt"
+          ]
         },
         "display": {
           "type": "array",
@@ -3058,13 +3737,18 @@
           "description": "Document type for mDOC credentials (e.g., \"org.iso.18013.5.1.mDL\").\nOnly applicable when format is \"mso_mdoc\"."
         }
       },
-      "required": ["format", "display"],
+      "required": [
+        "format",
+        "display"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FieldDisplayDto.schema.json",
-    "fileMatch": ["a://b/FieldDisplayDto*.schema.json"],
+    "fileMatch": [
+      "a://b/FieldDisplayDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FieldDisplayDto.schema.json",
@@ -3087,13 +3771,18 @@
           "example": "Primary first name"
         }
       },
-      "required": ["locale", "name"],
+      "required": [
+        "locale",
+        "name"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClaimFieldDefinitionDto.schema.json",
-    "fileMatch": ["a://b/ClaimFieldDefinitionDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ClaimFieldDefinitionDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClaimFieldDefinitionDto.schema.json",
@@ -3103,7 +3792,10 @@
         "path": {
           "type": "array",
           "description": "Path to claim value. For nested child fields this can be relative to the parent path.",
-          "example": ["address", "locality"],
+          "example": [
+            "address",
+            "locality"
+          ],
           "items": {
             "oneOf": [
               {
@@ -3119,7 +3811,14 @@
           }
         },
         "type": {
-          "enum": ["string", "number", "integer", "boolean", "object", "array"],
+          "enum": [
+            "string",
+            "number",
+            "integer",
+            "boolean",
+            "object",
+            "array"
+          ],
           "type": "string",
           "description": "Claim value type"
         },
@@ -3180,13 +3879,18 @@
           }
         }
       },
-      "required": ["path", "type"],
+      "required": [
+        "path",
+        "type"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AttributeProviderEntity.schema.json",
-    "fileMatch": ["a://b/AttributeProviderEntity*.schema.json"],
+    "fileMatch": [
+      "a://b/AttributeProviderEntity*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AttributeProviderEntity.schema.json",
@@ -3223,13 +3927,22 @@
           "type": "string"
         }
       },
-      "required": ["auth", "id", "tenantId", "tenant", "name", "url"],
+      "required": [
+        "auth",
+        "id",
+        "tenantId",
+        "tenant",
+        "name",
+        "url"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainEntity.schema.json",
-    "fileMatch": ["a://b/KeyChainEntity*.schema.json"],
+    "fileMatch": [
+      "a://b/KeyChainEntity*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainEntity.schema.json",
@@ -3259,12 +3972,21 @@
         "usageType": {
           "type": "string",
           "description": "The purpose/role of this key chain in the system.",
-          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"]
+          "enum": [
+            "access",
+            "attestation",
+            "trustList",
+            "statusList",
+            "encrypt"
+          ]
         },
         "usage": {
           "type": "string",
           "description": "The usage type of the keys (sign or encrypt).",
-          "enum": ["sign", "encrypt"]
+          "enum": [
+            "sign",
+            "encrypt"
+          ]
         },
         "kmsProvider": {
           "type": "string",
@@ -3344,7 +4066,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfig.schema.json",
-    "fileMatch": ["a://b/CredentialConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/CredentialConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfig.schema.json",
@@ -3471,20 +4195,30 @@
         "sdJwtTrustFormat": {
           "nullable": true,
           "description": "For SD-JWT credentials: determines whether to include certificate chain (x5c)\nor use federation-based trust (iss claim).\nDefault: \"x5c\" (federation must be explicitly selected)",
-          "enum": ["x5c", "federation"],
+          "enum": [
+            "x5c",
+            "federation"
+          ],
           "type": "string"
         },
         "lifeTime": {
           "type": "number"
         }
       },
-      "required": ["id", "tenant", "config", "fields"],
+      "required": [
+        "id",
+        "tenant",
+        "config",
+        "fields"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfigCreate.schema.json",
-    "fileMatch": ["a://b/CredentialConfigCreate*.schema.json"],
+    "fileMatch": [
+      "a://b/CredentialConfigCreate*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfigCreate.schema.json",
@@ -3594,20 +4328,29 @@
         "sdJwtTrustFormat": {
           "nullable": true,
           "description": "For SD-JWT credentials: determines whether to include certificate chain (x5c)\nor use federation-based trust (iss claim).\nDefault: \"x5c\" (federation must be explicitly selected)",
-          "enum": ["x5c", "federation"],
+          "enum": [
+            "x5c",
+            "federation"
+          ],
           "type": "string"
         },
         "lifeTime": {
           "type": "number"
         }
       },
-      "required": ["id", "config", "fields"],
+      "required": [
+        "id",
+        "config",
+        "fields"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfigUpdate.schema.json",
-    "fileMatch": ["a://b/CredentialConfigUpdate*.schema.json"],
+    "fileMatch": [
+      "a://b/CredentialConfigUpdate*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfigUpdate.schema.json",
@@ -3717,7 +4460,10 @@
         "sdJwtTrustFormat": {
           "nullable": true,
           "description": "For SD-JWT credentials: determines whether to include certificate chain (x5c)\nor use federation-based trust (iss claim).\nDefault: \"x5c\" (federation must be explicitly selected)",
-          "enum": ["x5c", "federation"],
+          "enum": [
+            "x5c",
+            "federation"
+          ],
           "type": "string"
         },
         "lifeTime": {
@@ -3729,7 +4475,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SignSchemaMetaConfigDto.schema.json",
-    "fileMatch": ["a://b/SignSchemaMetaConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/SignSchemaMetaConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SignSchemaMetaConfigDto.schema.json",
@@ -3753,13 +4501,17 @@
           "description": "ID of the credential config to link back after submission. When provided, schemaMeta.id on the credential config is updated with the reserved attestation ID."
         }
       },
-      "required": ["config"],
+      "required": [
+        "config"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SignVersionSchemaMetaConfigDto.schema.json",
-    "fileMatch": ["a://b/SignVersionSchemaMetaConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/SignVersionSchemaMetaConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SignVersionSchemaMetaConfigDto.schema.json",
@@ -3779,13 +4531,17 @@
           "description": "ID of the key chain to use for signing. Defaults to the tenant's default key chain."
         }
       },
-      "required": ["config"],
+      "required": [
+        "config"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/VocabularyEntryDto.schema.json",
-    "fileMatch": ["a://b/VocabularyEntryDto*.schema.json"],
+    "fileMatch": [
+      "a://b/VocabularyEntryDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/VocabularyEntryDto.schema.json",
@@ -3801,7 +4557,10 @@
           "description": "Display label for UI rendering."
         },
         "status": {
-          "enum": ["active", "deprecated"],
+          "enum": [
+            "active",
+            "deprecated"
+          ],
           "type": "string",
           "description": "Vocabulary lifecycle status."
         },
@@ -3810,13 +4569,19 @@
           "description": "Replacement code when status is deprecated."
         }
       },
-      "required": ["code", "label", "status"],
+      "required": [
+        "code",
+        "label",
+        "status"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetadataVocabulariesDto.schema.json",
-    "fileMatch": ["a://b/SchemaMetadataVocabulariesDto*.schema.json"],
+    "fileMatch": [
+      "a://b/SchemaMetadataVocabulariesDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetadataVocabulariesDto.schema.json",
@@ -3842,13 +4607,19 @@
           }
         }
       },
-      "required": ["version", "categories", "tags"],
+      "required": [
+        "version",
+        "categories",
+        "tags"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/MetadataSchemaDto.schema.json",
-    "fileMatch": ["a://b/MetadataSchemaDto*.schema.json"],
+    "fileMatch": [
+      "a://b/MetadataSchemaDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/MetadataSchemaDto.schema.json",
@@ -3860,7 +4631,10 @@
           "description": "Unique identifier for this schema entry"
         },
         "formatIdentifier": {
-          "enum": ["dc+sd-jwt", "mso_mdoc"],
+          "enum": [
+            "dc+sd-jwt",
+            "mso_mdoc"
+          ],
           "type": "string",
           "description": "The credential format identifier"
         },
@@ -3878,13 +4652,18 @@
           "description": "Subresource Integrity hash for the schema"
         }
       },
-      "required": ["id", "formatIdentifier"],
+      "required": [
+        "id",
+        "formatIdentifier"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustAuthorityDto.schema.json",
-    "fileMatch": ["a://b/TrustAuthorityDto*.schema.json"],
+    "fileMatch": [
+      "a://b/TrustAuthorityDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustAuthorityDto.schema.json",
@@ -3898,7 +4677,9 @@
         "frameworkType": {
           "type": "string",
           "description": "Type of trust framework",
-          "enum": ["etsi_tl"]
+          "enum": [
+            "etsi_tl"
+          ]
         },
         "value": {
           "type": "string",
@@ -3910,13 +4691,19 @@
           "description": "Verification method for the trust list signature (e.g., JWK)"
         }
       },
-      "required": ["id", "frameworkType", "value"],
+      "required": [
+        "id",
+        "frameworkType",
+        "value"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AccessCertificateRefDto.schema.json",
-    "fileMatch": ["a://b/AccessCertificateRefDto*.schema.json"],
+    "fileMatch": [
+      "a://b/AccessCertificateRefDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AccessCertificateRefDto.schema.json",
@@ -3939,13 +4726,21 @@
           "type": "string"
         }
       },
-      "required": ["id", "relyingPartyId", "certificate", "revoked", "createdAt"],
+      "required": [
+        "id",
+        "relyingPartyId",
+        "certificate",
+        "revoked",
+        "createdAt"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetadataResponseDto.schema.json",
-    "fileMatch": ["a://b/SchemaMetadataResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/SchemaMetadataResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetadataResponseDto.schema.json",
@@ -3979,7 +4774,12 @@
           "description": "Level of security (LoS) of this attestation"
         },
         "bindingType": {
-          "enum": ["claim", "key", "biometric", "none"],
+          "enum": [
+            "claim",
+            "key",
+            "biometric",
+            "none"
+          ],
           "type": "string",
           "description": "Required binding type between attestation and holder"
         },
@@ -3987,7 +4787,10 @@
           "type": "array",
           "items": {
             "type": "string",
-            "enum": ["dc+sd-jwt", "mso_mdoc"]
+            "enum": [
+              "dc+sd-jwt",
+              "mso_mdoc"
+            ]
           },
           "description": "Credential formats in which this attestation is available"
         },
@@ -4006,7 +4809,15 @@
           }
         },
         "category": {
-          "enum": ["identity", "health", "finance", "education", "mobility", "employment", "other"],
+          "enum": [
+            "identity",
+            "health",
+            "finance",
+            "education",
+            "mobility",
+            "employment",
+            "other"
+          ],
           "type": "string",
           "description": "Domain category for filtering"
         },
@@ -4082,7 +4893,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateSchemaMetadataDto.schema.json",
-    "fileMatch": ["a://b/UpdateSchemaMetadataDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateSchemaMetadataDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateSchemaMetadataDto.schema.json",
@@ -4090,7 +4903,15 @@
       "type": "object",
       "properties": {
         "category": {
-          "enum": ["identity", "health", "finance", "education", "mobility", "employment", "other"],
+          "enum": [
+            "identity",
+            "health",
+            "finance",
+            "education",
+            "mobility",
+            "employment",
+            "other"
+          ],
           "type": "string",
           "description": "Domain category for filtering"
         },
@@ -4119,7 +4940,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeprecateSchemaMetadataDto.schema.json",
-    "fileMatch": ["a://b/DeprecateSchemaMetadataDto*.schema.json"],
+    "fileMatch": [
+      "a://b/DeprecateSchemaMetadataDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeprecateSchemaMetadataDto.schema.json",
@@ -4139,13 +4962,17 @@
           "description": "The version that supersedes this one"
         }
       },
-      "required": ["deprecated"],
+      "required": [
+        "deprecated"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateAttributeProviderDto.schema.json",
-    "fileMatch": ["a://b/CreateAttributeProviderDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CreateAttributeProviderDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateAttributeProviderDto.schema.json",
@@ -4176,13 +5003,20 @@
           "type": "string"
         }
       },
-      "required": ["auth", "id", "name", "url"],
+      "required": [
+        "auth",
+        "id",
+        "name",
+        "url"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateAttributeProviderDto.schema.json",
-    "fileMatch": ["a://b/UpdateAttributeProviderDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateAttributeProviderDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateAttributeProviderDto.schema.json",
@@ -4218,7 +5052,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateWebhookEndpointDto.schema.json",
-    "fileMatch": ["a://b/CreateWebhookEndpointDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CreateWebhookEndpointDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateWebhookEndpointDto.schema.json",
@@ -4250,13 +5086,20 @@
           "type": "string"
         }
       },
-      "required": ["id", "auth", "name", "url"],
+      "required": [
+        "id",
+        "auth",
+        "name",
+        "url"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateWebhookEndpointDto.schema.json",
-    "fileMatch": ["a://b/UpdateWebhookEndpointDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateWebhookEndpointDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateWebhookEndpointDto.schema.json",
@@ -4293,7 +5136,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListEntityInfo.schema.json",
-    "fileMatch": ["a://b/TrustListEntityInfo*.schema.json"],
+    "fileMatch": [
+      "a://b/TrustListEntityInfo*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListEntityInfo.schema.json",
@@ -4325,13 +5170,17 @@
           "type": "string"
         }
       },
-      "required": ["name"],
+      "required": [
+        "name"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InternalTrustListEntity.schema.json",
-    "fileMatch": ["a://b/InternalTrustListEntity*.schema.json"],
+    "fileMatch": [
+      "a://b/InternalTrustListEntity*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InternalTrustListEntity.schema.json",
@@ -4340,7 +5189,9 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["internal"]
+          "enum": [
+            "internal"
+          ]
         },
         "issuerKeyChainId": {
           "type": "string"
@@ -4352,13 +5203,20 @@
           "$ref": "./TrustListEntityInfo.schema.json"
         }
       },
-      "required": ["type", "issuerKeyChainId", "revocationKeyChainId", "info"],
+      "required": [
+        "type",
+        "issuerKeyChainId",
+        "revocationKeyChainId",
+        "info"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExternalTrustListEntity.schema.json",
-    "fileMatch": ["a://b/ExternalTrustListEntity*.schema.json"],
+    "fileMatch": [
+      "a://b/ExternalTrustListEntity*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExternalTrustListEntity.schema.json",
@@ -4367,7 +5225,9 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["external"]
+          "enum": [
+            "external"
+          ]
         },
         "issuerCertPem": {
           "type": "string"
@@ -4379,13 +5239,20 @@
           "$ref": "./TrustListEntityInfo.schema.json"
         }
       },
-      "required": ["type", "issuerCertPem", "revocationCertPem", "info"],
+      "required": [
+        "type",
+        "issuerCertPem",
+        "revocationCertPem",
+        "info"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListCreateDto.schema.json",
-    "fileMatch": ["a://b/TrustListCreateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/TrustListCreateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListCreateDto.schema.json",
@@ -4426,13 +5293,17 @@
           "type": "string"
         }
       },
-      "required": ["entities"],
+      "required": [
+        "entities"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustList.schema.json",
-    "fileMatch": ["a://b/TrustList*.schema.json"],
+    "fileMatch": [
+      "a://b/TrustList*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustList.schema.json",
@@ -4508,7 +5379,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListVersion.schema.json",
-    "fileMatch": ["a://b/TrustListVersion*.schema.json"],
+    "fileMatch": [
+      "a://b/TrustListVersion*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListVersion.schema.json",
@@ -4563,7 +5436,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DCQL.schema.json",
-    "fileMatch": ["a://b/DCQL*.schema.json"],
+    "fileMatch": [
+      "a://b/DCQL*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DCQL.schema.json",
@@ -4583,13 +5458,17 @@
           }
         }
       },
-      "required": ["credentials"],
+      "required": [
+        "credentials"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificatePurpose.schema.json",
-    "fileMatch": ["a://b/RegistrationCertificatePurpose*.schema.json"],
+    "fileMatch": [
+      "a://b/RegistrationCertificatePurpose*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificatePurpose.schema.json",
@@ -4603,13 +5482,18 @@
           "type": "string"
         }
       },
-      "required": ["lang", "content"],
+      "required": [
+        "lang",
+        "content"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateBody.schema.json",
-    "fileMatch": ["a://b/RegistrationCertificateBody*.schema.json"],
+    "fileMatch": [
+      "a://b/RegistrationCertificateBody*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateBody.schema.json",
@@ -4649,7 +5533,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateRequest.schema.json",
-    "fileMatch": ["a://b/RegistrationCertificateRequest*.schema.json"],
+    "fileMatch": [
+      "a://b/RegistrationCertificateRequest*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateRequest.schema.json",
@@ -4678,7 +5564,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationAttachment.schema.json",
-    "fileMatch": ["a://b/PresentationAttachment*.schema.json"],
+    "fileMatch": [
+      "a://b/PresentationAttachment*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationAttachment.schema.json",
@@ -4698,13 +5586,18 @@
           }
         }
       },
-      "required": ["format", "data"],
+      "required": [
+        "format",
+        "data"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfig.schema.json",
-    "fileMatch": ["a://b/PresentationConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/PresentationConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfig.schema.json",
@@ -4813,13 +5706,21 @@
           "description": "Optional ID of the access certificate to use for signing the presentation request.\nIf not provided, the default access certificate for the tenant will be used.\n\nNote: This is intentionally NOT a TypeORM relationship because CertEntity uses\na composite primary key (id + tenantId), and SQLite cannot create foreign keys\nthat reference only part of a composite primary key. The relationship is handled\nat the application level in the service layer."
         }
       },
-      "required": ["id", "tenant", "dcql_query", "createdAt", "updatedAt"],
+      "required": [
+        "id",
+        "tenant",
+        "dcql_query",
+        "createdAt",
+        "updatedAt"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ResolveIssuerMetadataDto.schema.json",
-    "fileMatch": ["a://b/ResolveIssuerMetadataDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ResolveIssuerMetadataDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ResolveIssuerMetadataDto.schema.json",
@@ -4833,13 +5734,17 @@
           "example": "https://issuer.example.com/issuers/tenant-a"
         }
       },
-      "required": ["issuerUrl"],
+      "required": [
+        "issuerUrl"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ResolveSchemaMetadataDto.schema.json",
-    "fileMatch": ["a://b/ResolveSchemaMetadataDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ResolveSchemaMetadataDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ResolveSchemaMetadataDto.schema.json",
@@ -4853,13 +5758,17 @@
           "example": "https://registrar.example.com/schema-metadata/5c0d7dbb-ef2e-448b-b84f-b8103575947b"
         }
       },
-      "required": ["schemaMetadataUrl"],
+      "required": [
+        "schemaMetadataUrl"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfigCreateDto.schema.json",
-    "fileMatch": ["a://b/PresentationConfigCreateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/PresentationConfigCreateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfigCreateDto.schema.json",
@@ -4942,13 +5851,18 @@
           "description": "Optional ID of the access certificate to use for signing the presentation request.\nIf not provided, the default access certificate for the tenant will be used.\n\nNote: This is intentionally NOT a TypeORM relationship because CertEntity uses\na composite primary key (id + tenantId), and SQLite cannot create foreign keys\nthat reference only part of a composite primary key. The relationship is handled\nat the application level in the service layer."
         }
       },
-      "required": ["id", "dcql_query"],
+      "required": [
+        "id",
+        "dcql_query"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfigUpdateDto.schema.json",
-    "fileMatch": ["a://b/PresentationConfigUpdateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/PresentationConfigUpdateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfigUpdateDto.schema.json",
@@ -5036,7 +5950,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateDefaults.schema.json",
-    "fileMatch": ["a://b/RegistrationCertificateDefaults*.schema.json"],
+    "fileMatch": [
+      "a://b/RegistrationCertificateDefaults*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateDefaults.schema.json",
@@ -5059,7 +5975,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrarConfigResponseDto.schema.json",
-    "fileMatch": ["a://b/RegistrarConfigResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/RegistrarConfigResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrarConfigResponseDto.schema.json",
@@ -5107,13 +6025,21 @@
           "example": true
         }
       },
-      "required": ["registrarUrl", "oidcUrl", "clientId", "username", "hasPassword"],
+      "required": [
+        "registrarUrl",
+        "oidcUrl",
+        "clientId",
+        "username",
+        "hasPassword"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateRegistrarConfigDto.schema.json",
-    "fileMatch": ["a://b/CreateRegistrarConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CreateRegistrarConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateRegistrarConfigDto.schema.json",
@@ -5160,13 +6086,21 @@
           ]
         }
       },
-      "required": ["registrarUrl", "oidcUrl", "clientId", "username", "password"],
+      "required": [
+        "registrarUrl",
+        "oidcUrl",
+        "clientId",
+        "username",
+        "password"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateRegistrarConfigDto.schema.json",
-    "fileMatch": ["a://b/UpdateRegistrarConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateRegistrarConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateRegistrarConfigDto.schema.json",
@@ -5218,7 +6152,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateAccessCertificateDto.schema.json",
-    "fileMatch": ["a://b/CreateAccessCertificateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CreateAccessCertificateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateAccessCertificateDto.schema.json",
@@ -5231,13 +6167,17 @@
           "example": "my-signing-key"
         }
       },
-      "required": ["keyId"],
+      "required": [
+        "keyId"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeferredCredentialRequestDto.schema.json",
-    "fileMatch": ["a://b/DeferredCredentialRequestDto*.schema.json"],
+    "fileMatch": [
+      "a://b/DeferredCredentialRequestDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeferredCredentialRequestDto.schema.json",
@@ -5250,13 +6190,17 @@
           "example": "8xLOxBtZp8"
         }
       },
-      "required": ["transaction_id"],
+      "required": [
+        "transaction_id"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/NotificationRequestDto.schema.json",
-    "fileMatch": ["a://b/NotificationRequestDto*.schema.json"],
+    "fileMatch": [
+      "a://b/NotificationRequestDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/NotificationRequestDto.schema.json",
@@ -5268,16 +6212,25 @@
         },
         "event": {
           "type": "string",
-          "enum": ["credential_accepted", "credential_failure", "credential_deleted"]
+          "enum": [
+            "credential_accepted",
+            "credential_failure",
+            "credential_deleted"
+          ]
         }
       },
-      "required": ["notification_id", "event"],
+      "required": [
+        "notification_id",
+        "event"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/OfferResponse.schema.json",
-    "fileMatch": ["a://b/OfferResponse*.schema.json"],
+    "fileMatch": [
+      "a://b/OfferResponse*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/OfferResponse.schema.json",
@@ -5295,13 +6248,18 @@
           "type": "string"
         }
       },
-      "required": ["uri", "session"],
+      "required": [
+        "uri",
+        "session"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CompleteDeferredDto.schema.json",
-    "fileMatch": ["a://b/CompleteDeferredDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CompleteDeferredDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CompleteDeferredDto.schema.json",
@@ -5319,13 +6277,17 @@
           }
         }
       },
-      "required": ["claims"],
+      "required": [
+        "claims"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeferredOperationResponse.schema.json",
-    "fileMatch": ["a://b/DeferredOperationResponse*.schema.json"],
+    "fileMatch": [
+      "a://b/DeferredOperationResponse*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeferredOperationResponse.schema.json",
@@ -5338,7 +6300,13 @@
         },
         "status": {
           "description": "The new status of the transaction",
-          "enum": ["pending", "ready", "retrieved", "expired", "failed"],
+          "enum": [
+            "pending",
+            "ready",
+            "retrieved",
+            "expired",
+            "failed"
+          ],
           "type": "string"
         },
         "message": {
@@ -5346,13 +6314,18 @@
           "description": "Optional message"
         }
       },
-      "required": ["transactionId", "status"],
+      "required": [
+        "transactionId",
+        "status"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FailDeferredDto.schema.json",
-    "fileMatch": ["a://b/FailDeferredDto*.schema.json"],
+    "fileMatch": [
+      "a://b/FailDeferredDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FailDeferredDto.schema.json",
@@ -5370,7 +6343,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EC_Public.schema.json",
-    "fileMatch": ["a://b/EC_Public*.schema.json"],
+    "fileMatch": [
+      "a://b/EC_Public*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EC_Public.schema.json",
@@ -5394,13 +6369,20 @@
           "description": "The y coordinate of the EC public key."
         }
       },
-      "required": ["kty", "crv", "x", "y"],
+      "required": [
+        "kty",
+        "crv",
+        "x",
+        "y"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/JwksResponseDto.schema.json",
-    "fileMatch": ["a://b/JwksResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/JwksResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/JwksResponseDto.schema.json",
@@ -5415,13 +6397,17 @@
           }
         }
       },
-      "required": ["keys"],
+      "required": [
+        "keys"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthorizationResponse.schema.json",
-    "fileMatch": ["a://b/AuthorizationResponse*.schema.json"],
+    "fileMatch": [
+      "a://b/AuthorizationResponse*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthorizationResponse.schema.json",
@@ -5457,7 +6443,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Object.schema.json",
-    "fileMatch": ["a://b/Object*.schema.json"],
+    "fileMatch": [
+      "a://b/Object*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Object.schema.json",
@@ -5469,7 +6457,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ParResponseDto.schema.json",
-    "fileMatch": ["a://b/ParResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ParResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ParResponseDto.schema.json",
@@ -5485,13 +6475,18 @@
           "description": "The expiration time for the request URI in seconds."
         }
       },
-      "required": ["request_uri", "expires_in"],
+      "required": [
+        "request_uri",
+        "expires_in"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationRequestDto.schema.json",
-    "fileMatch": ["a://b/InteractiveAuthorizationRequestDto*.schema.json"],
+    "fileMatch": [
+      "a://b/InteractiveAuthorizationRequestDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationRequestDto.schema.json",
@@ -5564,7 +6559,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationCodeResponseDto.schema.json",
-    "fileMatch": ["a://b/InteractiveAuthorizationCodeResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/InteractiveAuthorizationCodeResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationCodeResponseDto.schema.json",
@@ -5582,13 +6579,18 @@
           "example": "auth-code-123"
         }
       },
-      "required": ["status", "code"],
+      "required": [
+        "status",
+        "code"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationErrorResponseDto.schema.json",
-    "fileMatch": ["a://b/InteractiveAuthorizationErrorResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/InteractiveAuthorizationErrorResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationErrorResponseDto.schema.json",
@@ -5606,13 +6608,17 @@
           "example": "Missing required parameter: interaction_types_supported"
         }
       },
-      "required": ["error"],
+      "required": [
+        "error"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsParResponseDto.schema.json",
-    "fileMatch": ["a://b/ChainedAsParResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ChainedAsParResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsParResponseDto.schema.json",
@@ -5630,13 +6636,18 @@
           "example": 600
         }
       },
-      "required": ["request_uri", "expires_in"],
+      "required": [
+        "request_uri",
+        "expires_in"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsErrorResponseDto.schema.json",
-    "fileMatch": ["a://b/ChainedAsErrorResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ChainedAsErrorResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsErrorResponseDto.schema.json",
@@ -5653,13 +6664,17 @@
           "description": "Human-readable error description"
         }
       },
-      "required": ["error"],
+      "required": [
+        "error"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenRequestDto.schema.json",
-    "fileMatch": ["a://b/ChainedAsTokenRequestDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ChainedAsTokenRequestDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenRequestDto.schema.json",
@@ -5692,13 +6707,17 @@
           "description": "PKCE code verifier"
         }
       },
-      "required": ["grant_type"],
+      "required": [
+        "grant_type"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenResponseDto.schema.json",
-    "fileMatch": ["a://b/ChainedAsTokenResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ChainedAsTokenResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenResponseDto.schema.json",
@@ -5743,13 +6762,19 @@
           "description": "Refresh token (issued when refresh tokens are enabled)"
         }
       },
-      "required": ["access_token", "token_type", "expires_in"],
+      "required": [
+        "access_token",
+        "token_type",
+        "expires_in"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProviderCapabilitiesDto.schema.json",
-    "fileMatch": ["a://b/KmsProviderCapabilitiesDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KmsProviderCapabilitiesDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProviderCapabilitiesDto.schema.json",
@@ -5773,7 +6798,9 @@
         },
         "supportedAlgs": {
           "description": "Signing algorithms supported by the provider.",
-          "example": ["ES256"],
+          "example": [
+            "ES256"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -5785,13 +6812,21 @@
           "example": "ES256"
         }
       },
-      "required": ["canImport", "canCreate", "canDelete", "supportedAlgs", "defaultAlg"],
+      "required": [
+        "canImport",
+        "canCreate",
+        "canDelete",
+        "supportedAlgs",
+        "defaultAlg"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProviderInfoDto.schema.json",
-    "fileMatch": ["a://b/KmsProviderInfoDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KmsProviderInfoDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProviderInfoDto.schema.json",
@@ -5822,13 +6857,19 @@
           ]
         }
       },
-      "required": ["name", "type", "capabilities"],
+      "required": [
+        "name",
+        "type",
+        "capabilities"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProvidersResponseDto.schema.json",
-    "fileMatch": ["a://b/KmsProvidersResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KmsProvidersResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProvidersResponseDto.schema.json",
@@ -5848,13 +6889,18 @@
           "example": "db"
         }
       },
-      "required": ["providers", "default"],
+      "required": [
+        "providers",
+        "default"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DbKmsConfigDto.schema.json",
-    "fileMatch": ["a://b/DbKmsConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/DbKmsConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DbKmsConfigDto.schema.json",
@@ -5867,7 +6913,9 @@
           "example": "main-vault"
         },
         "type": {
-          "enum": ["db"],
+          "enum": [
+            "db"
+          ],
           "type": "string",
           "description": "Type of the KMS provider.",
           "example": "db"
@@ -5878,13 +6926,18 @@
           "example": "Production HashiCorp Vault for signing keys"
         }
       },
-      "required": ["id", "type"],
+      "required": [
+        "id",
+        "type"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/VaultKmsConfigDto.schema.json",
-    "fileMatch": ["a://b/VaultKmsConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/VaultKmsConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/VaultKmsConfigDto.schema.json",
@@ -5897,7 +6950,9 @@
           "example": "main-vault"
         },
         "type": {
-          "enum": ["vault"],
+          "enum": [
+            "vault"
+          ],
           "type": "string",
           "description": "Type of the KMS provider.",
           "example": "vault"
@@ -5918,13 +6973,20 @@
           "example": "${VAULT_TOKEN}"
         }
       },
-      "required": ["id", "type", "vaultUrl", "vaultToken"],
+      "required": [
+        "id",
+        "type",
+        "vaultUrl",
+        "vaultToken"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AwsKmsConfigDto.schema.json",
-    "fileMatch": ["a://b/AwsKmsConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/AwsKmsConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AwsKmsConfigDto.schema.json",
@@ -5937,7 +6999,9 @@
           "example": "main-vault"
         },
         "type": {
-          "enum": ["aws-kms"],
+          "enum": [
+            "aws-kms"
+          ],
           "type": "string",
           "description": "Type of the KMS provider.",
           "example": "aws-kms"
@@ -5963,13 +7027,19 @@
           "example": "${AWS_SECRET_ACCESS_KEY}"
         }
       },
-      "required": ["id", "type", "region"],
+      "required": [
+        "id",
+        "type",
+        "region"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Pkcs11KmsConfigDto.schema.json",
-    "fileMatch": ["a://b/Pkcs11KmsConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/Pkcs11KmsConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Pkcs11KmsConfigDto.schema.json",
@@ -5982,7 +7052,9 @@
           "example": "main-vault"
         },
         "type": {
-          "enum": ["pkcs11"],
+          "enum": [
+            "pkcs11"
+          ],
           "type": "string",
           "description": "Type of the KMS provider.",
           "example": "pkcs11"
@@ -6013,13 +7085,21 @@
           "example": false
         }
       },
-      "required": ["id", "type", "library", "slot", "pin"],
+      "required": [
+        "id",
+        "type",
+        "library",
+        "slot",
+        "pin"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/HttpAuthBaseConfigDto.schema.json",
-    "fileMatch": ["a://b/HttpAuthBaseConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/HttpAuthBaseConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/HttpAuthBaseConfigDto.schema.json",
@@ -6027,18 +7107,27 @@
       "type": "object",
       "properties": {
         "type": {
-          "enum": ["none", "bearer", "oauth2-client-credentials", "mtls"],
+          "enum": [
+            "none",
+            "bearer",
+            "oauth2-client-credentials",
+            "mtls"
+          ],
           "type": "string",
           "description": "Authentication method for the remote KMS service."
         }
       },
-      "required": ["type"],
+      "required": [
+        "type"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/HttpKmsConfigDto.schema.json",
-    "fileMatch": ["a://b/HttpKmsConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/HttpKmsConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/HttpKmsConfigDto.schema.json",
@@ -6051,7 +7140,9 @@
           "example": "main-vault"
         },
         "type": {
-          "enum": ["http"],
+          "enum": [
+            "http"
+          ],
           "type": "string",
           "description": "Type of the KMS provider.",
           "example": "http"
@@ -6090,13 +7181,19 @@
           "example": false
         }
       },
-      "required": ["id", "type", "baseUrl"],
+      "required": [
+        "id",
+        "type",
+        "baseUrl"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CscAuthorizeAuthDataDto.schema.json",
-    "fileMatch": ["a://b/CscAuthorizeAuthDataDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CscAuthorizeAuthDataDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CscAuthorizeAuthDataDto.schema.json",
@@ -6114,13 +7211,18 @@
           "example": "123456"
         }
       },
-      "required": ["id", "value"],
+      "required": [
+        "id",
+        "value"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CscKmsConfigDto.schema.json",
-    "fileMatch": ["a://b/CscKmsConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CscKmsConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CscKmsConfigDto.schema.json",
@@ -6133,7 +7235,9 @@
           "example": "main-vault"
         },
         "type": {
-          "enum": ["csc"],
+          "enum": [
+            "csc"
+          ],
           "type": "string",
           "description": "Type of the KMS provider.",
           "example": "csc"
@@ -6211,13 +7315,22 @@
           }
         }
       },
-      "required": ["id", "type", "baseUrl", "tokenUrl", "clientId", "clientSecret"],
+      "required": [
+        "id",
+        "type",
+        "baseUrl",
+        "tokenUrl",
+        "clientId",
+        "clientSecret"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsConfigDto.schema.json",
-    "fileMatch": ["a://b/KmsConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KmsConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsConfigDto.schema.json",
@@ -6287,13 +7400,17 @@
           ]
         }
       },
-      "required": ["providers"],
+      "required": [
+        "providers"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsTenantConfigResponseDto.schema.json",
-    "fileMatch": ["a://b/KmsTenantConfigResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KmsTenantConfigResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsTenantConfigResponseDto.schema.json",
@@ -6319,13 +7436,17 @@
           ]
         }
       },
-      "required": ["effectiveConfig"],
+      "required": [
+        "effectiveConfig"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CertificateInfoDto.schema.json",
-    "fileMatch": ["a://b/CertificateInfoDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CertificateInfoDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CertificateInfoDto.schema.json",
@@ -6359,13 +7480,17 @@
           "description": "Serial number."
         }
       },
-      "required": ["pem"],
+      "required": [
+        "pem"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PublicKeyInfoDto.schema.json",
-    "fileMatch": ["a://b/PublicKeyInfoDto*.schema.json"],
+    "fileMatch": [
+      "a://b/PublicKeyInfoDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PublicKeyInfoDto.schema.json",
@@ -6392,13 +7517,17 @@
           "example": "P-256"
         }
       },
-      "required": ["kty"],
+      "required": [
+        "kty"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyResponseDto.schema.json",
-    "fileMatch": ["a://b/RotationPolicyResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/RotationPolicyResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyResponseDto.schema.json",
@@ -6423,13 +7552,17 @@
           "description": "Next scheduled rotation date."
         }
       },
-      "required": ["enabled"],
+      "required": [
+        "enabled"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainResponseDto.schema.json",
-    "fileMatch": ["a://b/KeyChainResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KeyChainResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainResponseDto.schema.json",
@@ -6441,12 +7574,21 @@
           "description": "Unique identifier for the key chain."
         },
         "usageType": {
-          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"],
+          "enum": [
+            "access",
+            "attestation",
+            "trustList",
+            "statusList",
+            "encrypt"
+          ],
           "type": "string",
           "description": "Usage type of the key chain."
         },
         "type": {
-          "enum": ["standalone", "internalChain"],
+          "enum": [
+            "standalone",
+            "internalChain"
+          ],
           "type": "string",
           "description": "Type of key chain (standalone or internalChain)."
         },
@@ -6537,7 +7679,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExportEcJwk.schema.json",
-    "fileMatch": ["a://b/ExportEcJwk*.schema.json"],
+    "fileMatch": [
+      "a://b/ExportEcJwk*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExportEcJwk.schema.json",
@@ -6576,13 +7720,21 @@
           "description": "Key ID"
         }
       },
-      "required": ["kty", "crv", "x", "y", "d"],
+      "required": [
+        "kty",
+        "crv",
+        "x",
+        "y",
+        "d"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExportRotationPolicyDto.schema.json",
-    "fileMatch": ["a://b/ExportRotationPolicyDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ExportRotationPolicyDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExportRotationPolicyDto.schema.json",
@@ -6602,13 +7754,17 @@
           "description": "Certificate validity in days."
         }
       },
-      "required": ["enabled"],
+      "required": [
+        "enabled"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainExportDto.schema.json",
-    "fileMatch": ["a://b/KeyChainExportDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KeyChainExportDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainExportDto.schema.json",
@@ -6624,7 +7780,13 @@
           "description": "Human-readable description."
         },
         "usageType": {
-          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"],
+          "enum": [
+            "access",
+            "attestation",
+            "trustList",
+            "statusList",
+            "encrypt"
+          ],
           "type": "string",
           "description": "Usage type for this key chain."
         },
@@ -6656,13 +7818,19 @@
           ]
         }
       },
-      "required": ["id", "usageType", "key"],
+      "required": [
+        "id",
+        "usageType",
+        "key"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyCreateDto.schema.json",
-    "fileMatch": ["a://b/RotationPolicyCreateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/RotationPolicyCreateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyCreateDto.schema.json",
@@ -6689,13 +7857,17 @@
           "example": 365
         }
       },
-      "required": ["enabled"],
+      "required": [
+        "enabled"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainCreateDto.schema.json",
-    "fileMatch": ["a://b/KeyChainCreateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KeyChainCreateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainCreateDto.schema.json",
@@ -6703,13 +7875,22 @@
       "type": "object",
       "properties": {
         "usageType": {
-          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"],
+          "enum": [
+            "access",
+            "attestation",
+            "trustList",
+            "statusList",
+            "encrypt"
+          ],
           "type": "string",
           "description": "Usage type determines the purpose of this key chain (access, attestation, etc.).",
           "example": "attestation"
         },
         "type": {
-          "enum": ["standalone", "internalChain"],
+          "enum": [
+            "standalone",
+            "internalChain"
+          ],
           "type": "string",
           "description": "Type of key chain to create.",
           "example": "internalChain"
@@ -6733,13 +7914,18 @@
           ]
         }
       },
-      "required": ["usageType", "type"],
+      "required": [
+        "usageType",
+        "type"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EcJwk.schema.json",
-    "fileMatch": ["a://b/EcJwk*.schema.json"],
+    "fileMatch": [
+      "a://b/EcJwk*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EcJwk.schema.json",
@@ -6768,13 +7954,21 @@
           "type": "string"
         }
       },
-      "required": ["kty", "x", "y", "crv", "d"],
+      "required": [
+        "kty",
+        "x",
+        "y",
+        "crv",
+        "d"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyImportDto.schema.json",
-    "fileMatch": ["a://b/RotationPolicyImportDto*.schema.json"],
+    "fileMatch": [
+      "a://b/RotationPolicyImportDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyImportDto.schema.json",
@@ -6801,13 +7995,17 @@
           "example": 365
         }
       },
-      "required": ["enabled"],
+      "required": [
+        "enabled"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainImportDto.schema.json",
-    "fileMatch": ["a://b/KeyChainImportDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KeyChainImportDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainImportDto.schema.json",
@@ -6831,7 +8029,13 @@
           "description": "Human-readable description."
         },
         "usageType": {
-          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"],
+          "enum": [
+            "access",
+            "attestation",
+            "trustList",
+            "statusList",
+            "encrypt"
+          ],
           "type": "string",
           "description": "Usage type for this key chain."
         },
@@ -6855,13 +8059,18 @@
           ]
         }
       },
-      "required": ["key", "usageType"],
+      "required": [
+        "key",
+        "usageType"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyUpdateDto.schema.json",
-    "fileMatch": ["a://b/RotationPolicyUpdateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/RotationPolicyUpdateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyUpdateDto.schema.json",
@@ -6890,7 +8099,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainUpdateDto.schema.json",
-    "fileMatch": ["a://b/KeyChainUpdateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KeyChainUpdateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainUpdateDto.schema.json",
@@ -6919,7 +8130,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationRequest.schema.json",
-    "fileMatch": ["a://b/PresentationRequest*.schema.json"],
+    "fileMatch": [
+      "a://b/PresentationRequest*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationRequest.schema.json",
@@ -6929,7 +8142,10 @@
         "response_type": {
           "type": "string",
           "description": "The type of response expected from the presentation request.",
-          "enum": ["uri", "dc-api"]
+          "enum": [
+            "uri",
+            "dc-api"
+          ]
         },
         "requestId": {
           "type": "string",
@@ -6960,13 +8176,18 @@
           }
         }
       },
-      "required": ["response_type", "requestId"],
+      "required": [
+        "response_type",
+        "requestId"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FileUploadDto.schema.json",
-    "fileMatch": ["a://b/FileUploadDto*.schema.json"],
+    "fileMatch": [
+      "a://b/FileUploadDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FileUploadDto.schema.json",
@@ -6978,7 +8199,9 @@
           "format": "binary"
         }
       },
-      "required": ["file"],
+      "required": [
+        "file"
+      ],
       "additionalProperties": false
     }
   }

--- a/apps/client/src/app/utils/schemas.json
+++ b/apps/client/src/app/utils/schemas.json
@@ -1,7 +1,9 @@
 [
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/GrafanaConfigDto.schema.json",
-    "fileMatch": ["a://b/GrafanaConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/GrafanaConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/GrafanaConfigDto.schema.json",
@@ -24,13 +26,18 @@
           "example": "loki"
         }
       },
-      "required": ["tempoUid", "lokiUid"],
+      "required": [
+        "tempoUid",
+        "lokiUid"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FrontendConfigResponseDto.schema.json",
-    "fileMatch": ["a://b/FrontendConfigResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/FrontendConfigResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FrontendConfigResponseDto.schema.json",
@@ -46,13 +53,17 @@
           ]
         }
       },
-      "required": ["grafana"],
+      "required": [
+        "grafana"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RoleDto.schema.json",
-    "fileMatch": ["a://b/RoleDto*.schema.json"],
+    "fileMatch": [
+      "a://b/RoleDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RoleDto.schema.json",
@@ -75,13 +86,17 @@
           "example": "issuance:manage"
         }
       },
-      "required": ["role"],
+      "required": [
+        "role"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientCredentialsDto.schema.json",
-    "fileMatch": ["a://b/ClientCredentialsDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ClientCredentialsDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientCredentialsDto.schema.json",
@@ -99,13 +114,18 @@
           "type": "string"
         }
       },
-      "required": ["client_id", "client_secret"],
+      "required": [
+        "client_id",
+        "client_secret"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TokenResponse.schema.json",
-    "fileMatch": ["a://b/TokenResponse*.schema.json"],
+    "fileMatch": [
+      "a://b/TokenResponse*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TokenResponse.schema.json",
@@ -128,13 +148,20 @@
           "type": "string"
         }
       },
-      "required": ["access_token", "token_type", "expires_in", "state"],
+      "required": [
+        "access_token",
+        "token_type",
+        "expires_in",
+        "state"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ImportTenantDto.schema.json",
-    "fileMatch": ["a://b/ImportTenantDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ImportTenantDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ImportTenantDto.schema.json",
@@ -150,13 +177,17 @@
           "description": "The description of the tenant."
         }
       },
-      "required": ["name"],
+      "required": [
+        "name"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SessionStorageConfig.schema.json",
-    "fileMatch": ["a://b/SessionStorageConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/SessionStorageConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SessionStorageConfig.schema.json",
@@ -172,7 +203,10 @@
         "cleanupMode": {
           "type": "string",
           "description": "Cleanup mode: 'full' deletes everything, 'anonymize' keeps metadata but removes PII.",
-          "enum": ["full", "anonymize"],
+          "enum": [
+            "full",
+            "anonymize"
+          ],
           "default": "full"
         }
       },
@@ -181,7 +215,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListConfig.schema.json",
-    "fileMatch": ["a://b/StatusListConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/StatusListConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListConfig.schema.json",
@@ -197,7 +233,12 @@
         "bits": {
           "type": "number",
           "description": "Bits per status entry: 1 (valid/revoked), 2 (with suspended), 4/8 (extended). If not set, uses global STATUS_BITS.",
-          "enum": [1, 2, 4, 8],
+          "enum": [
+            1,
+            2,
+            4,
+            8
+          ],
           "default": 1
         },
         "ttl": {
@@ -222,7 +263,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TenantEntity.schema.json",
-    "fileMatch": ["a://b/TenantEntity*.schema.json"],
+    "fileMatch": [
+      "a://b/TenantEntity*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TenantEntity.schema.json",
@@ -273,13 +316,20 @@
           }
         }
       },
-      "required": ["id", "name", "status", "clients"],
+      "required": [
+        "id",
+        "name",
+        "status",
+        "clients"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientEntity.schema.json",
-    "fileMatch": ["a://b/ClientEntity*.schema.json"],
+    "fileMatch": [
+      "a://b/ClientEntity*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientEntity.schema.json",
@@ -289,7 +339,10 @@
         "allowedPresentationConfigs": {
           "nullable": true,
           "description": "List of presentation config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": ["age-verification", "kyc-basic"],
+          "example": [
+            "age-verification",
+            "kyc-basic"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -298,7 +351,10 @@
         "allowedIssuanceConfigs": {
           "nullable": true,
           "description": "List of issuance config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": ["pid", "mdl"],
+          "example": [
+            "pid",
+            "mdl"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -346,13 +402,18 @@
           ]
         }
       },
-      "required": ["clientId", "roles"],
+      "required": [
+        "clientId",
+        "roles"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateTenantDto.schema.json",
-    "fileMatch": ["a://b/CreateTenantDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CreateTenantDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateTenantDto.schema.json",
@@ -406,13 +467,18 @@
           }
         }
       },
-      "required": ["id", "name"],
+      "required": [
+        "id",
+        "name"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateTenantDto.schema.json",
-    "fileMatch": ["a://b/UpdateTenantDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateTenantDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateTenantDto.schema.json",
@@ -467,7 +533,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuditLogResponseDto.schema.json",
-    "fileMatch": ["a://b/AuditLogResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/AuditLogResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuditLogResponseDto.schema.json",
@@ -504,7 +572,11 @@
           "type": "string"
         },
         "actorType": {
-          "enum": ["user", "client", "system"],
+          "enum": [
+            "user",
+            "client",
+            "system"
+          ],
           "type": "string"
         },
         "actorId": {
@@ -535,13 +607,21 @@
           "type": "string"
         }
       },
-      "required": ["id", "tenantId", "actionType", "actorType", "timestamp"],
+      "required": [
+        "id",
+        "tenantId",
+        "actionType",
+        "actorType",
+        "timestamp"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientSecretResponseDto.schema.json",
-    "fileMatch": ["a://b/ClientSecretResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ClientSecretResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientSecretResponseDto.schema.json",
@@ -552,13 +632,17 @@
           "type": "string"
         }
       },
-      "required": ["secret"],
+      "required": [
+        "secret"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateClientDto.schema.json",
-    "fileMatch": ["a://b/UpdateClientDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateClientDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateClientDto.schema.json",
@@ -568,7 +652,10 @@
         "allowedPresentationConfigs": {
           "nullable": true,
           "description": "List of presentation config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": ["age-verification", "kyc-basic"],
+          "example": [
+            "age-verification",
+            "kyc-basic"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -577,7 +664,10 @@
         "allowedIssuanceConfigs": {
           "nullable": true,
           "description": "List of issuance config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": ["pid", "mdl"],
+          "example": [
+            "pid",
+            "mdl"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -605,13 +695,17 @@
           }
         }
       },
-      "required": ["roles"],
+      "required": [
+        "roles"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateClientDto.schema.json",
-    "fileMatch": ["a://b/CreateClientDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CreateClientDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateClientDto.schema.json",
@@ -621,7 +715,10 @@
         "allowedPresentationConfigs": {
           "nullable": true,
           "description": "List of presentation config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": ["age-verification", "kyc-basic"],
+          "example": [
+            "age-verification",
+            "kyc-basic"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -630,7 +727,10 @@
         "allowedIssuanceConfigs": {
           "nullable": true,
           "description": "List of issuance config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": ["pid", "mdl"],
+          "example": [
+            "pid",
+            "mdl"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -666,13 +766,18 @@
           }
         }
       },
-      "required": ["clientId", "roles"],
+      "required": [
+        "clientId",
+        "roles"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListImportDto.schema.json",
-    "fileMatch": ["a://b/StatusListImportDto*.schema.json"],
+    "fileMatch": [
+      "a://b/StatusListImportDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListImportDto.schema.json",
@@ -702,18 +807,27 @@
         },
         "bits": {
           "description": "Bits per status value. If not provided, uses tenant or global defaults.",
-          "enum": [1, 2, 4, 8],
+          "enum": [
+            1,
+            2,
+            4,
+            8
+          ],
           "type": "number",
           "example": 1
         }
       },
-      "required": ["id"],
+      "required": [
+        "id"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListAggregationDto.schema.json",
-    "fileMatch": ["a://b/StatusListAggregationDto*.schema.json"],
+    "fileMatch": [
+      "a://b/StatusListAggregationDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListAggregationDto.schema.json",
@@ -732,13 +846,17 @@
           }
         }
       },
-      "required": ["status_lists"],
+      "required": [
+        "status_lists"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateStatusListConfigDto.schema.json",
-    "fileMatch": ["a://b/UpdateStatusListConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateStatusListConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateStatusListConfigDto.schema.json",
@@ -755,7 +873,12 @@
         "bits": {
           "nullable": true,
           "description": "Bits per status entry. Set to null to reset to global default.",
-          "enum": [1, 2, 4, 8],
+          "enum": [
+            1,
+            2,
+            4,
+            8
+          ],
           "type": "number"
         },
         "ttl": {
@@ -781,7 +904,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListResponseDto.schema.json",
-    "fileMatch": ["a://b/StatusListResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/StatusListResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListResponseDto.schema.json",
@@ -812,7 +937,12 @@
         },
         "bits": {
           "description": "Bits per status value",
-          "enum": [1, 2, 4, 8],
+          "enum": [
+            1,
+            2,
+            4,
+            8
+          ],
           "type": "number",
           "example": 1
         },
@@ -865,7 +995,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateStatusListDto.schema.json",
-    "fileMatch": ["a://b/CreateStatusListDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CreateStatusListDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateStatusListDto.schema.json",
@@ -884,7 +1016,12 @@
         },
         "bits": {
           "description": "Bits per status value. More bits allow more status states. Defaults to tenant configuration.",
-          "enum": [1, 2, 4, 8],
+          "enum": [
+            1,
+            2,
+            4,
+            8
+          ],
           "type": "number",
           "example": 1
         },
@@ -900,7 +1037,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateStatusListDto.schema.json",
-    "fileMatch": ["a://b/UpdateStatusListDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateStatusListDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateStatusListDto.schema.json",
@@ -925,7 +1064,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthorizeQueries.schema.json",
-    "fileMatch": ["a://b/AuthorizeQueries*.schema.json"],
+    "fileMatch": [
+      "a://b/AuthorizeQueries*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthorizeQueries.schema.json",
@@ -978,7 +1119,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/OfferRequestDto.schema.json",
-    "fileMatch": ["a://b/OfferRequestDto*.schema.json"],
+    "fileMatch": [
+      "a://b/OfferRequestDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/OfferRequestDto.schema.json",
@@ -986,7 +1129,10 @@
       "type": "object",
       "properties": {
         "response_type": {
-          "enum": ["uri", "dc-api"],
+          "enum": [
+            "uri",
+            "dc-api"
+          ],
           "type": "string",
           "examples": [
             {
@@ -1004,14 +1150,19 @@
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": ["inline"]
+                    "enum": [
+                      "inline"
+                    ]
                   },
                   "claims": {
                     "type": "object",
                     "additionalProperties": true
                   }
                 },
-                "required": ["type", "claims"],
+                "required": [
+                  "type",
+                  "claims"
+                ],
                 "additionalProperties": false
               },
               {
@@ -1019,13 +1170,18 @@
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": ["attributeProvider"]
+                    "enum": [
+                      "attributeProvider"
+                    ]
                   },
                   "attributeProviderId": {
                     "type": "string"
                   }
                 },
-                "required": ["type", "attributeProviderId"],
+                "required": [
+                  "type",
+                  "attributeProviderId"
+                ],
                 "additionalProperties": false
               },
               {
@@ -1033,7 +1189,9 @@
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": ["webhook"]
+                    "enum": [
+                      "webhook"
+                    ]
                   },
                   "webhook": {
                     "type": "object",
@@ -1045,11 +1203,16 @@
                         "type": "object"
                       }
                     },
-                    "required": ["url"],
+                    "required": [
+                      "url"
+                    ],
                     "additionalProperties": false
                   }
                 },
-                "required": ["type", "webhook"],
+                "required": [
+                  "type",
+                  "webhook"
+                ],
                 "additionalProperties": false
               }
             ]
@@ -1067,7 +1230,10 @@
         },
         "flow": {
           "description": "The flow type for the offer request.",
-          "enum": ["authorization_code", "pre_authorized_code"],
+          "enum": [
+            "authorization_code",
+            "pre_authorized_code"
+          ],
           "type": "string"
         },
         "tx_code": {
@@ -1094,13 +1260,19 @@
           "description": "ID of the webhook endpoint to notify about the status of the issuance process."
         }
       },
-      "required": ["response_type", "flow", "credentialConfigurationIds"],
+      "required": [
+        "response_type",
+        "flow",
+        "credentialConfigurationIds"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebHookAuthConfigNone.schema.json",
-    "fileMatch": ["a://b/WebHookAuthConfigNone*.schema.json"],
+    "fileMatch": [
+      "a://b/WebHookAuthConfigNone*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebHookAuthConfigNone.schema.json",
@@ -1110,16 +1282,22 @@
         "type": {
           "type": "string",
           "description": "The type of authentication used for the webhook.",
-          "enum": ["none"]
+          "enum": [
+            "none"
+          ]
         }
       },
-      "required": ["type"],
+      "required": [
+        "type"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ApiKeyConfig.schema.json",
-    "fileMatch": ["a://b/ApiKeyConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/ApiKeyConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ApiKeyConfig.schema.json",
@@ -1135,13 +1313,18 @@
           "description": "The value of the API key to be sent in the header."
         }
       },
-      "required": ["headerName", "value"],
+      "required": [
+        "headerName",
+        "value"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebHookAuthConfigHeader.schema.json",
-    "fileMatch": ["a://b/WebHookAuthConfigHeader*.schema.json"],
+    "fileMatch": [
+      "a://b/WebHookAuthConfigHeader*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebHookAuthConfigHeader.schema.json",
@@ -1151,7 +1334,9 @@
         "type": {
           "type": "string",
           "description": "The type of authentication used for the webhook.",
-          "enum": ["apiKey"]
+          "enum": [
+            "apiKey"
+          ]
         },
         "config": {
           "description": "Configuration for API key authentication.\nThis is required if the type is 'apiKey'.",
@@ -1162,13 +1347,18 @@
           ]
         }
       },
-      "required": ["type", "config"],
+      "required": [
+        "type",
+        "config"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebhookConfig.schema.json",
-    "fileMatch": ["a://b/WebhookConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/WebhookConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebhookConfig.schema.json",
@@ -1198,13 +1388,18 @@
           "description": "The URL to which the webhook will send notifications."
         }
       },
-      "required": ["auth", "url"],
+      "required": [
+        "auth",
+        "url"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TransactionData.schema.json",
-    "fileMatch": ["a://b/TransactionData*.schema.json"],
+    "fileMatch": [
+      "a://b/TransactionData*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TransactionData.schema.json",
@@ -1221,13 +1416,18 @@
           }
         }
       },
-      "required": ["type", "credential_ids"],
+      "required": [
+        "type",
+        "credential_ids"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Session.schema.json",
-    "fileMatch": ["a://b/Session*.schema.json"],
+    "fileMatch": [
+      "a://b/Session*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Session.schema.json",
@@ -1236,7 +1436,13 @@
       "properties": {
         "status": {
           "description": "Status of the session.",
-          "enum": ["active", "fetched", "completed", "expired", "failed"],
+          "enum": [
+            "active",
+            "fetched",
+            "completed",
+            "expired",
+            "failed"
+          ],
           "type": "string"
         },
         "id": {
@@ -1426,7 +1632,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PaginatedSessionResponseDto.schema.json",
-    "fileMatch": ["a://b/PaginatedSessionResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/PaginatedSessionResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PaginatedSessionResponseDto.schema.json",
@@ -1457,13 +1665,21 @@
           "description": "Total number of pages"
         }
       },
-      "required": ["items", "total", "page", "pageSize", "totalPages"],
+      "required": [
+        "items",
+        "total",
+        "page",
+        "pageSize",
+        "totalPages"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SessionLogEntryResponseDto.schema.json",
-    "fileMatch": ["a://b/SessionLogEntryResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/SessionLogEntryResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SessionLogEntryResponseDto.schema.json",
@@ -1486,7 +1702,11 @@
         "level": {
           "type": "string",
           "description": "Log level",
-          "enum": ["info", "warn", "error"]
+          "enum": [
+            "info",
+            "warn",
+            "error"
+          ]
         },
         "stage": {
           "type": "string",
@@ -1502,13 +1722,21 @@
           "description": "Additional structured detail"
         }
       },
-      "required": ["id", "sessionId", "timestamp", "level", "message"],
+      "required": [
+        "id",
+        "sessionId",
+        "timestamp",
+        "level",
+        "message"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusUpdateDto.schema.json",
-    "fileMatch": ["a://b/StatusUpdateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/StatusUpdateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusUpdateDto.schema.json",
@@ -1528,13 +1756,18 @@
           "description": "The status of the credential\n0 = valid, 1 = revoked, 2 = suspended"
         }
       },
-      "required": ["sessionId", "status"],
+      "required": [
+        "sessionId",
+        "status"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateSessionConfigDto.schema.json",
-    "fileMatch": ["a://b/UpdateSessionConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateSessionConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateSessionConfigDto.schema.json",
@@ -1550,7 +1783,10 @@
         },
         "cleanupMode": {
           "description": "Cleanup mode: 'full' deletes everything, 'anonymize' keeps metadata but removes PII.",
-          "enum": ["full", "anonymize"],
+          "enum": [
+            "full",
+            "anonymize"
+          ],
           "type": "string",
           "default": "full"
         }
@@ -1560,7 +1796,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ManagedUserDto.schema.json",
-    "fileMatch": ["a://b/ManagedUserDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ManagedUserDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ManagedUserDto.schema.json",
@@ -1609,13 +1847,20 @@
           "description": "One-time temporary password returned only on user creation."
         }
       },
-      "required": ["id", "username", "enabled", "roles"],
+      "required": [
+        "id",
+        "username",
+        "enabled",
+        "roles"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateUserDto.schema.json",
-    "fileMatch": ["a://b/CreateUserDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CreateUserDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateUserDto.schema.json",
@@ -1657,13 +1902,18 @@
           "example": true
         }
       },
-      "required": ["username", "roles"],
+      "required": [
+        "username",
+        "roles"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateUserDto.schema.json",
-    "fileMatch": ["a://b/UpdateUserDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateUserDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateUserDto.schema.json",
@@ -1715,7 +1965,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodNone.schema.json",
-    "fileMatch": ["a://b/AuthenticationMethodNone*.schema.json"],
+    "fileMatch": [
+      "a://b/AuthenticationMethodNone*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodNone.schema.json",
@@ -1724,16 +1976,22 @@
       "properties": {
         "method": {
           "type": "string",
-          "enum": ["none"]
+          "enum": [
+            "none"
+          ]
         }
       },
-      "required": ["method"],
+      "required": [
+        "method"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationUrlConfig.schema.json",
-    "fileMatch": ["a://b/AuthenticationUrlConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/AuthenticationUrlConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationUrlConfig.schema.json",
@@ -1753,13 +2011,17 @@
           ]
         }
       },
-      "required": ["url"],
+      "required": [
+        "url"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodAuth.schema.json",
-    "fileMatch": ["a://b/AuthenticationMethodAuth*.schema.json"],
+    "fileMatch": [
+      "a://b/AuthenticationMethodAuth*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodAuth.schema.json",
@@ -1768,19 +2030,26 @@
       "properties": {
         "method": {
           "type": "string",
-          "enum": ["auth"]
+          "enum": [
+            "auth"
+          ]
         },
         "config": {
           "$ref": "./AuthenticationUrlConfig.schema.json"
         }
       },
-      "required": ["method", "config"],
+      "required": [
+        "method",
+        "config"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationDuringIssuanceConfig.schema.json",
-    "fileMatch": ["a://b/PresentationDuringIssuanceConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/PresentationDuringIssuanceConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationDuringIssuanceConfig.schema.json",
@@ -1792,13 +2061,17 @@
           "description": "Link to the presentation configuration that is relevant for the issuance process"
         }
       },
-      "required": ["type"],
+      "required": [
+        "type"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodPresentation.schema.json",
-    "fileMatch": ["a://b/AuthenticationMethodPresentation*.schema.json"],
+    "fileMatch": [
+      "a://b/AuthenticationMethodPresentation*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodPresentation.schema.json",
@@ -1807,19 +2080,26 @@
       "properties": {
         "method": {
           "type": "string",
-          "enum": ["presentationDuringIssuance"]
+          "enum": [
+            "presentationDuringIssuance"
+          ]
         },
         "config": {
           "$ref": "./PresentationDuringIssuanceConfig.schema.json"
         }
       },
-      "required": ["method", "config"],
+      "required": [
+        "method",
+        "config"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpstreamOidcConfig.schema.json",
-    "fileMatch": ["a://b/UpstreamOidcConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/UpstreamOidcConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpstreamOidcConfig.schema.json",
@@ -1843,20 +2123,28 @@
         },
         "scopes": {
           "description": "Scopes to request from the upstream provider",
-          "default": ["openid", "profile"],
+          "default": [
+            "openid",
+            "profile"
+          ],
           "type": "array",
           "items": {
             "type": "string"
           }
         }
       },
-      "required": ["issuer", "clientId"],
+      "required": [
+        "issuer",
+        "clientId"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenConfig.schema.json",
-    "fileMatch": ["a://b/ChainedAsTokenConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/ChainedAsTokenConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenConfig.schema.json",
@@ -1890,7 +2178,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ManagedAuthorizationServerConfig.schema.json",
-    "fileMatch": ["a://b/ManagedAuthorizationServerConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/ManagedAuthorizationServerConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ManagedAuthorizationServerConfig.schema.json",
@@ -1908,7 +2198,12 @@
           "example": "PID Authorization Server"
         },
         "type": {
-          "enum": ["external", "oid4vp", "chained"],
+          "enum": [
+            "external",
+            "oid4vp",
+            "chained",
+            "built-in"
+          ],
           "type": "string",
           "description": "Authorization server implementation type",
           "example": "external"
@@ -1956,13 +2251,17 @@
           "default": false
         }
       },
-      "required": ["type"],
+      "required": [
+        "type"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FederationTrustAnchorConfig.schema.json",
-    "fileMatch": ["a://b/FederationTrustAnchorConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/FederationTrustAnchorConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FederationTrustAnchorConfig.schema.json",
@@ -1980,13 +2279,18 @@
           "example": "https://ta.example.org/.well-known/openid-federation"
         }
       },
-      "required": ["entityId", "entityConfigurationUri"],
+      "required": [
+        "entityId",
+        "entityConfigurationUri"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FederationConfig.schema.json",
-    "fileMatch": ["a://b/FederationConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/FederationConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FederationConfig.schema.json",
@@ -1994,13 +2298,20 @@
       "type": "object",
       "properties": {
         "role": {
-          "enum": ["trust_anchor", "intermediate", "leaf"],
+          "enum": [
+            "trust_anchor",
+            "intermediate",
+            "leaf"
+          ],
           "type": "string",
           "description": "Role this tenant plays in the OpenID Federation topology.",
           "default": "leaf"
         },
         "mode": {
-          "enum": ["federation-only", "hybrid"],
+          "enum": [
+            "federation-only",
+            "hybrid"
+          ],
           "type": "string",
           "description": "Trust decision strategy when both LoTE trust lists and OpenID Federation are configured.",
           "default": "hybrid"
@@ -2028,13 +2339,17 @@
           }
         }
       },
-      "required": ["trustAnchors"],
+      "required": [
+        "trustAnchors"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerProvidedAttestation.schema.json",
-    "fileMatch": ["a://b/IssuerProvidedAttestation*.schema.json"],
+    "fileMatch": [
+      "a://b/IssuerProvidedAttestation*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerProvidedAttestation.schema.json",
@@ -2057,7 +2372,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerRegistrationCertificateConfig.schema.json",
-    "fileMatch": ["a://b/IssuerRegistrationCertificateConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/IssuerRegistrationCertificateConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerRegistrationCertificateConfig.schema.json",
@@ -2070,7 +2387,10 @@
           "default": false
         },
         "mode": {
-          "enum": ["import", "generate"],
+          "enum": [
+            "import",
+            "generate"
+          ],
           "type": "string",
           "description": "import: use an existing JWT, generate: create via registrar from provided attestations and selected credential configurations.",
           "default": "import"
@@ -2109,7 +2429,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerRegistrationCertificateCache.schema.json",
-    "fileMatch": ["a://b/IssuerRegistrationCertificateCache*.schema.json"],
+    "fileMatch": [
+      "a://b/IssuerRegistrationCertificateCache*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerRegistrationCertificateCache.schema.json",
@@ -2142,7 +2464,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayLogo.schema.json",
-    "fileMatch": ["a://b/DisplayLogo*.schema.json"],
+    "fileMatch": [
+      "a://b/DisplayLogo*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayLogo.schema.json",
@@ -2156,13 +2480,17 @@
           "type": "string"
         }
       },
-      "required": ["uri"],
+      "required": [
+        "uri"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayInfo.schema.json",
-    "fileMatch": ["a://b/DisplayInfo*.schema.json"],
+    "fileMatch": [
+      "a://b/DisplayInfo*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayInfo.schema.json",
@@ -2184,7 +2512,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuanceConfig.schema.json",
-    "fileMatch": ["a://b/IssuanceConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/IssuanceConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuanceConfig.schema.json",
@@ -2294,13 +2624,20 @@
           "description": "The timestamp when the VP request was last updated."
         }
       },
-      "required": ["tenant", "display", "createdAt", "updatedAt"],
+      "required": [
+        "tenant",
+        "display",
+        "createdAt",
+        "updatedAt"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuanceDto.schema.json",
-    "fileMatch": ["a://b/IssuanceDto*.schema.json"],
+    "fileMatch": [
+      "a://b/IssuanceDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuanceDto.schema.json",
@@ -2392,13 +2729,17 @@
           }
         }
       },
-      "required": ["display"],
+      "required": [
+        "display"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClaimsQuery.schema.json",
-    "fileMatch": ["a://b/ClaimsQuery*.schema.json"],
+    "fileMatch": [
+      "a://b/ClaimsQuery*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClaimsQuery.schema.json",
@@ -2421,13 +2762,17 @@
           }
         }
       },
-      "required": ["path"],
+      "required": [
+        "path"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustedAuthorityQuery.schema.json",
-    "fileMatch": ["a://b/TrustedAuthorityQuery*.schema.json"],
+    "fileMatch": [
+      "a://b/TrustedAuthorityQuery*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustedAuthorityQuery.schema.json",
@@ -2436,7 +2781,10 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["etsi_tl", "openid_federation"]
+          "enum": [
+            "etsi_tl",
+            "openid_federation"
+          ]
         },
         "values": {
           "type": "array",
@@ -2445,13 +2793,18 @@
           }
         }
       },
-      "required": ["type", "values"],
+      "required": [
+        "type",
+        "values"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialQuery.schema.json",
-    "fileMatch": ["a://b/CredentialQuery*.schema.json"],
+    "fileMatch": [
+      "a://b/CredentialQuery*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialQuery.schema.json",
@@ -2494,13 +2847,19 @@
           }
         }
       },
-      "required": ["id", "format", "meta"],
+      "required": [
+        "id",
+        "format",
+        "meta"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialSetQuery.schema.json",
-    "fileMatch": ["a://b/CredentialSetQuery*.schema.json"],
+    "fileMatch": [
+      "a://b/CredentialSetQuery*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialSetQuery.schema.json",
@@ -2520,13 +2879,17 @@
           "type": "boolean"
         }
       },
-      "required": ["options"],
+      "required": [
+        "options"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PolicyCredential.schema.json",
-    "fileMatch": ["a://b/PolicyCredential*.schema.json"],
+    "fileMatch": [
+      "a://b/PolicyCredential*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PolicyCredential.schema.json",
@@ -2552,13 +2915,17 @@
           }
         }
       },
-      "required": ["credentials"],
+      "required": [
+        "credentials"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AttestationBasedPolicy.schema.json",
-    "fileMatch": ["a://b/AttestationBasedPolicy*.schema.json"],
+    "fileMatch": [
+      "a://b/AttestationBasedPolicy*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AttestationBasedPolicy.schema.json",
@@ -2567,7 +2934,9 @@
       "properties": {
         "policy": {
           "type": "string",
-          "enum": ["attestationBased"]
+          "enum": [
+            "attestationBased"
+          ]
         },
         "values": {
           "type": "array",
@@ -2576,13 +2945,18 @@
           }
         }
       },
-      "required": ["policy", "values"],
+      "required": [
+        "policy",
+        "values"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/NoneTrustPolicy.schema.json",
-    "fileMatch": ["a://b/NoneTrustPolicy*.schema.json"],
+    "fileMatch": [
+      "a://b/NoneTrustPolicy*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/NoneTrustPolicy.schema.json",
@@ -2591,16 +2965,22 @@
       "properties": {
         "policy": {
           "type": "string",
-          "enum": ["none"]
+          "enum": [
+            "none"
+          ]
         }
       },
-      "required": ["policy"],
+      "required": [
+        "policy"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AllowListPolicy.schema.json",
-    "fileMatch": ["a://b/AllowListPolicy*.schema.json"],
+    "fileMatch": [
+      "a://b/AllowListPolicy*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AllowListPolicy.schema.json",
@@ -2609,7 +2989,9 @@
       "properties": {
         "policy": {
           "type": "string",
-          "enum": ["allowList"]
+          "enum": [
+            "allowList"
+          ]
         },
         "values": {
           "type": "array",
@@ -2618,13 +3000,18 @@
           }
         }
       },
-      "required": ["policy", "values"],
+      "required": [
+        "policy",
+        "values"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RootOfTrustPolicy.schema.json",
-    "fileMatch": ["a://b/RootOfTrustPolicy*.schema.json"],
+    "fileMatch": [
+      "a://b/RootOfTrustPolicy*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RootOfTrustPolicy.schema.json",
@@ -2633,19 +3020,26 @@
       "properties": {
         "policy": {
           "type": "string",
-          "enum": ["rootOfTrust"]
+          "enum": [
+            "rootOfTrust"
+          ]
         },
         "values": {
           "type": "string"
         }
       },
-      "required": ["policy", "values"],
+      "required": [
+        "policy",
+        "values"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/VCT.schema.json",
-    "fileMatch": ["a://b/VCT*.schema.json"],
+    "fileMatch": [
+      "a://b/VCT*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/VCT.schema.json",
@@ -2679,7 +3073,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IaeActionOpenid4vpPresentation.schema.json",
-    "fileMatch": ["a://b/IaeActionOpenid4vpPresentation*.schema.json"],
+    "fileMatch": [
+      "a://b/IaeActionOpenid4vpPresentation*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IaeActionOpenid4vpPresentation.schema.json",
@@ -2687,7 +3083,9 @@
       "type": "object",
       "properties": {
         "type": {
-          "enum": ["openid4vp_presentation"],
+          "enum": [
+            "openid4vp_presentation"
+          ],
           "type": "string",
           "description": "Action type discriminator",
           "example": "openid4vp_presentation"
@@ -2703,13 +3101,18 @@
           "example": "pid-presentation-config"
         }
       },
-      "required": ["type", "presentationConfigId"],
+      "required": [
+        "type",
+        "presentationConfigId"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IaeActionRedirectToWeb.schema.json",
-    "fileMatch": ["a://b/IaeActionRedirectToWeb*.schema.json"],
+    "fileMatch": [
+      "a://b/IaeActionRedirectToWeb*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IaeActionRedirectToWeb.schema.json",
@@ -2717,7 +3120,9 @@
       "type": "object",
       "properties": {
         "type": {
-          "enum": ["redirect_to_web"],
+          "enum": [
+            "redirect_to_web"
+          ],
           "type": "string",
           "description": "Action type discriminator",
           "example": "redirect_to_web"
@@ -2745,13 +3150,18 @@
           "example": "Please complete the identity verification form"
         }
       },
-      "required": ["type", "url"],
+      "required": [
+        "type",
+        "url"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebhookEndpointEntity.schema.json",
-    "fileMatch": ["a://b/WebhookEndpointEntity*.schema.json"],
+    "fileMatch": [
+      "a://b/WebhookEndpointEntity*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebhookEndpointEntity.schema.json",
@@ -2789,13 +3199,22 @@
           "type": "string"
         }
       },
-      "required": ["id", "auth", "tenantId", "tenant", "name", "url"],
+      "required": [
+        "id",
+        "auth",
+        "tenantId",
+        "tenant",
+        "name",
+        "url"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaUriEntry.schema.json",
-    "fileMatch": ["a://b/SchemaUriEntry*.schema.json"],
+    "fileMatch": [
+      "a://b/SchemaUriEntry*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaUriEntry.schema.json",
@@ -2827,7 +3246,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustAuthorityEntry.schema.json",
-    "fileMatch": ["a://b/TrustAuthorityEntry*.schema.json"],
+    "fileMatch": [
+      "a://b/TrustAuthorityEntry*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustAuthorityEntry.schema.json",
@@ -2839,7 +3260,11 @@
           "description": "Trust list ID to resolve from the database. When set, frameworkType, value, and verificationMethod are derived automatically."
         },
         "frameworkType": {
-          "enum": ["aki", "etsi_tl", "openid_federation"],
+          "enum": [
+            "aki",
+            "etsi_tl",
+            "openid_federation"
+          ],
           "type": "string",
           "description": "Trust framework type (ignored when trustListId is set)"
         },
@@ -2870,7 +3295,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetaConfig.schema.json",
-    "fileMatch": ["a://b/SchemaMetaConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/SchemaMetaConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetaConfig.schema.json",
@@ -2903,7 +3330,12 @@
           "description": "Attestation Level of Security"
         },
         "bindingType": {
-          "enum": ["claim", "key", "biometric", "none"],
+          "enum": [
+            "claim",
+            "key",
+            "biometric",
+            "none"
+          ],
           "type": "string",
           "description": "Cryptographic binding type"
         },
@@ -2927,7 +3359,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EmbeddedDisclosurePolicy.schema.json",
-    "fileMatch": ["a://b/EmbeddedDisclosurePolicy*.schema.json"],
+    "fileMatch": [
+      "a://b/EmbeddedDisclosurePolicy*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EmbeddedDisclosurePolicy.schema.json",
@@ -2938,13 +3372,17 @@
           "type": "string"
         }
       },
-      "required": ["policy"],
+      "required": [
+        "policy"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyAttestationsRequired.schema.json",
-    "fileMatch": ["a://b/KeyAttestationsRequired*.schema.json"],
+    "fileMatch": [
+      "a://b/KeyAttestationsRequired*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyAttestationsRequired.schema.json",
@@ -2953,7 +3391,10 @@
       "properties": {
         "key_storage": {
           "description": "List of required key storage types (e.g., iso_18045_high, iso_18045_moderate)",
-          "example": ["iso_18045_high", "iso_18045_moderate"],
+          "example": [
+            "iso_18045_high",
+            "iso_18045_moderate"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -2961,7 +3402,10 @@
         },
         "user_authentication": {
           "description": "List of required user authentication types (e.g., iso_18045_high, iso_18045_moderate)",
-          "example": ["iso_18045_high", "iso_18045_moderate"],
+          "example": [
+            "iso_18045_high",
+            "iso_18045_moderate"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -2973,7 +3417,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayImage.schema.json",
-    "fileMatch": ["a://b/DisplayImage*.schema.json"],
+    "fileMatch": [
+      "a://b/DisplayImage*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayImage.schema.json",
@@ -2984,13 +3430,17 @@
           "type": "string"
         }
       },
-      "required": ["uri"],
+      "required": [
+        "uri"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Display.schema.json",
-    "fileMatch": ["a://b/Display*.schema.json"],
+    "fileMatch": [
+      "a://b/Display*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Display.schema.json",
@@ -3019,13 +3469,19 @@
           "$ref": "./DisplayImage.schema.json"
         }
       },
-      "required": ["name", "description", "locale"],
+      "required": [
+        "name",
+        "description",
+        "locale"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerMetadataCredentialConfig.schema.json",
-    "fileMatch": ["a://b/IssuerMetadataCredentialConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/IssuerMetadataCredentialConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerMetadataCredentialConfig.schema.json",
@@ -3042,7 +3498,10 @@
         },
         "format": {
           "type": "string",
-          "enum": ["mso_mdoc", "dc+sd-jwt"]
+          "enum": [
+            "mso_mdoc",
+            "dc+sd-jwt"
+          ]
         },
         "display": {
           "type": "array",
@@ -3058,13 +3517,18 @@
           "description": "Document type for mDOC credentials (e.g., \"org.iso.18013.5.1.mDL\").\nOnly applicable when format is \"mso_mdoc\"."
         }
       },
-      "required": ["format", "display"],
+      "required": [
+        "format",
+        "display"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FieldDisplayDto.schema.json",
-    "fileMatch": ["a://b/FieldDisplayDto*.schema.json"],
+    "fileMatch": [
+      "a://b/FieldDisplayDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FieldDisplayDto.schema.json",
@@ -3087,13 +3551,18 @@
           "example": "Primary first name"
         }
       },
-      "required": ["locale", "name"],
+      "required": [
+        "locale",
+        "name"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClaimFieldDefinitionDto.schema.json",
-    "fileMatch": ["a://b/ClaimFieldDefinitionDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ClaimFieldDefinitionDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClaimFieldDefinitionDto.schema.json",
@@ -3103,7 +3572,10 @@
         "path": {
           "type": "array",
           "description": "Path to claim value. For nested child fields this can be relative to the parent path.",
-          "example": ["address", "locality"],
+          "example": [
+            "address",
+            "locality"
+          ],
           "items": {
             "oneOf": [
               {
@@ -3119,7 +3591,14 @@
           }
         },
         "type": {
-          "enum": ["string", "number", "integer", "boolean", "object", "array"],
+          "enum": [
+            "string",
+            "number",
+            "integer",
+            "boolean",
+            "object",
+            "array"
+          ],
           "type": "string",
           "description": "Claim value type"
         },
@@ -3180,13 +3659,18 @@
           }
         }
       },
-      "required": ["path", "type"],
+      "required": [
+        "path",
+        "type"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AttributeProviderEntity.schema.json",
-    "fileMatch": ["a://b/AttributeProviderEntity*.schema.json"],
+    "fileMatch": [
+      "a://b/AttributeProviderEntity*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AttributeProviderEntity.schema.json",
@@ -3223,13 +3707,22 @@
           "type": "string"
         }
       },
-      "required": ["auth", "id", "tenantId", "tenant", "name", "url"],
+      "required": [
+        "auth",
+        "id",
+        "tenantId",
+        "tenant",
+        "name",
+        "url"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainEntity.schema.json",
-    "fileMatch": ["a://b/KeyChainEntity*.schema.json"],
+    "fileMatch": [
+      "a://b/KeyChainEntity*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainEntity.schema.json",
@@ -3259,12 +3752,21 @@
         "usageType": {
           "type": "string",
           "description": "The purpose/role of this key chain in the system.",
-          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"]
+          "enum": [
+            "access",
+            "attestation",
+            "trustList",
+            "statusList",
+            "encrypt"
+          ]
         },
         "usage": {
           "type": "string",
           "description": "The usage type of the keys (sign or encrypt).",
-          "enum": ["sign", "encrypt"]
+          "enum": [
+            "sign",
+            "encrypt"
+          ]
         },
         "kmsProvider": {
           "type": "string",
@@ -3344,7 +3846,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfig.schema.json",
-    "fileMatch": ["a://b/CredentialConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/CredentialConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfig.schema.json",
@@ -3471,20 +3975,30 @@
         "sdJwtTrustFormat": {
           "nullable": true,
           "description": "For SD-JWT credentials: determines whether to include certificate chain (x5c)\nor use federation-based trust (iss claim).\nDefault: \"x5c\" (federation must be explicitly selected)",
-          "enum": ["x5c", "federation"],
+          "enum": [
+            "x5c",
+            "federation"
+          ],
           "type": "string"
         },
         "lifeTime": {
           "type": "number"
         }
       },
-      "required": ["id", "tenant", "config", "fields"],
+      "required": [
+        "id",
+        "tenant",
+        "config",
+        "fields"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfigCreate.schema.json",
-    "fileMatch": ["a://b/CredentialConfigCreate*.schema.json"],
+    "fileMatch": [
+      "a://b/CredentialConfigCreate*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfigCreate.schema.json",
@@ -3594,20 +4108,29 @@
         "sdJwtTrustFormat": {
           "nullable": true,
           "description": "For SD-JWT credentials: determines whether to include certificate chain (x5c)\nor use federation-based trust (iss claim).\nDefault: \"x5c\" (federation must be explicitly selected)",
-          "enum": ["x5c", "federation"],
+          "enum": [
+            "x5c",
+            "federation"
+          ],
           "type": "string"
         },
         "lifeTime": {
           "type": "number"
         }
       },
-      "required": ["id", "config", "fields"],
+      "required": [
+        "id",
+        "config",
+        "fields"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfigUpdate.schema.json",
-    "fileMatch": ["a://b/CredentialConfigUpdate*.schema.json"],
+    "fileMatch": [
+      "a://b/CredentialConfigUpdate*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfigUpdate.schema.json",
@@ -3717,7 +4240,10 @@
         "sdJwtTrustFormat": {
           "nullable": true,
           "description": "For SD-JWT credentials: determines whether to include certificate chain (x5c)\nor use federation-based trust (iss claim).\nDefault: \"x5c\" (federation must be explicitly selected)",
-          "enum": ["x5c", "federation"],
+          "enum": [
+            "x5c",
+            "federation"
+          ],
           "type": "string"
         },
         "lifeTime": {
@@ -3729,7 +4255,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SignSchemaMetaConfigDto.schema.json",
-    "fileMatch": ["a://b/SignSchemaMetaConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/SignSchemaMetaConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SignSchemaMetaConfigDto.schema.json",
@@ -3753,13 +4281,17 @@
           "description": "ID of the credential config to link back after submission. When provided, schemaMeta.id on the credential config is updated with the reserved attestation ID."
         }
       },
-      "required": ["config"],
+      "required": [
+        "config"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SignVersionSchemaMetaConfigDto.schema.json",
-    "fileMatch": ["a://b/SignVersionSchemaMetaConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/SignVersionSchemaMetaConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SignVersionSchemaMetaConfigDto.schema.json",
@@ -3779,13 +4311,17 @@
           "description": "ID of the key chain to use for signing. Defaults to the tenant's default key chain."
         }
       },
-      "required": ["config"],
+      "required": [
+        "config"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/VocabularyEntryDto.schema.json",
-    "fileMatch": ["a://b/VocabularyEntryDto*.schema.json"],
+    "fileMatch": [
+      "a://b/VocabularyEntryDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/VocabularyEntryDto.schema.json",
@@ -3801,7 +4337,10 @@
           "description": "Display label for UI rendering."
         },
         "status": {
-          "enum": ["active", "deprecated"],
+          "enum": [
+            "active",
+            "deprecated"
+          ],
           "type": "string",
           "description": "Vocabulary lifecycle status."
         },
@@ -3810,13 +4349,19 @@
           "description": "Replacement code when status is deprecated."
         }
       },
-      "required": ["code", "label", "status"],
+      "required": [
+        "code",
+        "label",
+        "status"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetadataVocabulariesDto.schema.json",
-    "fileMatch": ["a://b/SchemaMetadataVocabulariesDto*.schema.json"],
+    "fileMatch": [
+      "a://b/SchemaMetadataVocabulariesDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetadataVocabulariesDto.schema.json",
@@ -3842,13 +4387,19 @@
           }
         }
       },
-      "required": ["version", "categories", "tags"],
+      "required": [
+        "version",
+        "categories",
+        "tags"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/MetadataSchemaDto.schema.json",
-    "fileMatch": ["a://b/MetadataSchemaDto*.schema.json"],
+    "fileMatch": [
+      "a://b/MetadataSchemaDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/MetadataSchemaDto.schema.json",
@@ -3860,7 +4411,10 @@
           "description": "Unique identifier for this schema entry"
         },
         "formatIdentifier": {
-          "enum": ["dc+sd-jwt", "mso_mdoc"],
+          "enum": [
+            "dc+sd-jwt",
+            "mso_mdoc"
+          ],
           "type": "string",
           "description": "The credential format identifier"
         },
@@ -3878,13 +4432,18 @@
           "description": "Subresource Integrity hash for the schema"
         }
       },
-      "required": ["id", "formatIdentifier"],
+      "required": [
+        "id",
+        "formatIdentifier"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustAuthorityDto.schema.json",
-    "fileMatch": ["a://b/TrustAuthorityDto*.schema.json"],
+    "fileMatch": [
+      "a://b/TrustAuthorityDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustAuthorityDto.schema.json",
@@ -3898,7 +4457,9 @@
         "frameworkType": {
           "type": "string",
           "description": "Type of trust framework",
-          "enum": ["etsi_tl"]
+          "enum": [
+            "etsi_tl"
+          ]
         },
         "value": {
           "type": "string",
@@ -3910,13 +4471,19 @@
           "description": "Verification method for the trust list signature (e.g., JWK)"
         }
       },
-      "required": ["id", "frameworkType", "value"],
+      "required": [
+        "id",
+        "frameworkType",
+        "value"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AccessCertificateRefDto.schema.json",
-    "fileMatch": ["a://b/AccessCertificateRefDto*.schema.json"],
+    "fileMatch": [
+      "a://b/AccessCertificateRefDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AccessCertificateRefDto.schema.json",
@@ -3939,13 +4506,21 @@
           "type": "string"
         }
       },
-      "required": ["id", "relyingPartyId", "certificate", "revoked", "createdAt"],
+      "required": [
+        "id",
+        "relyingPartyId",
+        "certificate",
+        "revoked",
+        "createdAt"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetadataResponseDto.schema.json",
-    "fileMatch": ["a://b/SchemaMetadataResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/SchemaMetadataResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetadataResponseDto.schema.json",
@@ -3979,7 +4554,12 @@
           "description": "Level of security (LoS) of this attestation"
         },
         "bindingType": {
-          "enum": ["claim", "key", "biometric", "none"],
+          "enum": [
+            "claim",
+            "key",
+            "biometric",
+            "none"
+          ],
           "type": "string",
           "description": "Required binding type between attestation and holder"
         },
@@ -3987,7 +4567,10 @@
           "type": "array",
           "items": {
             "type": "string",
-            "enum": ["dc+sd-jwt", "mso_mdoc"]
+            "enum": [
+              "dc+sd-jwt",
+              "mso_mdoc"
+            ]
           },
           "description": "Credential formats in which this attestation is available"
         },
@@ -4006,7 +4589,15 @@
           }
         },
         "category": {
-          "enum": ["identity", "health", "finance", "education", "mobility", "employment", "other"],
+          "enum": [
+            "identity",
+            "health",
+            "finance",
+            "education",
+            "mobility",
+            "employment",
+            "other"
+          ],
           "type": "string",
           "description": "Domain category for filtering"
         },
@@ -4082,7 +4673,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateSchemaMetadataDto.schema.json",
-    "fileMatch": ["a://b/UpdateSchemaMetadataDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateSchemaMetadataDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateSchemaMetadataDto.schema.json",
@@ -4090,7 +4683,15 @@
       "type": "object",
       "properties": {
         "category": {
-          "enum": ["identity", "health", "finance", "education", "mobility", "employment", "other"],
+          "enum": [
+            "identity",
+            "health",
+            "finance",
+            "education",
+            "mobility",
+            "employment",
+            "other"
+          ],
           "type": "string",
           "description": "Domain category for filtering"
         },
@@ -4119,7 +4720,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeprecateSchemaMetadataDto.schema.json",
-    "fileMatch": ["a://b/DeprecateSchemaMetadataDto*.schema.json"],
+    "fileMatch": [
+      "a://b/DeprecateSchemaMetadataDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeprecateSchemaMetadataDto.schema.json",
@@ -4139,13 +4742,17 @@
           "description": "The version that supersedes this one"
         }
       },
-      "required": ["deprecated"],
+      "required": [
+        "deprecated"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateAttributeProviderDto.schema.json",
-    "fileMatch": ["a://b/CreateAttributeProviderDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CreateAttributeProviderDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateAttributeProviderDto.schema.json",
@@ -4176,13 +4783,20 @@
           "type": "string"
         }
       },
-      "required": ["auth", "id", "name", "url"],
+      "required": [
+        "auth",
+        "id",
+        "name",
+        "url"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateAttributeProviderDto.schema.json",
-    "fileMatch": ["a://b/UpdateAttributeProviderDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateAttributeProviderDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateAttributeProviderDto.schema.json",
@@ -4218,7 +4832,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateWebhookEndpointDto.schema.json",
-    "fileMatch": ["a://b/CreateWebhookEndpointDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CreateWebhookEndpointDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateWebhookEndpointDto.schema.json",
@@ -4250,13 +4866,20 @@
           "type": "string"
         }
       },
-      "required": ["id", "auth", "name", "url"],
+      "required": [
+        "id",
+        "auth",
+        "name",
+        "url"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateWebhookEndpointDto.schema.json",
-    "fileMatch": ["a://b/UpdateWebhookEndpointDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateWebhookEndpointDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateWebhookEndpointDto.schema.json",
@@ -4293,7 +4916,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListEntityInfo.schema.json",
-    "fileMatch": ["a://b/TrustListEntityInfo*.schema.json"],
+    "fileMatch": [
+      "a://b/TrustListEntityInfo*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListEntityInfo.schema.json",
@@ -4325,13 +4950,17 @@
           "type": "string"
         }
       },
-      "required": ["name"],
+      "required": [
+        "name"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InternalTrustListEntity.schema.json",
-    "fileMatch": ["a://b/InternalTrustListEntity*.schema.json"],
+    "fileMatch": [
+      "a://b/InternalTrustListEntity*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InternalTrustListEntity.schema.json",
@@ -4340,7 +4969,9 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["internal"]
+          "enum": [
+            "internal"
+          ]
         },
         "issuerKeyChainId": {
           "type": "string"
@@ -4352,13 +4983,20 @@
           "$ref": "./TrustListEntityInfo.schema.json"
         }
       },
-      "required": ["type", "issuerKeyChainId", "revocationKeyChainId", "info"],
+      "required": [
+        "type",
+        "issuerKeyChainId",
+        "revocationKeyChainId",
+        "info"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExternalTrustListEntity.schema.json",
-    "fileMatch": ["a://b/ExternalTrustListEntity*.schema.json"],
+    "fileMatch": [
+      "a://b/ExternalTrustListEntity*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExternalTrustListEntity.schema.json",
@@ -4367,7 +5005,9 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["external"]
+          "enum": [
+            "external"
+          ]
         },
         "issuerCertPem": {
           "type": "string"
@@ -4379,13 +5019,20 @@
           "$ref": "./TrustListEntityInfo.schema.json"
         }
       },
-      "required": ["type", "issuerCertPem", "revocationCertPem", "info"],
+      "required": [
+        "type",
+        "issuerCertPem",
+        "revocationCertPem",
+        "info"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListCreateDto.schema.json",
-    "fileMatch": ["a://b/TrustListCreateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/TrustListCreateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListCreateDto.schema.json",
@@ -4426,13 +5073,17 @@
           "type": "string"
         }
       },
-      "required": ["entities"],
+      "required": [
+        "entities"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustList.schema.json",
-    "fileMatch": ["a://b/TrustList*.schema.json"],
+    "fileMatch": [
+      "a://b/TrustList*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustList.schema.json",
@@ -4508,7 +5159,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListVersion.schema.json",
-    "fileMatch": ["a://b/TrustListVersion*.schema.json"],
+    "fileMatch": [
+      "a://b/TrustListVersion*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListVersion.schema.json",
@@ -4563,7 +5216,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DCQL.schema.json",
-    "fileMatch": ["a://b/DCQL*.schema.json"],
+    "fileMatch": [
+      "a://b/DCQL*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DCQL.schema.json",
@@ -4583,13 +5238,17 @@
           }
         }
       },
-      "required": ["credentials"],
+      "required": [
+        "credentials"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificatePurpose.schema.json",
-    "fileMatch": ["a://b/RegistrationCertificatePurpose*.schema.json"],
+    "fileMatch": [
+      "a://b/RegistrationCertificatePurpose*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificatePurpose.schema.json",
@@ -4603,13 +5262,18 @@
           "type": "string"
         }
       },
-      "required": ["lang", "content"],
+      "required": [
+        "lang",
+        "content"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateBody.schema.json",
-    "fileMatch": ["a://b/RegistrationCertificateBody*.schema.json"],
+    "fileMatch": [
+      "a://b/RegistrationCertificateBody*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateBody.schema.json",
@@ -4649,7 +5313,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateRequest.schema.json",
-    "fileMatch": ["a://b/RegistrationCertificateRequest*.schema.json"],
+    "fileMatch": [
+      "a://b/RegistrationCertificateRequest*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateRequest.schema.json",
@@ -4678,7 +5344,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationAttachment.schema.json",
-    "fileMatch": ["a://b/PresentationAttachment*.schema.json"],
+    "fileMatch": [
+      "a://b/PresentationAttachment*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationAttachment.schema.json",
@@ -4698,13 +5366,18 @@
           }
         }
       },
-      "required": ["format", "data"],
+      "required": [
+        "format",
+        "data"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfig.schema.json",
-    "fileMatch": ["a://b/PresentationConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/PresentationConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfig.schema.json",
@@ -4813,13 +5486,21 @@
           "description": "Optional ID of the access certificate to use for signing the presentation request.\nIf not provided, the default access certificate for the tenant will be used.\n\nNote: This is intentionally NOT a TypeORM relationship because CertEntity uses\na composite primary key (id + tenantId), and SQLite cannot create foreign keys\nthat reference only part of a composite primary key. The relationship is handled\nat the application level in the service layer."
         }
       },
-      "required": ["id", "tenant", "dcql_query", "createdAt", "updatedAt"],
+      "required": [
+        "id",
+        "tenant",
+        "dcql_query",
+        "createdAt",
+        "updatedAt"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ResolveIssuerMetadataDto.schema.json",
-    "fileMatch": ["a://b/ResolveIssuerMetadataDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ResolveIssuerMetadataDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ResolveIssuerMetadataDto.schema.json",
@@ -4833,13 +5514,17 @@
           "example": "https://issuer.example.com/issuers/tenant-a"
         }
       },
-      "required": ["issuerUrl"],
+      "required": [
+        "issuerUrl"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ResolveSchemaMetadataDto.schema.json",
-    "fileMatch": ["a://b/ResolveSchemaMetadataDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ResolveSchemaMetadataDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ResolveSchemaMetadataDto.schema.json",
@@ -4853,13 +5538,17 @@
           "example": "https://registrar.example.com/schema-metadata/5c0d7dbb-ef2e-448b-b84f-b8103575947b"
         }
       },
-      "required": ["schemaMetadataUrl"],
+      "required": [
+        "schemaMetadataUrl"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfigCreateDto.schema.json",
-    "fileMatch": ["a://b/PresentationConfigCreateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/PresentationConfigCreateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfigCreateDto.schema.json",
@@ -4942,13 +5631,18 @@
           "description": "Optional ID of the access certificate to use for signing the presentation request.\nIf not provided, the default access certificate for the tenant will be used.\n\nNote: This is intentionally NOT a TypeORM relationship because CertEntity uses\na composite primary key (id + tenantId), and SQLite cannot create foreign keys\nthat reference only part of a composite primary key. The relationship is handled\nat the application level in the service layer."
         }
       },
-      "required": ["id", "dcql_query"],
+      "required": [
+        "id",
+        "dcql_query"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfigUpdateDto.schema.json",
-    "fileMatch": ["a://b/PresentationConfigUpdateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/PresentationConfigUpdateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfigUpdateDto.schema.json",
@@ -5036,7 +5730,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateDefaults.schema.json",
-    "fileMatch": ["a://b/RegistrationCertificateDefaults*.schema.json"],
+    "fileMatch": [
+      "a://b/RegistrationCertificateDefaults*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateDefaults.schema.json",
@@ -5059,7 +5755,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrarConfigResponseDto.schema.json",
-    "fileMatch": ["a://b/RegistrarConfigResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/RegistrarConfigResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrarConfigResponseDto.schema.json",
@@ -5107,13 +5805,21 @@
           "example": true
         }
       },
-      "required": ["registrarUrl", "oidcUrl", "clientId", "username", "hasPassword"],
+      "required": [
+        "registrarUrl",
+        "oidcUrl",
+        "clientId",
+        "username",
+        "hasPassword"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateRegistrarConfigDto.schema.json",
-    "fileMatch": ["a://b/CreateRegistrarConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CreateRegistrarConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateRegistrarConfigDto.schema.json",
@@ -5160,13 +5866,21 @@
           ]
         }
       },
-      "required": ["registrarUrl", "oidcUrl", "clientId", "username", "password"],
+      "required": [
+        "registrarUrl",
+        "oidcUrl",
+        "clientId",
+        "username",
+        "password"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateRegistrarConfigDto.schema.json",
-    "fileMatch": ["a://b/UpdateRegistrarConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateRegistrarConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateRegistrarConfigDto.schema.json",
@@ -5218,7 +5932,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateAccessCertificateDto.schema.json",
-    "fileMatch": ["a://b/CreateAccessCertificateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CreateAccessCertificateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateAccessCertificateDto.schema.json",
@@ -5231,13 +5947,17 @@
           "example": "my-signing-key"
         }
       },
-      "required": ["keyId"],
+      "required": [
+        "keyId"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeferredCredentialRequestDto.schema.json",
-    "fileMatch": ["a://b/DeferredCredentialRequestDto*.schema.json"],
+    "fileMatch": [
+      "a://b/DeferredCredentialRequestDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeferredCredentialRequestDto.schema.json",
@@ -5250,13 +5970,17 @@
           "example": "8xLOxBtZp8"
         }
       },
-      "required": ["transaction_id"],
+      "required": [
+        "transaction_id"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/NotificationRequestDto.schema.json",
-    "fileMatch": ["a://b/NotificationRequestDto*.schema.json"],
+    "fileMatch": [
+      "a://b/NotificationRequestDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/NotificationRequestDto.schema.json",
@@ -5268,16 +5992,25 @@
         },
         "event": {
           "type": "string",
-          "enum": ["credential_accepted", "credential_failure", "credential_deleted"]
+          "enum": [
+            "credential_accepted",
+            "credential_failure",
+            "credential_deleted"
+          ]
         }
       },
-      "required": ["notification_id", "event"],
+      "required": [
+        "notification_id",
+        "event"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/OfferResponse.schema.json",
-    "fileMatch": ["a://b/OfferResponse*.schema.json"],
+    "fileMatch": [
+      "a://b/OfferResponse*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/OfferResponse.schema.json",
@@ -5295,13 +6028,18 @@
           "type": "string"
         }
       },
-      "required": ["uri", "session"],
+      "required": [
+        "uri",
+        "session"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CompleteDeferredDto.schema.json",
-    "fileMatch": ["a://b/CompleteDeferredDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CompleteDeferredDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CompleteDeferredDto.schema.json",
@@ -5319,13 +6057,17 @@
           }
         }
       },
-      "required": ["claims"],
+      "required": [
+        "claims"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeferredOperationResponse.schema.json",
-    "fileMatch": ["a://b/DeferredOperationResponse*.schema.json"],
+    "fileMatch": [
+      "a://b/DeferredOperationResponse*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeferredOperationResponse.schema.json",
@@ -5338,7 +6080,13 @@
         },
         "status": {
           "description": "The new status of the transaction",
-          "enum": ["pending", "ready", "retrieved", "expired", "failed"],
+          "enum": [
+            "pending",
+            "ready",
+            "retrieved",
+            "expired",
+            "failed"
+          ],
           "type": "string"
         },
         "message": {
@@ -5346,13 +6094,18 @@
           "description": "Optional message"
         }
       },
-      "required": ["transactionId", "status"],
+      "required": [
+        "transactionId",
+        "status"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FailDeferredDto.schema.json",
-    "fileMatch": ["a://b/FailDeferredDto*.schema.json"],
+    "fileMatch": [
+      "a://b/FailDeferredDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FailDeferredDto.schema.json",
@@ -5370,7 +6123,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EC_Public.schema.json",
-    "fileMatch": ["a://b/EC_Public*.schema.json"],
+    "fileMatch": [
+      "a://b/EC_Public*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EC_Public.schema.json",
@@ -5394,13 +6149,20 @@
           "description": "The y coordinate of the EC public key."
         }
       },
-      "required": ["kty", "crv", "x", "y"],
+      "required": [
+        "kty",
+        "crv",
+        "x",
+        "y"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/JwksResponseDto.schema.json",
-    "fileMatch": ["a://b/JwksResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/JwksResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/JwksResponseDto.schema.json",
@@ -5415,13 +6177,17 @@
           }
         }
       },
-      "required": ["keys"],
+      "required": [
+        "keys"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthorizationResponse.schema.json",
-    "fileMatch": ["a://b/AuthorizationResponse*.schema.json"],
+    "fileMatch": [
+      "a://b/AuthorizationResponse*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthorizationResponse.schema.json",
@@ -5457,7 +6223,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Object.schema.json",
-    "fileMatch": ["a://b/Object*.schema.json"],
+    "fileMatch": [
+      "a://b/Object*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Object.schema.json",
@@ -5469,7 +6237,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ParResponseDto.schema.json",
-    "fileMatch": ["a://b/ParResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ParResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ParResponseDto.schema.json",
@@ -5485,13 +6255,18 @@
           "description": "The expiration time for the request URI in seconds."
         }
       },
-      "required": ["request_uri", "expires_in"],
+      "required": [
+        "request_uri",
+        "expires_in"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationRequestDto.schema.json",
-    "fileMatch": ["a://b/InteractiveAuthorizationRequestDto*.schema.json"],
+    "fileMatch": [
+      "a://b/InteractiveAuthorizationRequestDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationRequestDto.schema.json",
@@ -5564,7 +6339,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationCodeResponseDto.schema.json",
-    "fileMatch": ["a://b/InteractiveAuthorizationCodeResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/InteractiveAuthorizationCodeResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationCodeResponseDto.schema.json",
@@ -5582,13 +6359,18 @@
           "example": "auth-code-123"
         }
       },
-      "required": ["status", "code"],
+      "required": [
+        "status",
+        "code"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationErrorResponseDto.schema.json",
-    "fileMatch": ["a://b/InteractiveAuthorizationErrorResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/InteractiveAuthorizationErrorResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationErrorResponseDto.schema.json",
@@ -5606,13 +6388,17 @@
           "example": "Missing required parameter: interaction_types_supported"
         }
       },
-      "required": ["error"],
+      "required": [
+        "error"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsParResponseDto.schema.json",
-    "fileMatch": ["a://b/ChainedAsParResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ChainedAsParResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsParResponseDto.schema.json",
@@ -5630,13 +6416,18 @@
           "example": 600
         }
       },
-      "required": ["request_uri", "expires_in"],
+      "required": [
+        "request_uri",
+        "expires_in"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsErrorResponseDto.schema.json",
-    "fileMatch": ["a://b/ChainedAsErrorResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ChainedAsErrorResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsErrorResponseDto.schema.json",
@@ -5653,13 +6444,17 @@
           "description": "Human-readable error description"
         }
       },
-      "required": ["error"],
+      "required": [
+        "error"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenRequestDto.schema.json",
-    "fileMatch": ["a://b/ChainedAsTokenRequestDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ChainedAsTokenRequestDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenRequestDto.schema.json",
@@ -5692,13 +6487,17 @@
           "description": "PKCE code verifier"
         }
       },
-      "required": ["grant_type"],
+      "required": [
+        "grant_type"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenResponseDto.schema.json",
-    "fileMatch": ["a://b/ChainedAsTokenResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ChainedAsTokenResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenResponseDto.schema.json",
@@ -5743,13 +6542,19 @@
           "description": "Refresh token (issued when refresh tokens are enabled)"
         }
       },
-      "required": ["access_token", "token_type", "expires_in"],
+      "required": [
+        "access_token",
+        "token_type",
+        "expires_in"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProviderCapabilitiesDto.schema.json",
-    "fileMatch": ["a://b/KmsProviderCapabilitiesDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KmsProviderCapabilitiesDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProviderCapabilitiesDto.schema.json",
@@ -5773,7 +6578,9 @@
         },
         "supportedAlgs": {
           "description": "Signing algorithms supported by the provider.",
-          "example": ["ES256"],
+          "example": [
+            "ES256"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -5785,13 +6592,21 @@
           "example": "ES256"
         }
       },
-      "required": ["canImport", "canCreate", "canDelete", "supportedAlgs", "defaultAlg"],
+      "required": [
+        "canImport",
+        "canCreate",
+        "canDelete",
+        "supportedAlgs",
+        "defaultAlg"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProviderInfoDto.schema.json",
-    "fileMatch": ["a://b/KmsProviderInfoDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KmsProviderInfoDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProviderInfoDto.schema.json",
@@ -5822,13 +6637,19 @@
           ]
         }
       },
-      "required": ["name", "type", "capabilities"],
+      "required": [
+        "name",
+        "type",
+        "capabilities"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProvidersResponseDto.schema.json",
-    "fileMatch": ["a://b/KmsProvidersResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KmsProvidersResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProvidersResponseDto.schema.json",
@@ -5848,13 +6669,18 @@
           "example": "db"
         }
       },
-      "required": ["providers", "default"],
+      "required": [
+        "providers",
+        "default"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DbKmsConfigDto.schema.json",
-    "fileMatch": ["a://b/DbKmsConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/DbKmsConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DbKmsConfigDto.schema.json",
@@ -5867,7 +6693,9 @@
           "example": "main-vault"
         },
         "type": {
-          "enum": ["db"],
+          "enum": [
+            "db"
+          ],
           "type": "string",
           "description": "Type of the KMS provider.",
           "example": "db"
@@ -5878,13 +6706,18 @@
           "example": "Production HashiCorp Vault for signing keys"
         }
       },
-      "required": ["id", "type"],
+      "required": [
+        "id",
+        "type"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/VaultKmsConfigDto.schema.json",
-    "fileMatch": ["a://b/VaultKmsConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/VaultKmsConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/VaultKmsConfigDto.schema.json",
@@ -5897,7 +6730,9 @@
           "example": "main-vault"
         },
         "type": {
-          "enum": ["vault"],
+          "enum": [
+            "vault"
+          ],
           "type": "string",
           "description": "Type of the KMS provider.",
           "example": "vault"
@@ -5918,13 +6753,20 @@
           "example": "${VAULT_TOKEN}"
         }
       },
-      "required": ["id", "type", "vaultUrl", "vaultToken"],
+      "required": [
+        "id",
+        "type",
+        "vaultUrl",
+        "vaultToken"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AwsKmsConfigDto.schema.json",
-    "fileMatch": ["a://b/AwsKmsConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/AwsKmsConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AwsKmsConfigDto.schema.json",
@@ -5937,7 +6779,9 @@
           "example": "main-vault"
         },
         "type": {
-          "enum": ["aws-kms"],
+          "enum": [
+            "aws-kms"
+          ],
           "type": "string",
           "description": "Type of the KMS provider.",
           "example": "aws-kms"
@@ -5963,13 +6807,19 @@
           "example": "${AWS_SECRET_ACCESS_KEY}"
         }
       },
-      "required": ["id", "type", "region"],
+      "required": [
+        "id",
+        "type",
+        "region"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Pkcs11KmsConfigDto.schema.json",
-    "fileMatch": ["a://b/Pkcs11KmsConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/Pkcs11KmsConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Pkcs11KmsConfigDto.schema.json",
@@ -5982,7 +6832,9 @@
           "example": "main-vault"
         },
         "type": {
-          "enum": ["pkcs11"],
+          "enum": [
+            "pkcs11"
+          ],
           "type": "string",
           "description": "Type of the KMS provider.",
           "example": "pkcs11"
@@ -6013,13 +6865,21 @@
           "example": false
         }
       },
-      "required": ["id", "type", "library", "slot", "pin"],
+      "required": [
+        "id",
+        "type",
+        "library",
+        "slot",
+        "pin"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/HttpAuthBaseConfigDto.schema.json",
-    "fileMatch": ["a://b/HttpAuthBaseConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/HttpAuthBaseConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/HttpAuthBaseConfigDto.schema.json",
@@ -6027,18 +6887,27 @@
       "type": "object",
       "properties": {
         "type": {
-          "enum": ["none", "bearer", "oauth2-client-credentials", "mtls"],
+          "enum": [
+            "none",
+            "bearer",
+            "oauth2-client-credentials",
+            "mtls"
+          ],
           "type": "string",
           "description": "Authentication method for the remote KMS service."
         }
       },
-      "required": ["type"],
+      "required": [
+        "type"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/HttpKmsConfigDto.schema.json",
-    "fileMatch": ["a://b/HttpKmsConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/HttpKmsConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/HttpKmsConfigDto.schema.json",
@@ -6051,7 +6920,9 @@
           "example": "main-vault"
         },
         "type": {
-          "enum": ["http"],
+          "enum": [
+            "http"
+          ],
           "type": "string",
           "description": "Type of the KMS provider.",
           "example": "http"
@@ -6090,13 +6961,19 @@
           "example": false
         }
       },
-      "required": ["id", "type", "baseUrl"],
+      "required": [
+        "id",
+        "type",
+        "baseUrl"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CscAuthorizeAuthDataDto.schema.json",
-    "fileMatch": ["a://b/CscAuthorizeAuthDataDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CscAuthorizeAuthDataDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CscAuthorizeAuthDataDto.schema.json",
@@ -6114,13 +6991,18 @@
           "example": "123456"
         }
       },
-      "required": ["id", "value"],
+      "required": [
+        "id",
+        "value"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CscKmsConfigDto.schema.json",
-    "fileMatch": ["a://b/CscKmsConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CscKmsConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CscKmsConfigDto.schema.json",
@@ -6133,7 +7015,9 @@
           "example": "main-vault"
         },
         "type": {
-          "enum": ["csc"],
+          "enum": [
+            "csc"
+          ],
           "type": "string",
           "description": "Type of the KMS provider.",
           "example": "csc"
@@ -6211,13 +7095,22 @@
           }
         }
       },
-      "required": ["id", "type", "baseUrl", "tokenUrl", "clientId", "clientSecret"],
+      "required": [
+        "id",
+        "type",
+        "baseUrl",
+        "tokenUrl",
+        "clientId",
+        "clientSecret"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsConfigDto.schema.json",
-    "fileMatch": ["a://b/KmsConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KmsConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsConfigDto.schema.json",
@@ -6287,13 +7180,17 @@
           ]
         }
       },
-      "required": ["providers"],
+      "required": [
+        "providers"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsTenantConfigResponseDto.schema.json",
-    "fileMatch": ["a://b/KmsTenantConfigResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KmsTenantConfigResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsTenantConfigResponseDto.schema.json",
@@ -6319,13 +7216,17 @@
           ]
         }
       },
-      "required": ["effectiveConfig"],
+      "required": [
+        "effectiveConfig"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CertificateInfoDto.schema.json",
-    "fileMatch": ["a://b/CertificateInfoDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CertificateInfoDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CertificateInfoDto.schema.json",
@@ -6359,13 +7260,17 @@
           "description": "Serial number."
         }
       },
-      "required": ["pem"],
+      "required": [
+        "pem"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PublicKeyInfoDto.schema.json",
-    "fileMatch": ["a://b/PublicKeyInfoDto*.schema.json"],
+    "fileMatch": [
+      "a://b/PublicKeyInfoDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PublicKeyInfoDto.schema.json",
@@ -6392,13 +7297,17 @@
           "example": "P-256"
         }
       },
-      "required": ["kty"],
+      "required": [
+        "kty"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyResponseDto.schema.json",
-    "fileMatch": ["a://b/RotationPolicyResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/RotationPolicyResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyResponseDto.schema.json",
@@ -6423,13 +7332,17 @@
           "description": "Next scheduled rotation date."
         }
       },
-      "required": ["enabled"],
+      "required": [
+        "enabled"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainResponseDto.schema.json",
-    "fileMatch": ["a://b/KeyChainResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KeyChainResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainResponseDto.schema.json",
@@ -6441,12 +7354,21 @@
           "description": "Unique identifier for the key chain."
         },
         "usageType": {
-          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"],
+          "enum": [
+            "access",
+            "attestation",
+            "trustList",
+            "statusList",
+            "encrypt"
+          ],
           "type": "string",
           "description": "Usage type of the key chain."
         },
         "type": {
-          "enum": ["standalone", "internalChain"],
+          "enum": [
+            "standalone",
+            "internalChain"
+          ],
           "type": "string",
           "description": "Type of key chain (standalone or internalChain)."
         },
@@ -6537,7 +7459,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExportEcJwk.schema.json",
-    "fileMatch": ["a://b/ExportEcJwk*.schema.json"],
+    "fileMatch": [
+      "a://b/ExportEcJwk*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExportEcJwk.schema.json",
@@ -6576,13 +7500,21 @@
           "description": "Key ID"
         }
       },
-      "required": ["kty", "crv", "x", "y", "d"],
+      "required": [
+        "kty",
+        "crv",
+        "x",
+        "y",
+        "d"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExportRotationPolicyDto.schema.json",
-    "fileMatch": ["a://b/ExportRotationPolicyDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ExportRotationPolicyDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExportRotationPolicyDto.schema.json",
@@ -6602,13 +7534,17 @@
           "description": "Certificate validity in days."
         }
       },
-      "required": ["enabled"],
+      "required": [
+        "enabled"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainExportDto.schema.json",
-    "fileMatch": ["a://b/KeyChainExportDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KeyChainExportDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainExportDto.schema.json",
@@ -6624,7 +7560,13 @@
           "description": "Human-readable description."
         },
         "usageType": {
-          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"],
+          "enum": [
+            "access",
+            "attestation",
+            "trustList",
+            "statusList",
+            "encrypt"
+          ],
           "type": "string",
           "description": "Usage type for this key chain."
         },
@@ -6656,13 +7598,19 @@
           ]
         }
       },
-      "required": ["id", "usageType", "key"],
+      "required": [
+        "id",
+        "usageType",
+        "key"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyCreateDto.schema.json",
-    "fileMatch": ["a://b/RotationPolicyCreateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/RotationPolicyCreateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyCreateDto.schema.json",
@@ -6689,13 +7637,17 @@
           "example": 365
         }
       },
-      "required": ["enabled"],
+      "required": [
+        "enabled"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainCreateDto.schema.json",
-    "fileMatch": ["a://b/KeyChainCreateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KeyChainCreateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainCreateDto.schema.json",
@@ -6703,13 +7655,22 @@
       "type": "object",
       "properties": {
         "usageType": {
-          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"],
+          "enum": [
+            "access",
+            "attestation",
+            "trustList",
+            "statusList",
+            "encrypt"
+          ],
           "type": "string",
           "description": "Usage type determines the purpose of this key chain (access, attestation, etc.).",
           "example": "attestation"
         },
         "type": {
-          "enum": ["standalone", "internalChain"],
+          "enum": [
+            "standalone",
+            "internalChain"
+          ],
           "type": "string",
           "description": "Type of key chain to create.",
           "example": "internalChain"
@@ -6733,13 +7694,18 @@
           ]
         }
       },
-      "required": ["usageType", "type"],
+      "required": [
+        "usageType",
+        "type"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EcJwk.schema.json",
-    "fileMatch": ["a://b/EcJwk*.schema.json"],
+    "fileMatch": [
+      "a://b/EcJwk*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EcJwk.schema.json",
@@ -6768,13 +7734,21 @@
           "type": "string"
         }
       },
-      "required": ["kty", "x", "y", "crv", "d"],
+      "required": [
+        "kty",
+        "x",
+        "y",
+        "crv",
+        "d"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyImportDto.schema.json",
-    "fileMatch": ["a://b/RotationPolicyImportDto*.schema.json"],
+    "fileMatch": [
+      "a://b/RotationPolicyImportDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyImportDto.schema.json",
@@ -6801,13 +7775,17 @@
           "example": 365
         }
       },
-      "required": ["enabled"],
+      "required": [
+        "enabled"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainImportDto.schema.json",
-    "fileMatch": ["a://b/KeyChainImportDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KeyChainImportDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainImportDto.schema.json",
@@ -6831,7 +7809,13 @@
           "description": "Human-readable description."
         },
         "usageType": {
-          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"],
+          "enum": [
+            "access",
+            "attestation",
+            "trustList",
+            "statusList",
+            "encrypt"
+          ],
           "type": "string",
           "description": "Usage type for this key chain."
         },
@@ -6855,13 +7839,18 @@
           ]
         }
       },
-      "required": ["key", "usageType"],
+      "required": [
+        "key",
+        "usageType"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyUpdateDto.schema.json",
-    "fileMatch": ["a://b/RotationPolicyUpdateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/RotationPolicyUpdateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyUpdateDto.schema.json",
@@ -6890,7 +7879,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainUpdateDto.schema.json",
-    "fileMatch": ["a://b/KeyChainUpdateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KeyChainUpdateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainUpdateDto.schema.json",
@@ -6919,7 +7910,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationRequest.schema.json",
-    "fileMatch": ["a://b/PresentationRequest*.schema.json"],
+    "fileMatch": [
+      "a://b/PresentationRequest*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationRequest.schema.json",
@@ -6929,7 +7922,10 @@
         "response_type": {
           "type": "string",
           "description": "The type of response expected from the presentation request.",
-          "enum": ["uri", "dc-api"]
+          "enum": [
+            "uri",
+            "dc-api"
+          ]
         },
         "requestId": {
           "type": "string",
@@ -6960,13 +7956,18 @@
           }
         }
       },
-      "required": ["response_type", "requestId"],
+      "required": [
+        "response_type",
+        "requestId"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FileUploadDto.schema.json",
-    "fileMatch": ["a://b/FileUploadDto*.schema.json"],
+    "fileMatch": [
+      "a://b/FileUploadDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FileUploadDto.schema.json",
@@ -6978,7 +7979,9 @@
           "format": "binary"
         }
       },
-      "required": ["file"],
+      "required": [
+        "file"
+      ],
       "additionalProperties": false
     }
   }

--- a/apps/client/src/app/utils/schemas.json
+++ b/apps/client/src/app/utils/schemas.json
@@ -1,9 +1,7 @@
 [
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/GrafanaConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/GrafanaConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/GrafanaConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/GrafanaConfigDto.schema.json",
@@ -26,18 +24,13 @@
           "example": "loki"
         }
       },
-      "required": [
-        "tempoUid",
-        "lokiUid"
-      ],
+      "required": ["tempoUid", "lokiUid"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FrontendConfigResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/FrontendConfigResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/FrontendConfigResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FrontendConfigResponseDto.schema.json",
@@ -53,17 +46,13 @@
           ]
         }
       },
-      "required": [
-        "grafana"
-      ],
+      "required": ["grafana"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RoleDto.schema.json",
-    "fileMatch": [
-      "a://b/RoleDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/RoleDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RoleDto.schema.json",
@@ -86,17 +75,13 @@
           "example": "issuance:manage"
         }
       },
-      "required": [
-        "role"
-      ],
+      "required": ["role"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientCredentialsDto.schema.json",
-    "fileMatch": [
-      "a://b/ClientCredentialsDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ClientCredentialsDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientCredentialsDto.schema.json",
@@ -114,18 +99,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "client_id",
-        "client_secret"
-      ],
+      "required": ["client_id", "client_secret"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TokenResponse.schema.json",
-    "fileMatch": [
-      "a://b/TokenResponse*.schema.json"
-    ],
+    "fileMatch": ["a://b/TokenResponse*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TokenResponse.schema.json",
@@ -148,20 +128,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "access_token",
-        "token_type",
-        "expires_in",
-        "state"
-      ],
+      "required": ["access_token", "token_type", "expires_in", "state"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ImportTenantDto.schema.json",
-    "fileMatch": [
-      "a://b/ImportTenantDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ImportTenantDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ImportTenantDto.schema.json",
@@ -177,17 +150,13 @@
           "description": "The description of the tenant."
         }
       },
-      "required": [
-        "name"
-      ],
+      "required": ["name"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SessionStorageConfig.schema.json",
-    "fileMatch": [
-      "a://b/SessionStorageConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/SessionStorageConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SessionStorageConfig.schema.json",
@@ -203,10 +172,7 @@
         "cleanupMode": {
           "type": "string",
           "description": "Cleanup mode: 'full' deletes everything, 'anonymize' keeps metadata but removes PII.",
-          "enum": [
-            "full",
-            "anonymize"
-          ],
+          "enum": ["full", "anonymize"],
           "default": "full"
         }
       },
@@ -215,9 +181,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListConfig.schema.json",
-    "fileMatch": [
-      "a://b/StatusListConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/StatusListConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListConfig.schema.json",
@@ -233,12 +197,7 @@
         "bits": {
           "type": "number",
           "description": "Bits per status entry: 1 (valid/revoked), 2 (with suspended), 4/8 (extended). If not set, uses global STATUS_BITS.",
-          "enum": [
-            1,
-            2,
-            4,
-            8
-          ],
+          "enum": [1, 2, 4, 8],
           "default": 1
         },
         "ttl": {
@@ -263,9 +222,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TenantEntity.schema.json",
-    "fileMatch": [
-      "a://b/TenantEntity*.schema.json"
-    ],
+    "fileMatch": ["a://b/TenantEntity*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TenantEntity.schema.json",
@@ -316,20 +273,13 @@
           }
         }
       },
-      "required": [
-        "id",
-        "name",
-        "status",
-        "clients"
-      ],
+      "required": ["id", "name", "status", "clients"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientEntity.schema.json",
-    "fileMatch": [
-      "a://b/ClientEntity*.schema.json"
-    ],
+    "fileMatch": ["a://b/ClientEntity*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientEntity.schema.json",
@@ -339,10 +289,7 @@
         "allowedPresentationConfigs": {
           "nullable": true,
           "description": "List of presentation config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": [
-            "age-verification",
-            "kyc-basic"
-          ],
+          "example": ["age-verification", "kyc-basic"],
           "type": "array",
           "items": {
             "type": "string"
@@ -351,10 +298,7 @@
         "allowedIssuanceConfigs": {
           "nullable": true,
           "description": "List of issuance config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": [
-            "pid",
-            "mdl"
-          ],
+          "example": ["pid", "mdl"],
           "type": "array",
           "items": {
             "type": "string"
@@ -402,18 +346,13 @@
           ]
         }
       },
-      "required": [
-        "clientId",
-        "roles"
-      ],
+      "required": ["clientId", "roles"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateTenantDto.schema.json",
-    "fileMatch": [
-      "a://b/CreateTenantDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CreateTenantDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateTenantDto.schema.json",
@@ -467,18 +406,13 @@
           }
         }
       },
-      "required": [
-        "id",
-        "name"
-      ],
+      "required": ["id", "name"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateTenantDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateTenantDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateTenantDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateTenantDto.schema.json",
@@ -533,9 +467,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuditLogResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/AuditLogResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/AuditLogResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuditLogResponseDto.schema.json",
@@ -572,11 +504,7 @@
           "type": "string"
         },
         "actorType": {
-          "enum": [
-            "user",
-            "client",
-            "system"
-          ],
+          "enum": ["user", "client", "system"],
           "type": "string"
         },
         "actorId": {
@@ -607,21 +535,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "id",
-        "tenantId",
-        "actionType",
-        "actorType",
-        "timestamp"
-      ],
+      "required": ["id", "tenantId", "actionType", "actorType", "timestamp"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientSecretResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/ClientSecretResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ClientSecretResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientSecretResponseDto.schema.json",
@@ -632,17 +552,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "secret"
-      ],
+      "required": ["secret"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateClientDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateClientDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateClientDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateClientDto.schema.json",
@@ -652,10 +568,7 @@
         "allowedPresentationConfigs": {
           "nullable": true,
           "description": "List of presentation config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": [
-            "age-verification",
-            "kyc-basic"
-          ],
+          "example": ["age-verification", "kyc-basic"],
           "type": "array",
           "items": {
             "type": "string"
@@ -664,10 +577,7 @@
         "allowedIssuanceConfigs": {
           "nullable": true,
           "description": "List of issuance config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": [
-            "pid",
-            "mdl"
-          ],
+          "example": ["pid", "mdl"],
           "type": "array",
           "items": {
             "type": "string"
@@ -695,17 +605,13 @@
           }
         }
       },
-      "required": [
-        "roles"
-      ],
+      "required": ["roles"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateClientDto.schema.json",
-    "fileMatch": [
-      "a://b/CreateClientDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CreateClientDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateClientDto.schema.json",
@@ -715,10 +621,7 @@
         "allowedPresentationConfigs": {
           "nullable": true,
           "description": "List of presentation config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": [
-            "age-verification",
-            "kyc-basic"
-          ],
+          "example": ["age-verification", "kyc-basic"],
           "type": "array",
           "items": {
             "type": "string"
@@ -727,10 +630,7 @@
         "allowedIssuanceConfigs": {
           "nullable": true,
           "description": "List of issuance config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": [
-            "pid",
-            "mdl"
-          ],
+          "example": ["pid", "mdl"],
           "type": "array",
           "items": {
             "type": "string"
@@ -766,18 +666,13 @@
           }
         }
       },
-      "required": [
-        "clientId",
-        "roles"
-      ],
+      "required": ["clientId", "roles"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListImportDto.schema.json",
-    "fileMatch": [
-      "a://b/StatusListImportDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/StatusListImportDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListImportDto.schema.json",
@@ -807,27 +702,18 @@
         },
         "bits": {
           "description": "Bits per status value. If not provided, uses tenant or global defaults.",
-          "enum": [
-            1,
-            2,
-            4,
-            8
-          ],
+          "enum": [1, 2, 4, 8],
           "type": "number",
           "example": 1
         }
       },
-      "required": [
-        "id"
-      ],
+      "required": ["id"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListAggregationDto.schema.json",
-    "fileMatch": [
-      "a://b/StatusListAggregationDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/StatusListAggregationDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListAggregationDto.schema.json",
@@ -846,17 +732,13 @@
           }
         }
       },
-      "required": [
-        "status_lists"
-      ],
+      "required": ["status_lists"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateStatusListConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateStatusListConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateStatusListConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateStatusListConfigDto.schema.json",
@@ -873,12 +755,7 @@
         "bits": {
           "nullable": true,
           "description": "Bits per status entry. Set to null to reset to global default.",
-          "enum": [
-            1,
-            2,
-            4,
-            8
-          ],
+          "enum": [1, 2, 4, 8],
           "type": "number"
         },
         "ttl": {
@@ -904,9 +781,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/StatusListResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/StatusListResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListResponseDto.schema.json",
@@ -937,12 +812,7 @@
         },
         "bits": {
           "description": "Bits per status value",
-          "enum": [
-            1,
-            2,
-            4,
-            8
-          ],
+          "enum": [1, 2, 4, 8],
           "type": "number",
           "example": 1
         },
@@ -995,9 +865,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateStatusListDto.schema.json",
-    "fileMatch": [
-      "a://b/CreateStatusListDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CreateStatusListDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateStatusListDto.schema.json",
@@ -1016,12 +884,7 @@
         },
         "bits": {
           "description": "Bits per status value. More bits allow more status states. Defaults to tenant configuration.",
-          "enum": [
-            1,
-            2,
-            4,
-            8
-          ],
+          "enum": [1, 2, 4, 8],
           "type": "number",
           "example": 1
         },
@@ -1037,9 +900,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateStatusListDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateStatusListDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateStatusListDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateStatusListDto.schema.json",
@@ -1064,9 +925,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthorizeQueries.schema.json",
-    "fileMatch": [
-      "a://b/AuthorizeQueries*.schema.json"
-    ],
+    "fileMatch": ["a://b/AuthorizeQueries*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthorizeQueries.schema.json",
@@ -1119,9 +978,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/OfferRequestDto.schema.json",
-    "fileMatch": [
-      "a://b/OfferRequestDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/OfferRequestDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/OfferRequestDto.schema.json",
@@ -1129,10 +986,7 @@
       "type": "object",
       "properties": {
         "response_type": {
-          "enum": [
-            "uri",
-            "dc-api"
-          ],
+          "enum": ["uri", "dc-api"],
           "type": "string",
           "examples": [
             {
@@ -1150,19 +1004,14 @@
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "inline"
-                    ]
+                    "enum": ["inline"]
                   },
                   "claims": {
                     "type": "object",
                     "additionalProperties": true
                   }
                 },
-                "required": [
-                  "type",
-                  "claims"
-                ],
+                "required": ["type", "claims"],
                 "additionalProperties": false
               },
               {
@@ -1170,18 +1019,13 @@
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "attributeProvider"
-                    ]
+                    "enum": ["attributeProvider"]
                   },
                   "attributeProviderId": {
                     "type": "string"
                   }
                 },
-                "required": [
-                  "type",
-                  "attributeProviderId"
-                ],
+                "required": ["type", "attributeProviderId"],
                 "additionalProperties": false
               },
               {
@@ -1189,9 +1033,7 @@
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "webhook"
-                    ]
+                    "enum": ["webhook"]
                   },
                   "webhook": {
                     "type": "object",
@@ -1203,16 +1045,11 @@
                         "type": "object"
                       }
                     },
-                    "required": [
-                      "url"
-                    ],
+                    "required": ["url"],
                     "additionalProperties": false
                   }
                 },
-                "required": [
-                  "type",
-                  "webhook"
-                ],
+                "required": ["type", "webhook"],
                 "additionalProperties": false
               }
             ]
@@ -1230,10 +1067,7 @@
         },
         "flow": {
           "description": "The flow type for the offer request.",
-          "enum": [
-            "authorization_code",
-            "pre_authorized_code"
-          ],
+          "enum": ["authorization_code", "pre_authorized_code"],
           "type": "string"
         },
         "tx_code": {
@@ -1260,19 +1094,13 @@
           "description": "ID of the webhook endpoint to notify about the status of the issuance process."
         }
       },
-      "required": [
-        "response_type",
-        "flow",
-        "credentialConfigurationIds"
-      ],
+      "required": ["response_type", "flow", "credentialConfigurationIds"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebHookAuthConfigNone.schema.json",
-    "fileMatch": [
-      "a://b/WebHookAuthConfigNone*.schema.json"
-    ],
+    "fileMatch": ["a://b/WebHookAuthConfigNone*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebHookAuthConfigNone.schema.json",
@@ -1282,22 +1110,16 @@
         "type": {
           "type": "string",
           "description": "The type of authentication used for the webhook.",
-          "enum": [
-            "none"
-          ]
+          "enum": ["none"]
         }
       },
-      "required": [
-        "type"
-      ],
+      "required": ["type"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ApiKeyConfig.schema.json",
-    "fileMatch": [
-      "a://b/ApiKeyConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/ApiKeyConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ApiKeyConfig.schema.json",
@@ -1313,18 +1135,13 @@
           "description": "The value of the API key to be sent in the header."
         }
       },
-      "required": [
-        "headerName",
-        "value"
-      ],
+      "required": ["headerName", "value"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebHookAuthConfigHeader.schema.json",
-    "fileMatch": [
-      "a://b/WebHookAuthConfigHeader*.schema.json"
-    ],
+    "fileMatch": ["a://b/WebHookAuthConfigHeader*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebHookAuthConfigHeader.schema.json",
@@ -1334,9 +1151,7 @@
         "type": {
           "type": "string",
           "description": "The type of authentication used for the webhook.",
-          "enum": [
-            "apiKey"
-          ]
+          "enum": ["apiKey"]
         },
         "config": {
           "description": "Configuration for API key authentication.\nThis is required if the type is 'apiKey'.",
@@ -1347,18 +1162,13 @@
           ]
         }
       },
-      "required": [
-        "type",
-        "config"
-      ],
+      "required": ["type", "config"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebhookConfig.schema.json",
-    "fileMatch": [
-      "a://b/WebhookConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/WebhookConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebhookConfig.schema.json",
@@ -1388,18 +1198,13 @@
           "description": "The URL to which the webhook will send notifications."
         }
       },
-      "required": [
-        "auth",
-        "url"
-      ],
+      "required": ["auth", "url"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TransactionData.schema.json",
-    "fileMatch": [
-      "a://b/TransactionData*.schema.json"
-    ],
+    "fileMatch": ["a://b/TransactionData*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TransactionData.schema.json",
@@ -1416,18 +1221,13 @@
           }
         }
       },
-      "required": [
-        "type",
-        "credential_ids"
-      ],
+      "required": ["type", "credential_ids"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Session.schema.json",
-    "fileMatch": [
-      "a://b/Session*.schema.json"
-    ],
+    "fileMatch": ["a://b/Session*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Session.schema.json",
@@ -1436,13 +1236,7 @@
       "properties": {
         "status": {
           "description": "Status of the session.",
-          "enum": [
-            "active",
-            "fetched",
-            "completed",
-            "expired",
-            "failed"
-          ],
+          "enum": ["active", "fetched", "completed", "expired", "failed"],
           "type": "string"
         },
         "id": {
@@ -1632,9 +1426,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PaginatedSessionResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/PaginatedSessionResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/PaginatedSessionResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PaginatedSessionResponseDto.schema.json",
@@ -1665,21 +1457,13 @@
           "description": "Total number of pages"
         }
       },
-      "required": [
-        "items",
-        "total",
-        "page",
-        "pageSize",
-        "totalPages"
-      ],
+      "required": ["items", "total", "page", "pageSize", "totalPages"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SessionLogEntryResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/SessionLogEntryResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/SessionLogEntryResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SessionLogEntryResponseDto.schema.json",
@@ -1702,11 +1486,7 @@
         "level": {
           "type": "string",
           "description": "Log level",
-          "enum": [
-            "info",
-            "warn",
-            "error"
-          ]
+          "enum": ["info", "warn", "error"]
         },
         "stage": {
           "type": "string",
@@ -1722,21 +1502,13 @@
           "description": "Additional structured detail"
         }
       },
-      "required": [
-        "id",
-        "sessionId",
-        "timestamp",
-        "level",
-        "message"
-      ],
+      "required": ["id", "sessionId", "timestamp", "level", "message"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusUpdateDto.schema.json",
-    "fileMatch": [
-      "a://b/StatusUpdateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/StatusUpdateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusUpdateDto.schema.json",
@@ -1756,18 +1528,13 @@
           "description": "The status of the credential\n0 = valid, 1 = revoked, 2 = suspended"
         }
       },
-      "required": [
-        "sessionId",
-        "status"
-      ],
+      "required": ["sessionId", "status"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateSessionConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateSessionConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateSessionConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateSessionConfigDto.schema.json",
@@ -1783,10 +1550,7 @@
         },
         "cleanupMode": {
           "description": "Cleanup mode: 'full' deletes everything, 'anonymize' keeps metadata but removes PII.",
-          "enum": [
-            "full",
-            "anonymize"
-          ],
+          "enum": ["full", "anonymize"],
           "type": "string",
           "default": "full"
         }
@@ -1796,9 +1560,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ManagedUserDto.schema.json",
-    "fileMatch": [
-      "a://b/ManagedUserDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ManagedUserDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ManagedUserDto.schema.json",
@@ -1847,20 +1609,13 @@
           "description": "One-time temporary password returned only on user creation."
         }
       },
-      "required": [
-        "id",
-        "username",
-        "enabled",
-        "roles"
-      ],
+      "required": ["id", "username", "enabled", "roles"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateUserDto.schema.json",
-    "fileMatch": [
-      "a://b/CreateUserDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CreateUserDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateUserDto.schema.json",
@@ -1902,18 +1657,13 @@
           "example": true
         }
       },
-      "required": [
-        "username",
-        "roles"
-      ],
+      "required": ["username", "roles"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateUserDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateUserDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateUserDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateUserDto.schema.json",
@@ -1965,9 +1715,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodNone.schema.json",
-    "fileMatch": [
-      "a://b/AuthenticationMethodNone*.schema.json"
-    ],
+    "fileMatch": ["a://b/AuthenticationMethodNone*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodNone.schema.json",
@@ -1976,22 +1724,16 @@
       "properties": {
         "method": {
           "type": "string",
-          "enum": [
-            "none"
-          ]
+          "enum": ["none"]
         }
       },
-      "required": [
-        "method"
-      ],
+      "required": ["method"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationUrlConfig.schema.json",
-    "fileMatch": [
-      "a://b/AuthenticationUrlConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/AuthenticationUrlConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationUrlConfig.schema.json",
@@ -2011,17 +1753,13 @@
           ]
         }
       },
-      "required": [
-        "url"
-      ],
+      "required": ["url"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodAuth.schema.json",
-    "fileMatch": [
-      "a://b/AuthenticationMethodAuth*.schema.json"
-    ],
+    "fileMatch": ["a://b/AuthenticationMethodAuth*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodAuth.schema.json",
@@ -2030,26 +1768,19 @@
       "properties": {
         "method": {
           "type": "string",
-          "enum": [
-            "auth"
-          ]
+          "enum": ["auth"]
         },
         "config": {
           "$ref": "./AuthenticationUrlConfig.schema.json"
         }
       },
-      "required": [
-        "method",
-        "config"
-      ],
+      "required": ["method", "config"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationDuringIssuanceConfig.schema.json",
-    "fileMatch": [
-      "a://b/PresentationDuringIssuanceConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/PresentationDuringIssuanceConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationDuringIssuanceConfig.schema.json",
@@ -2061,17 +1792,13 @@
           "description": "Link to the presentation configuration that is relevant for the issuance process"
         }
       },
-      "required": [
-        "type"
-      ],
+      "required": ["type"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodPresentation.schema.json",
-    "fileMatch": [
-      "a://b/AuthenticationMethodPresentation*.schema.json"
-    ],
+    "fileMatch": ["a://b/AuthenticationMethodPresentation*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodPresentation.schema.json",
@@ -2080,26 +1807,19 @@
       "properties": {
         "method": {
           "type": "string",
-          "enum": [
-            "presentationDuringIssuance"
-          ]
+          "enum": ["presentationDuringIssuance"]
         },
         "config": {
           "$ref": "./PresentationDuringIssuanceConfig.schema.json"
         }
       },
-      "required": [
-        "method",
-        "config"
-      ],
+      "required": ["method", "config"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ManagedAuthorizationServerConfig.schema.json",
-    "fileMatch": [
-      "a://b/ManagedAuthorizationServerConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/ManagedAuthorizationServerConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ManagedAuthorizationServerConfig.schema.json",
@@ -2107,12 +1827,7 @@
       "type": "object",
       "properties": {
         "type": {
-          "enum": [
-            "external",
-            "oid4vp",
-            "chained",
-            "built-in"
-          ],
+          "enum": ["external", "oid4vp", "chained", "built-in"],
           "type": "string",
           "description": "Authorization server implementation type",
           "example": "external"
@@ -2128,17 +1843,13 @@
           "default": true
         }
       },
-      "required": [
-        "type"
-      ],
+      "required": ["type"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExternalAuthorizationServerConfig.schema.json",
-    "fileMatch": [
-      "a://b/ExternalAuthorizationServerConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/ExternalAuthorizationServerConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExternalAuthorizationServerConfig.schema.json",
@@ -2146,9 +1857,7 @@
       "type": "object",
       "properties": {
         "type": {
-          "enum": [
-            "external"
-          ],
+          "enum": ["external"],
           "type": "string",
           "description": "Authorization server implementation type",
           "example": "external"
@@ -2170,18 +1879,13 @@
           "example": "https://auth.example.com"
         }
       },
-      "required": [
-        "type",
-        "issuer"
-      ],
+      "required": ["type", "issuer"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenConfig.schema.json",
-    "fileMatch": [
-      "a://b/ChainedAsTokenConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/ChainedAsTokenConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenConfig.schema.json",
@@ -2215,9 +1919,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Oid4VpAuthorizationServerConfig.schema.json",
-    "fileMatch": [
-      "a://b/Oid4VpAuthorizationServerConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/Oid4VpAuthorizationServerConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Oid4VpAuthorizationServerConfig.schema.json",
@@ -2225,9 +1927,7 @@
       "type": "object",
       "properties": {
         "type": {
-          "enum": [
-            "oid4vp"
-          ],
+          "enum": ["oid4vp"],
           "type": "string",
           "description": "Authorization server implementation type",
           "example": "oid4vp"
@@ -2271,19 +1971,13 @@
           "default": false
         }
       },
-      "required": [
-        "type",
-        "id",
-        "presentationConfigId"
-      ],
+      "required": ["type", "id", "presentationConfigId"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpstreamOidcConfig.schema.json",
-    "fileMatch": [
-      "a://b/UpstreamOidcConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpstreamOidcConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpstreamOidcConfig.schema.json",
@@ -2307,28 +2001,20 @@
         },
         "scopes": {
           "description": "Scopes to request from the upstream provider",
-          "default": [
-            "openid",
-            "profile"
-          ],
+          "default": ["openid", "profile"],
           "type": "array",
           "items": {
             "type": "string"
           }
         }
       },
-      "required": [
-        "issuer",
-        "clientId"
-      ],
+      "required": ["issuer", "clientId"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAuthorizationServerConfig.schema.json",
-    "fileMatch": [
-      "a://b/ChainedAuthorizationServerConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/ChainedAuthorizationServerConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAuthorizationServerConfig.schema.json",
@@ -2336,9 +2022,7 @@
       "type": "object",
       "properties": {
         "type": {
-          "enum": [
-            "chained"
-          ],
+          "enum": ["chained"],
           "type": "string",
           "description": "Authorization server implementation type",
           "example": "chained"
@@ -2375,18 +2059,13 @@
           "default": false
         }
       },
-      "required": [
-        "type",
-        "upstream"
-      ],
+      "required": ["type", "upstream"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/BuiltInAuthorizationServerConfig.schema.json",
-    "fileMatch": [
-      "a://b/BuiltInAuthorizationServerConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/BuiltInAuthorizationServerConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/BuiltInAuthorizationServerConfig.schema.json",
@@ -2394,9 +2073,7 @@
       "type": "object",
       "properties": {
         "type": {
-          "enum": [
-            "built-in"
-          ],
+          "enum": ["built-in"],
           "type": "string",
           "description": "Authorization server implementation type",
           "example": "built-in"
@@ -2425,17 +2102,13 @@
           "default": false
         }
       },
-      "required": [
-        "type"
-      ],
+      "required": ["type"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FederationTrustAnchorConfig.schema.json",
-    "fileMatch": [
-      "a://b/FederationTrustAnchorConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/FederationTrustAnchorConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FederationTrustAnchorConfig.schema.json",
@@ -2453,18 +2126,13 @@
           "example": "https://ta.example.org/.well-known/openid-federation"
         }
       },
-      "required": [
-        "entityId",
-        "entityConfigurationUri"
-      ],
+      "required": ["entityId", "entityConfigurationUri"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FederationConfig.schema.json",
-    "fileMatch": [
-      "a://b/FederationConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/FederationConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FederationConfig.schema.json",
@@ -2472,20 +2140,13 @@
       "type": "object",
       "properties": {
         "role": {
-          "enum": [
-            "trust_anchor",
-            "intermediate",
-            "leaf"
-          ],
+          "enum": ["trust_anchor", "intermediate", "leaf"],
           "type": "string",
           "description": "Role this tenant plays in the OpenID Federation topology.",
           "default": "leaf"
         },
         "mode": {
-          "enum": [
-            "federation-only",
-            "hybrid"
-          ],
+          "enum": ["federation-only", "hybrid"],
           "type": "string",
           "description": "Trust decision strategy when both LoTE trust lists and OpenID Federation are configured.",
           "default": "hybrid"
@@ -2513,17 +2174,13 @@
           }
         }
       },
-      "required": [
-        "trustAnchors"
-      ],
+      "required": ["trustAnchors"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerProvidedAttestation.schema.json",
-    "fileMatch": [
-      "a://b/IssuerProvidedAttestation*.schema.json"
-    ],
+    "fileMatch": ["a://b/IssuerProvidedAttestation*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerProvidedAttestation.schema.json",
@@ -2546,9 +2203,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerRegistrationCertificateConfig.schema.json",
-    "fileMatch": [
-      "a://b/IssuerRegistrationCertificateConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/IssuerRegistrationCertificateConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerRegistrationCertificateConfig.schema.json",
@@ -2561,10 +2216,7 @@
           "default": false
         },
         "mode": {
-          "enum": [
-            "import",
-            "generate"
-          ],
+          "enum": ["import", "generate"],
           "type": "string",
           "description": "import: use an existing JWT, generate: create via registrar from provided attestations and selected credential configurations.",
           "default": "import"
@@ -2603,9 +2255,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerRegistrationCertificateCache.schema.json",
-    "fileMatch": [
-      "a://b/IssuerRegistrationCertificateCache*.schema.json"
-    ],
+    "fileMatch": ["a://b/IssuerRegistrationCertificateCache*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerRegistrationCertificateCache.schema.json",
@@ -2638,9 +2288,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayLogo.schema.json",
-    "fileMatch": [
-      "a://b/DisplayLogo*.schema.json"
-    ],
+    "fileMatch": ["a://b/DisplayLogo*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayLogo.schema.json",
@@ -2654,17 +2302,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "uri"
-      ],
+      "required": ["uri"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayInfo.schema.json",
-    "fileMatch": [
-      "a://b/DisplayInfo*.schema.json"
-    ],
+    "fileMatch": ["a://b/DisplayInfo*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayInfo.schema.json",
@@ -2686,9 +2330,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuanceConfig.schema.json",
-    "fileMatch": [
-      "a://b/IssuanceConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/IssuanceConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuanceConfig.schema.json",
@@ -2820,21 +2462,13 @@
           "description": "The timestamp when the VP request was last updated."
         }
       },
-      "required": [
-        "authorizationServers",
-        "tenant",
-        "display",
-        "createdAt",
-        "updatedAt"
-      ],
+      "required": ["authorizationServers", "tenant", "display", "createdAt", "updatedAt"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuanceDto.schema.json",
-    "fileMatch": [
-      "a://b/IssuanceDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/IssuanceDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuanceDto.schema.json",
@@ -2948,18 +2582,13 @@
           }
         }
       },
-      "required": [
-        "authorizationServers",
-        "display"
-      ],
+      "required": ["authorizationServers", "display"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClaimsQuery.schema.json",
-    "fileMatch": [
-      "a://b/ClaimsQuery*.schema.json"
-    ],
+    "fileMatch": ["a://b/ClaimsQuery*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClaimsQuery.schema.json",
@@ -2982,17 +2611,13 @@
           }
         }
       },
-      "required": [
-        "path"
-      ],
+      "required": ["path"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustedAuthorityQuery.schema.json",
-    "fileMatch": [
-      "a://b/TrustedAuthorityQuery*.schema.json"
-    ],
+    "fileMatch": ["a://b/TrustedAuthorityQuery*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustedAuthorityQuery.schema.json",
@@ -3001,10 +2626,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": [
-            "etsi_tl",
-            "openid_federation"
-          ]
+          "enum": ["etsi_tl", "openid_federation"]
         },
         "values": {
           "type": "array",
@@ -3013,18 +2635,13 @@
           }
         }
       },
-      "required": [
-        "type",
-        "values"
-      ],
+      "required": ["type", "values"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialQuery.schema.json",
-    "fileMatch": [
-      "a://b/CredentialQuery*.schema.json"
-    ],
+    "fileMatch": ["a://b/CredentialQuery*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialQuery.schema.json",
@@ -3067,19 +2684,13 @@
           }
         }
       },
-      "required": [
-        "id",
-        "format",
-        "meta"
-      ],
+      "required": ["id", "format", "meta"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialSetQuery.schema.json",
-    "fileMatch": [
-      "a://b/CredentialSetQuery*.schema.json"
-    ],
+    "fileMatch": ["a://b/CredentialSetQuery*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialSetQuery.schema.json",
@@ -3099,17 +2710,13 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "options"
-      ],
+      "required": ["options"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PolicyCredential.schema.json",
-    "fileMatch": [
-      "a://b/PolicyCredential*.schema.json"
-    ],
+    "fileMatch": ["a://b/PolicyCredential*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PolicyCredential.schema.json",
@@ -3135,17 +2742,13 @@
           }
         }
       },
-      "required": [
-        "credentials"
-      ],
+      "required": ["credentials"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AttestationBasedPolicy.schema.json",
-    "fileMatch": [
-      "a://b/AttestationBasedPolicy*.schema.json"
-    ],
+    "fileMatch": ["a://b/AttestationBasedPolicy*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AttestationBasedPolicy.schema.json",
@@ -3154,9 +2757,7 @@
       "properties": {
         "policy": {
           "type": "string",
-          "enum": [
-            "attestationBased"
-          ]
+          "enum": ["attestationBased"]
         },
         "values": {
           "type": "array",
@@ -3165,18 +2766,13 @@
           }
         }
       },
-      "required": [
-        "policy",
-        "values"
-      ],
+      "required": ["policy", "values"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/NoneTrustPolicy.schema.json",
-    "fileMatch": [
-      "a://b/NoneTrustPolicy*.schema.json"
-    ],
+    "fileMatch": ["a://b/NoneTrustPolicy*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/NoneTrustPolicy.schema.json",
@@ -3185,22 +2781,16 @@
       "properties": {
         "policy": {
           "type": "string",
-          "enum": [
-            "none"
-          ]
+          "enum": ["none"]
         }
       },
-      "required": [
-        "policy"
-      ],
+      "required": ["policy"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AllowListPolicy.schema.json",
-    "fileMatch": [
-      "a://b/AllowListPolicy*.schema.json"
-    ],
+    "fileMatch": ["a://b/AllowListPolicy*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AllowListPolicy.schema.json",
@@ -3209,9 +2799,7 @@
       "properties": {
         "policy": {
           "type": "string",
-          "enum": [
-            "allowList"
-          ]
+          "enum": ["allowList"]
         },
         "values": {
           "type": "array",
@@ -3220,18 +2808,13 @@
           }
         }
       },
-      "required": [
-        "policy",
-        "values"
-      ],
+      "required": ["policy", "values"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RootOfTrustPolicy.schema.json",
-    "fileMatch": [
-      "a://b/RootOfTrustPolicy*.schema.json"
-    ],
+    "fileMatch": ["a://b/RootOfTrustPolicy*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RootOfTrustPolicy.schema.json",
@@ -3240,26 +2823,19 @@
       "properties": {
         "policy": {
           "type": "string",
-          "enum": [
-            "rootOfTrust"
-          ]
+          "enum": ["rootOfTrust"]
         },
         "values": {
           "type": "string"
         }
       },
-      "required": [
-        "policy",
-        "values"
-      ],
+      "required": ["policy", "values"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/VCT.schema.json",
-    "fileMatch": [
-      "a://b/VCT*.schema.json"
-    ],
+    "fileMatch": ["a://b/VCT*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/VCT.schema.json",
@@ -3293,9 +2869,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IaeActionOpenid4vpPresentation.schema.json",
-    "fileMatch": [
-      "a://b/IaeActionOpenid4vpPresentation*.schema.json"
-    ],
+    "fileMatch": ["a://b/IaeActionOpenid4vpPresentation*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IaeActionOpenid4vpPresentation.schema.json",
@@ -3303,9 +2877,7 @@
       "type": "object",
       "properties": {
         "type": {
-          "enum": [
-            "openid4vp_presentation"
-          ],
+          "enum": ["openid4vp_presentation"],
           "type": "string",
           "description": "Action type discriminator",
           "example": "openid4vp_presentation"
@@ -3321,18 +2893,13 @@
           "example": "pid-presentation-config"
         }
       },
-      "required": [
-        "type",
-        "presentationConfigId"
-      ],
+      "required": ["type", "presentationConfigId"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IaeActionRedirectToWeb.schema.json",
-    "fileMatch": [
-      "a://b/IaeActionRedirectToWeb*.schema.json"
-    ],
+    "fileMatch": ["a://b/IaeActionRedirectToWeb*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IaeActionRedirectToWeb.schema.json",
@@ -3340,9 +2907,7 @@
       "type": "object",
       "properties": {
         "type": {
-          "enum": [
-            "redirect_to_web"
-          ],
+          "enum": ["redirect_to_web"],
           "type": "string",
           "description": "Action type discriminator",
           "example": "redirect_to_web"
@@ -3370,18 +2935,13 @@
           "example": "Please complete the identity verification form"
         }
       },
-      "required": [
-        "type",
-        "url"
-      ],
+      "required": ["type", "url"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebhookEndpointEntity.schema.json",
-    "fileMatch": [
-      "a://b/WebhookEndpointEntity*.schema.json"
-    ],
+    "fileMatch": ["a://b/WebhookEndpointEntity*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebhookEndpointEntity.schema.json",
@@ -3419,22 +2979,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "id",
-        "auth",
-        "tenantId",
-        "tenant",
-        "name",
-        "url"
-      ],
+      "required": ["id", "auth", "tenantId", "tenant", "name", "url"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaUriEntry.schema.json",
-    "fileMatch": [
-      "a://b/SchemaUriEntry*.schema.json"
-    ],
+    "fileMatch": ["a://b/SchemaUriEntry*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaUriEntry.schema.json",
@@ -3466,9 +3017,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustAuthorityEntry.schema.json",
-    "fileMatch": [
-      "a://b/TrustAuthorityEntry*.schema.json"
-    ],
+    "fileMatch": ["a://b/TrustAuthorityEntry*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustAuthorityEntry.schema.json",
@@ -3480,11 +3029,7 @@
           "description": "Trust list ID to resolve from the database. When set, frameworkType, value, and verificationMethod are derived automatically."
         },
         "frameworkType": {
-          "enum": [
-            "aki",
-            "etsi_tl",
-            "openid_federation"
-          ],
+          "enum": ["aki", "etsi_tl", "openid_federation"],
           "type": "string",
           "description": "Trust framework type (ignored when trustListId is set)"
         },
@@ -3515,9 +3060,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetaConfig.schema.json",
-    "fileMatch": [
-      "a://b/SchemaMetaConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/SchemaMetaConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetaConfig.schema.json",
@@ -3550,12 +3093,7 @@
           "description": "Attestation Level of Security"
         },
         "bindingType": {
-          "enum": [
-            "claim",
-            "key",
-            "biometric",
-            "none"
-          ],
+          "enum": ["claim", "key", "biometric", "none"],
           "type": "string",
           "description": "Cryptographic binding type"
         },
@@ -3579,9 +3117,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EmbeddedDisclosurePolicy.schema.json",
-    "fileMatch": [
-      "a://b/EmbeddedDisclosurePolicy*.schema.json"
-    ],
+    "fileMatch": ["a://b/EmbeddedDisclosurePolicy*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EmbeddedDisclosurePolicy.schema.json",
@@ -3592,17 +3128,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "policy"
-      ],
+      "required": ["policy"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyAttestationsRequired.schema.json",
-    "fileMatch": [
-      "a://b/KeyAttestationsRequired*.schema.json"
-    ],
+    "fileMatch": ["a://b/KeyAttestationsRequired*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyAttestationsRequired.schema.json",
@@ -3611,10 +3143,7 @@
       "properties": {
         "key_storage": {
           "description": "List of required key storage types (e.g., iso_18045_high, iso_18045_moderate)",
-          "example": [
-            "iso_18045_high",
-            "iso_18045_moderate"
-          ],
+          "example": ["iso_18045_high", "iso_18045_moderate"],
           "type": "array",
           "items": {
             "type": "string"
@@ -3622,10 +3151,7 @@
         },
         "user_authentication": {
           "description": "List of required user authentication types (e.g., iso_18045_high, iso_18045_moderate)",
-          "example": [
-            "iso_18045_high",
-            "iso_18045_moderate"
-          ],
+          "example": ["iso_18045_high", "iso_18045_moderate"],
           "type": "array",
           "items": {
             "type": "string"
@@ -3637,9 +3163,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayImage.schema.json",
-    "fileMatch": [
-      "a://b/DisplayImage*.schema.json"
-    ],
+    "fileMatch": ["a://b/DisplayImage*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayImage.schema.json",
@@ -3650,17 +3174,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "uri"
-      ],
+      "required": ["uri"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Display.schema.json",
-    "fileMatch": [
-      "a://b/Display*.schema.json"
-    ],
+    "fileMatch": ["a://b/Display*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Display.schema.json",
@@ -3689,19 +3209,13 @@
           "$ref": "./DisplayImage.schema.json"
         }
       },
-      "required": [
-        "name",
-        "description",
-        "locale"
-      ],
+      "required": ["name", "description", "locale"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerMetadataCredentialConfig.schema.json",
-    "fileMatch": [
-      "a://b/IssuerMetadataCredentialConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/IssuerMetadataCredentialConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerMetadataCredentialConfig.schema.json",
@@ -3718,10 +3232,7 @@
         },
         "format": {
           "type": "string",
-          "enum": [
-            "mso_mdoc",
-            "dc+sd-jwt"
-          ]
+          "enum": ["mso_mdoc", "dc+sd-jwt"]
         },
         "display": {
           "type": "array",
@@ -3737,18 +3248,13 @@
           "description": "Document type for mDOC credentials (e.g., \"org.iso.18013.5.1.mDL\").\nOnly applicable when format is \"mso_mdoc\"."
         }
       },
-      "required": [
-        "format",
-        "display"
-      ],
+      "required": ["format", "display"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FieldDisplayDto.schema.json",
-    "fileMatch": [
-      "a://b/FieldDisplayDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/FieldDisplayDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FieldDisplayDto.schema.json",
@@ -3771,18 +3277,13 @@
           "example": "Primary first name"
         }
       },
-      "required": [
-        "locale",
-        "name"
-      ],
+      "required": ["locale", "name"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClaimFieldDefinitionDto.schema.json",
-    "fileMatch": [
-      "a://b/ClaimFieldDefinitionDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ClaimFieldDefinitionDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClaimFieldDefinitionDto.schema.json",
@@ -3792,10 +3293,7 @@
         "path": {
           "type": "array",
           "description": "Path to claim value. For nested child fields this can be relative to the parent path.",
-          "example": [
-            "address",
-            "locality"
-          ],
+          "example": ["address", "locality"],
           "items": {
             "oneOf": [
               {
@@ -3811,14 +3309,7 @@
           }
         },
         "type": {
-          "enum": [
-            "string",
-            "number",
-            "integer",
-            "boolean",
-            "object",
-            "array"
-          ],
+          "enum": ["string", "number", "integer", "boolean", "object", "array"],
           "type": "string",
           "description": "Claim value type"
         },
@@ -3879,18 +3370,13 @@
           }
         }
       },
-      "required": [
-        "path",
-        "type"
-      ],
+      "required": ["path", "type"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AttributeProviderEntity.schema.json",
-    "fileMatch": [
-      "a://b/AttributeProviderEntity*.schema.json"
-    ],
+    "fileMatch": ["a://b/AttributeProviderEntity*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AttributeProviderEntity.schema.json",
@@ -3927,22 +3413,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "auth",
-        "id",
-        "tenantId",
-        "tenant",
-        "name",
-        "url"
-      ],
+      "required": ["auth", "id", "tenantId", "tenant", "name", "url"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainEntity.schema.json",
-    "fileMatch": [
-      "a://b/KeyChainEntity*.schema.json"
-    ],
+    "fileMatch": ["a://b/KeyChainEntity*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainEntity.schema.json",
@@ -3972,21 +3449,12 @@
         "usageType": {
           "type": "string",
           "description": "The purpose/role of this key chain in the system.",
-          "enum": [
-            "access",
-            "attestation",
-            "trustList",
-            "statusList",
-            "encrypt"
-          ]
+          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"]
         },
         "usage": {
           "type": "string",
           "description": "The usage type of the keys (sign or encrypt).",
-          "enum": [
-            "sign",
-            "encrypt"
-          ]
+          "enum": ["sign", "encrypt"]
         },
         "kmsProvider": {
           "type": "string",
@@ -4066,9 +3534,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfig.schema.json",
-    "fileMatch": [
-      "a://b/CredentialConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/CredentialConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfig.schema.json",
@@ -4195,30 +3661,20 @@
         "sdJwtTrustFormat": {
           "nullable": true,
           "description": "For SD-JWT credentials: determines whether to include certificate chain (x5c)\nor use federation-based trust (iss claim).\nDefault: \"x5c\" (federation must be explicitly selected)",
-          "enum": [
-            "x5c",
-            "federation"
-          ],
+          "enum": ["x5c", "federation"],
           "type": "string"
         },
         "lifeTime": {
           "type": "number"
         }
       },
-      "required": [
-        "id",
-        "tenant",
-        "config",
-        "fields"
-      ],
+      "required": ["id", "tenant", "config", "fields"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfigCreate.schema.json",
-    "fileMatch": [
-      "a://b/CredentialConfigCreate*.schema.json"
-    ],
+    "fileMatch": ["a://b/CredentialConfigCreate*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfigCreate.schema.json",
@@ -4328,29 +3784,20 @@
         "sdJwtTrustFormat": {
           "nullable": true,
           "description": "For SD-JWT credentials: determines whether to include certificate chain (x5c)\nor use federation-based trust (iss claim).\nDefault: \"x5c\" (federation must be explicitly selected)",
-          "enum": [
-            "x5c",
-            "federation"
-          ],
+          "enum": ["x5c", "federation"],
           "type": "string"
         },
         "lifeTime": {
           "type": "number"
         }
       },
-      "required": [
-        "id",
-        "config",
-        "fields"
-      ],
+      "required": ["id", "config", "fields"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfigUpdate.schema.json",
-    "fileMatch": [
-      "a://b/CredentialConfigUpdate*.schema.json"
-    ],
+    "fileMatch": ["a://b/CredentialConfigUpdate*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfigUpdate.schema.json",
@@ -4460,10 +3907,7 @@
         "sdJwtTrustFormat": {
           "nullable": true,
           "description": "For SD-JWT credentials: determines whether to include certificate chain (x5c)\nor use federation-based trust (iss claim).\nDefault: \"x5c\" (federation must be explicitly selected)",
-          "enum": [
-            "x5c",
-            "federation"
-          ],
+          "enum": ["x5c", "federation"],
           "type": "string"
         },
         "lifeTime": {
@@ -4475,9 +3919,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SignSchemaMetaConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/SignSchemaMetaConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/SignSchemaMetaConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SignSchemaMetaConfigDto.schema.json",
@@ -4501,17 +3943,13 @@
           "description": "ID of the credential config to link back after submission. When provided, schemaMeta.id on the credential config is updated with the reserved attestation ID."
         }
       },
-      "required": [
-        "config"
-      ],
+      "required": ["config"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SignVersionSchemaMetaConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/SignVersionSchemaMetaConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/SignVersionSchemaMetaConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SignVersionSchemaMetaConfigDto.schema.json",
@@ -4531,17 +3969,13 @@
           "description": "ID of the key chain to use for signing. Defaults to the tenant's default key chain."
         }
       },
-      "required": [
-        "config"
-      ],
+      "required": ["config"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/VocabularyEntryDto.schema.json",
-    "fileMatch": [
-      "a://b/VocabularyEntryDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/VocabularyEntryDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/VocabularyEntryDto.schema.json",
@@ -4557,10 +3991,7 @@
           "description": "Display label for UI rendering."
         },
         "status": {
-          "enum": [
-            "active",
-            "deprecated"
-          ],
+          "enum": ["active", "deprecated"],
           "type": "string",
           "description": "Vocabulary lifecycle status."
         },
@@ -4569,19 +4000,13 @@
           "description": "Replacement code when status is deprecated."
         }
       },
-      "required": [
-        "code",
-        "label",
-        "status"
-      ],
+      "required": ["code", "label", "status"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetadataVocabulariesDto.schema.json",
-    "fileMatch": [
-      "a://b/SchemaMetadataVocabulariesDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/SchemaMetadataVocabulariesDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetadataVocabulariesDto.schema.json",
@@ -4607,19 +4032,13 @@
           }
         }
       },
-      "required": [
-        "version",
-        "categories",
-        "tags"
-      ],
+      "required": ["version", "categories", "tags"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/MetadataSchemaDto.schema.json",
-    "fileMatch": [
-      "a://b/MetadataSchemaDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/MetadataSchemaDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/MetadataSchemaDto.schema.json",
@@ -4631,10 +4050,7 @@
           "description": "Unique identifier for this schema entry"
         },
         "formatIdentifier": {
-          "enum": [
-            "dc+sd-jwt",
-            "mso_mdoc"
-          ],
+          "enum": ["dc+sd-jwt", "mso_mdoc"],
           "type": "string",
           "description": "The credential format identifier"
         },
@@ -4652,18 +4068,13 @@
           "description": "Subresource Integrity hash for the schema"
         }
       },
-      "required": [
-        "id",
-        "formatIdentifier"
-      ],
+      "required": ["id", "formatIdentifier"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustAuthorityDto.schema.json",
-    "fileMatch": [
-      "a://b/TrustAuthorityDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/TrustAuthorityDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustAuthorityDto.schema.json",
@@ -4677,9 +4088,7 @@
         "frameworkType": {
           "type": "string",
           "description": "Type of trust framework",
-          "enum": [
-            "etsi_tl"
-          ]
+          "enum": ["etsi_tl"]
         },
         "value": {
           "type": "string",
@@ -4691,19 +4100,13 @@
           "description": "Verification method for the trust list signature (e.g., JWK)"
         }
       },
-      "required": [
-        "id",
-        "frameworkType",
-        "value"
-      ],
+      "required": ["id", "frameworkType", "value"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AccessCertificateRefDto.schema.json",
-    "fileMatch": [
-      "a://b/AccessCertificateRefDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/AccessCertificateRefDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AccessCertificateRefDto.schema.json",
@@ -4726,21 +4129,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "id",
-        "relyingPartyId",
-        "certificate",
-        "revoked",
-        "createdAt"
-      ],
+      "required": ["id", "relyingPartyId", "certificate", "revoked", "createdAt"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetadataResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/SchemaMetadataResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/SchemaMetadataResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetadataResponseDto.schema.json",
@@ -4774,12 +4169,7 @@
           "description": "Level of security (LoS) of this attestation"
         },
         "bindingType": {
-          "enum": [
-            "claim",
-            "key",
-            "biometric",
-            "none"
-          ],
+          "enum": ["claim", "key", "biometric", "none"],
           "type": "string",
           "description": "Required binding type between attestation and holder"
         },
@@ -4787,10 +4177,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "enum": [
-              "dc+sd-jwt",
-              "mso_mdoc"
-            ]
+            "enum": ["dc+sd-jwt", "mso_mdoc"]
           },
           "description": "Credential formats in which this attestation is available"
         },
@@ -4809,15 +4196,7 @@
           }
         },
         "category": {
-          "enum": [
-            "identity",
-            "health",
-            "finance",
-            "education",
-            "mobility",
-            "employment",
-            "other"
-          ],
+          "enum": ["identity", "health", "finance", "education", "mobility", "employment", "other"],
           "type": "string",
           "description": "Domain category for filtering"
         },
@@ -4893,9 +4272,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateSchemaMetadataDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateSchemaMetadataDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateSchemaMetadataDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateSchemaMetadataDto.schema.json",
@@ -4903,15 +4280,7 @@
       "type": "object",
       "properties": {
         "category": {
-          "enum": [
-            "identity",
-            "health",
-            "finance",
-            "education",
-            "mobility",
-            "employment",
-            "other"
-          ],
+          "enum": ["identity", "health", "finance", "education", "mobility", "employment", "other"],
           "type": "string",
           "description": "Domain category for filtering"
         },
@@ -4940,9 +4309,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeprecateSchemaMetadataDto.schema.json",
-    "fileMatch": [
-      "a://b/DeprecateSchemaMetadataDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/DeprecateSchemaMetadataDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeprecateSchemaMetadataDto.schema.json",
@@ -4962,17 +4329,13 @@
           "description": "The version that supersedes this one"
         }
       },
-      "required": [
-        "deprecated"
-      ],
+      "required": ["deprecated"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateAttributeProviderDto.schema.json",
-    "fileMatch": [
-      "a://b/CreateAttributeProviderDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CreateAttributeProviderDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateAttributeProviderDto.schema.json",
@@ -5003,20 +4366,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "auth",
-        "id",
-        "name",
-        "url"
-      ],
+      "required": ["auth", "id", "name", "url"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateAttributeProviderDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateAttributeProviderDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateAttributeProviderDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateAttributeProviderDto.schema.json",
@@ -5052,9 +4408,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateWebhookEndpointDto.schema.json",
-    "fileMatch": [
-      "a://b/CreateWebhookEndpointDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CreateWebhookEndpointDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateWebhookEndpointDto.schema.json",
@@ -5086,20 +4440,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "id",
-        "auth",
-        "name",
-        "url"
-      ],
+      "required": ["id", "auth", "name", "url"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateWebhookEndpointDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateWebhookEndpointDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateWebhookEndpointDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateWebhookEndpointDto.schema.json",
@@ -5136,9 +4483,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListEntityInfo.schema.json",
-    "fileMatch": [
-      "a://b/TrustListEntityInfo*.schema.json"
-    ],
+    "fileMatch": ["a://b/TrustListEntityInfo*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListEntityInfo.schema.json",
@@ -5170,17 +4515,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "name"
-      ],
+      "required": ["name"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InternalTrustListEntity.schema.json",
-    "fileMatch": [
-      "a://b/InternalTrustListEntity*.schema.json"
-    ],
+    "fileMatch": ["a://b/InternalTrustListEntity*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InternalTrustListEntity.schema.json",
@@ -5189,9 +4530,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": [
-            "internal"
-          ]
+          "enum": ["internal"]
         },
         "issuerKeyChainId": {
           "type": "string"
@@ -5203,20 +4542,13 @@
           "$ref": "./TrustListEntityInfo.schema.json"
         }
       },
-      "required": [
-        "type",
-        "issuerKeyChainId",
-        "revocationKeyChainId",
-        "info"
-      ],
+      "required": ["type", "issuerKeyChainId", "revocationKeyChainId", "info"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExternalTrustListEntity.schema.json",
-    "fileMatch": [
-      "a://b/ExternalTrustListEntity*.schema.json"
-    ],
+    "fileMatch": ["a://b/ExternalTrustListEntity*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExternalTrustListEntity.schema.json",
@@ -5225,9 +4557,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": [
-            "external"
-          ]
+          "enum": ["external"]
         },
         "issuerCertPem": {
           "type": "string"
@@ -5239,20 +4569,13 @@
           "$ref": "./TrustListEntityInfo.schema.json"
         }
       },
-      "required": [
-        "type",
-        "issuerCertPem",
-        "revocationCertPem",
-        "info"
-      ],
+      "required": ["type", "issuerCertPem", "revocationCertPem", "info"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListCreateDto.schema.json",
-    "fileMatch": [
-      "a://b/TrustListCreateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/TrustListCreateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListCreateDto.schema.json",
@@ -5293,17 +4616,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "entities"
-      ],
+      "required": ["entities"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustList.schema.json",
-    "fileMatch": [
-      "a://b/TrustList*.schema.json"
-    ],
+    "fileMatch": ["a://b/TrustList*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustList.schema.json",
@@ -5379,9 +4698,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListVersion.schema.json",
-    "fileMatch": [
-      "a://b/TrustListVersion*.schema.json"
-    ],
+    "fileMatch": ["a://b/TrustListVersion*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListVersion.schema.json",
@@ -5436,9 +4753,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DCQL.schema.json",
-    "fileMatch": [
-      "a://b/DCQL*.schema.json"
-    ],
+    "fileMatch": ["a://b/DCQL*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DCQL.schema.json",
@@ -5458,17 +4773,13 @@
           }
         }
       },
-      "required": [
-        "credentials"
-      ],
+      "required": ["credentials"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificatePurpose.schema.json",
-    "fileMatch": [
-      "a://b/RegistrationCertificatePurpose*.schema.json"
-    ],
+    "fileMatch": ["a://b/RegistrationCertificatePurpose*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificatePurpose.schema.json",
@@ -5482,18 +4793,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "lang",
-        "content"
-      ],
+      "required": ["lang", "content"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateBody.schema.json",
-    "fileMatch": [
-      "a://b/RegistrationCertificateBody*.schema.json"
-    ],
+    "fileMatch": ["a://b/RegistrationCertificateBody*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateBody.schema.json",
@@ -5533,9 +4839,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateRequest.schema.json",
-    "fileMatch": [
-      "a://b/RegistrationCertificateRequest*.schema.json"
-    ],
+    "fileMatch": ["a://b/RegistrationCertificateRequest*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateRequest.schema.json",
@@ -5564,9 +4868,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationAttachment.schema.json",
-    "fileMatch": [
-      "a://b/PresentationAttachment*.schema.json"
-    ],
+    "fileMatch": ["a://b/PresentationAttachment*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationAttachment.schema.json",
@@ -5586,18 +4888,13 @@
           }
         }
       },
-      "required": [
-        "format",
-        "data"
-      ],
+      "required": ["format", "data"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfig.schema.json",
-    "fileMatch": [
-      "a://b/PresentationConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/PresentationConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfig.schema.json",
@@ -5706,21 +5003,13 @@
           "description": "Optional ID of the access certificate to use for signing the presentation request.\nIf not provided, the default access certificate for the tenant will be used.\n\nNote: This is intentionally NOT a TypeORM relationship because CertEntity uses\na composite primary key (id + tenantId), and SQLite cannot create foreign keys\nthat reference only part of a composite primary key. The relationship is handled\nat the application level in the service layer."
         }
       },
-      "required": [
-        "id",
-        "tenant",
-        "dcql_query",
-        "createdAt",
-        "updatedAt"
-      ],
+      "required": ["id", "tenant", "dcql_query", "createdAt", "updatedAt"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ResolveIssuerMetadataDto.schema.json",
-    "fileMatch": [
-      "a://b/ResolveIssuerMetadataDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ResolveIssuerMetadataDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ResolveIssuerMetadataDto.schema.json",
@@ -5734,17 +5023,13 @@
           "example": "https://issuer.example.com/issuers/tenant-a"
         }
       },
-      "required": [
-        "issuerUrl"
-      ],
+      "required": ["issuerUrl"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ResolveSchemaMetadataDto.schema.json",
-    "fileMatch": [
-      "a://b/ResolveSchemaMetadataDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ResolveSchemaMetadataDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ResolveSchemaMetadataDto.schema.json",
@@ -5758,17 +5043,13 @@
           "example": "https://registrar.example.com/schema-metadata/5c0d7dbb-ef2e-448b-b84f-b8103575947b"
         }
       },
-      "required": [
-        "schemaMetadataUrl"
-      ],
+      "required": ["schemaMetadataUrl"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfigCreateDto.schema.json",
-    "fileMatch": [
-      "a://b/PresentationConfigCreateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/PresentationConfigCreateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfigCreateDto.schema.json",
@@ -5851,18 +5132,13 @@
           "description": "Optional ID of the access certificate to use for signing the presentation request.\nIf not provided, the default access certificate for the tenant will be used.\n\nNote: This is intentionally NOT a TypeORM relationship because CertEntity uses\na composite primary key (id + tenantId), and SQLite cannot create foreign keys\nthat reference only part of a composite primary key. The relationship is handled\nat the application level in the service layer."
         }
       },
-      "required": [
-        "id",
-        "dcql_query"
-      ],
+      "required": ["id", "dcql_query"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfigUpdateDto.schema.json",
-    "fileMatch": [
-      "a://b/PresentationConfigUpdateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/PresentationConfigUpdateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfigUpdateDto.schema.json",
@@ -5950,9 +5226,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateDefaults.schema.json",
-    "fileMatch": [
-      "a://b/RegistrationCertificateDefaults*.schema.json"
-    ],
+    "fileMatch": ["a://b/RegistrationCertificateDefaults*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateDefaults.schema.json",
@@ -5975,9 +5249,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrarConfigResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/RegistrarConfigResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/RegistrarConfigResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrarConfigResponseDto.schema.json",
@@ -6025,21 +5297,13 @@
           "example": true
         }
       },
-      "required": [
-        "registrarUrl",
-        "oidcUrl",
-        "clientId",
-        "username",
-        "hasPassword"
-      ],
+      "required": ["registrarUrl", "oidcUrl", "clientId", "username", "hasPassword"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateRegistrarConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/CreateRegistrarConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CreateRegistrarConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateRegistrarConfigDto.schema.json",
@@ -6086,21 +5350,13 @@
           ]
         }
       },
-      "required": [
-        "registrarUrl",
-        "oidcUrl",
-        "clientId",
-        "username",
-        "password"
-      ],
+      "required": ["registrarUrl", "oidcUrl", "clientId", "username", "password"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateRegistrarConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateRegistrarConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateRegistrarConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateRegistrarConfigDto.schema.json",
@@ -6152,9 +5408,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateAccessCertificateDto.schema.json",
-    "fileMatch": [
-      "a://b/CreateAccessCertificateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CreateAccessCertificateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateAccessCertificateDto.schema.json",
@@ -6167,17 +5421,13 @@
           "example": "my-signing-key"
         }
       },
-      "required": [
-        "keyId"
-      ],
+      "required": ["keyId"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeferredCredentialRequestDto.schema.json",
-    "fileMatch": [
-      "a://b/DeferredCredentialRequestDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/DeferredCredentialRequestDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeferredCredentialRequestDto.schema.json",
@@ -6190,17 +5440,13 @@
           "example": "8xLOxBtZp8"
         }
       },
-      "required": [
-        "transaction_id"
-      ],
+      "required": ["transaction_id"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/NotificationRequestDto.schema.json",
-    "fileMatch": [
-      "a://b/NotificationRequestDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/NotificationRequestDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/NotificationRequestDto.schema.json",
@@ -6212,25 +5458,16 @@
         },
         "event": {
           "type": "string",
-          "enum": [
-            "credential_accepted",
-            "credential_failure",
-            "credential_deleted"
-          ]
+          "enum": ["credential_accepted", "credential_failure", "credential_deleted"]
         }
       },
-      "required": [
-        "notification_id",
-        "event"
-      ],
+      "required": ["notification_id", "event"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/OfferResponse.schema.json",
-    "fileMatch": [
-      "a://b/OfferResponse*.schema.json"
-    ],
+    "fileMatch": ["a://b/OfferResponse*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/OfferResponse.schema.json",
@@ -6248,18 +5485,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "uri",
-        "session"
-      ],
+      "required": ["uri", "session"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CompleteDeferredDto.schema.json",
-    "fileMatch": [
-      "a://b/CompleteDeferredDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CompleteDeferredDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CompleteDeferredDto.schema.json",
@@ -6277,17 +5509,13 @@
           }
         }
       },
-      "required": [
-        "claims"
-      ],
+      "required": ["claims"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeferredOperationResponse.schema.json",
-    "fileMatch": [
-      "a://b/DeferredOperationResponse*.schema.json"
-    ],
+    "fileMatch": ["a://b/DeferredOperationResponse*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeferredOperationResponse.schema.json",
@@ -6300,13 +5528,7 @@
         },
         "status": {
           "description": "The new status of the transaction",
-          "enum": [
-            "pending",
-            "ready",
-            "retrieved",
-            "expired",
-            "failed"
-          ],
+          "enum": ["pending", "ready", "retrieved", "expired", "failed"],
           "type": "string"
         },
         "message": {
@@ -6314,18 +5536,13 @@
           "description": "Optional message"
         }
       },
-      "required": [
-        "transactionId",
-        "status"
-      ],
+      "required": ["transactionId", "status"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FailDeferredDto.schema.json",
-    "fileMatch": [
-      "a://b/FailDeferredDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/FailDeferredDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FailDeferredDto.schema.json",
@@ -6343,9 +5560,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EC_Public.schema.json",
-    "fileMatch": [
-      "a://b/EC_Public*.schema.json"
-    ],
+    "fileMatch": ["a://b/EC_Public*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EC_Public.schema.json",
@@ -6369,20 +5584,13 @@
           "description": "The y coordinate of the EC public key."
         }
       },
-      "required": [
-        "kty",
-        "crv",
-        "x",
-        "y"
-      ],
+      "required": ["kty", "crv", "x", "y"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/JwksResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/JwksResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/JwksResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/JwksResponseDto.schema.json",
@@ -6397,17 +5605,13 @@
           }
         }
       },
-      "required": [
-        "keys"
-      ],
+      "required": ["keys"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthorizationResponse.schema.json",
-    "fileMatch": [
-      "a://b/AuthorizationResponse*.schema.json"
-    ],
+    "fileMatch": ["a://b/AuthorizationResponse*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthorizationResponse.schema.json",
@@ -6443,9 +5647,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Object.schema.json",
-    "fileMatch": [
-      "a://b/Object*.schema.json"
-    ],
+    "fileMatch": ["a://b/Object*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Object.schema.json",
@@ -6457,9 +5659,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ParResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/ParResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ParResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ParResponseDto.schema.json",
@@ -6475,18 +5675,13 @@
           "description": "The expiration time for the request URI in seconds."
         }
       },
-      "required": [
-        "request_uri",
-        "expires_in"
-      ],
+      "required": ["request_uri", "expires_in"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationRequestDto.schema.json",
-    "fileMatch": [
-      "a://b/InteractiveAuthorizationRequestDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/InteractiveAuthorizationRequestDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationRequestDto.schema.json",
@@ -6559,9 +5754,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationCodeResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/InteractiveAuthorizationCodeResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/InteractiveAuthorizationCodeResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationCodeResponseDto.schema.json",
@@ -6579,18 +5772,13 @@
           "example": "auth-code-123"
         }
       },
-      "required": [
-        "status",
-        "code"
-      ],
+      "required": ["status", "code"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationErrorResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/InteractiveAuthorizationErrorResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/InteractiveAuthorizationErrorResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationErrorResponseDto.schema.json",
@@ -6608,17 +5796,13 @@
           "example": "Missing required parameter: interaction_types_supported"
         }
       },
-      "required": [
-        "error"
-      ],
+      "required": ["error"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsParResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/ChainedAsParResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ChainedAsParResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsParResponseDto.schema.json",
@@ -6636,18 +5820,13 @@
           "example": 600
         }
       },
-      "required": [
-        "request_uri",
-        "expires_in"
-      ],
+      "required": ["request_uri", "expires_in"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsErrorResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/ChainedAsErrorResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ChainedAsErrorResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsErrorResponseDto.schema.json",
@@ -6664,17 +5843,13 @@
           "description": "Human-readable error description"
         }
       },
-      "required": [
-        "error"
-      ],
+      "required": ["error"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenRequestDto.schema.json",
-    "fileMatch": [
-      "a://b/ChainedAsTokenRequestDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ChainedAsTokenRequestDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenRequestDto.schema.json",
@@ -6707,17 +5882,13 @@
           "description": "PKCE code verifier"
         }
       },
-      "required": [
-        "grant_type"
-      ],
+      "required": ["grant_type"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/ChainedAsTokenResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ChainedAsTokenResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenResponseDto.schema.json",
@@ -6762,19 +5933,13 @@
           "description": "Refresh token (issued when refresh tokens are enabled)"
         }
       },
-      "required": [
-        "access_token",
-        "token_type",
-        "expires_in"
-      ],
+      "required": ["access_token", "token_type", "expires_in"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProviderCapabilitiesDto.schema.json",
-    "fileMatch": [
-      "a://b/KmsProviderCapabilitiesDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KmsProviderCapabilitiesDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProviderCapabilitiesDto.schema.json",
@@ -6798,9 +5963,7 @@
         },
         "supportedAlgs": {
           "description": "Signing algorithms supported by the provider.",
-          "example": [
-            "ES256"
-          ],
+          "example": ["ES256"],
           "type": "array",
           "items": {
             "type": "string"
@@ -6812,21 +5975,13 @@
           "example": "ES256"
         }
       },
-      "required": [
-        "canImport",
-        "canCreate",
-        "canDelete",
-        "supportedAlgs",
-        "defaultAlg"
-      ],
+      "required": ["canImport", "canCreate", "canDelete", "supportedAlgs", "defaultAlg"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProviderInfoDto.schema.json",
-    "fileMatch": [
-      "a://b/KmsProviderInfoDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KmsProviderInfoDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProviderInfoDto.schema.json",
@@ -6857,19 +6012,13 @@
           ]
         }
       },
-      "required": [
-        "name",
-        "type",
-        "capabilities"
-      ],
+      "required": ["name", "type", "capabilities"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProvidersResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/KmsProvidersResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KmsProvidersResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProvidersResponseDto.schema.json",
@@ -6889,18 +6038,13 @@
           "example": "db"
         }
       },
-      "required": [
-        "providers",
-        "default"
-      ],
+      "required": ["providers", "default"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DbKmsConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/DbKmsConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/DbKmsConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DbKmsConfigDto.schema.json",
@@ -6913,9 +6057,7 @@
           "example": "main-vault"
         },
         "type": {
-          "enum": [
-            "db"
-          ],
+          "enum": ["db"],
           "type": "string",
           "description": "Type of the KMS provider.",
           "example": "db"
@@ -6926,18 +6068,13 @@
           "example": "Production HashiCorp Vault for signing keys"
         }
       },
-      "required": [
-        "id",
-        "type"
-      ],
+      "required": ["id", "type"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/VaultKmsConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/VaultKmsConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/VaultKmsConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/VaultKmsConfigDto.schema.json",
@@ -6950,9 +6087,7 @@
           "example": "main-vault"
         },
         "type": {
-          "enum": [
-            "vault"
-          ],
+          "enum": ["vault"],
           "type": "string",
           "description": "Type of the KMS provider.",
           "example": "vault"
@@ -6973,20 +6108,13 @@
           "example": "${VAULT_TOKEN}"
         }
       },
-      "required": [
-        "id",
-        "type",
-        "vaultUrl",
-        "vaultToken"
-      ],
+      "required": ["id", "type", "vaultUrl", "vaultToken"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AwsKmsConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/AwsKmsConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/AwsKmsConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AwsKmsConfigDto.schema.json",
@@ -6999,9 +6127,7 @@
           "example": "main-vault"
         },
         "type": {
-          "enum": [
-            "aws-kms"
-          ],
+          "enum": ["aws-kms"],
           "type": "string",
           "description": "Type of the KMS provider.",
           "example": "aws-kms"
@@ -7027,19 +6153,13 @@
           "example": "${AWS_SECRET_ACCESS_KEY}"
         }
       },
-      "required": [
-        "id",
-        "type",
-        "region"
-      ],
+      "required": ["id", "type", "region"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Pkcs11KmsConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/Pkcs11KmsConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/Pkcs11KmsConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Pkcs11KmsConfigDto.schema.json",
@@ -7052,9 +6172,7 @@
           "example": "main-vault"
         },
         "type": {
-          "enum": [
-            "pkcs11"
-          ],
+          "enum": ["pkcs11"],
           "type": "string",
           "description": "Type of the KMS provider.",
           "example": "pkcs11"
@@ -7085,21 +6203,13 @@
           "example": false
         }
       },
-      "required": [
-        "id",
-        "type",
-        "library",
-        "slot",
-        "pin"
-      ],
+      "required": ["id", "type", "library", "slot", "pin"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/HttpAuthBaseConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/HttpAuthBaseConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/HttpAuthBaseConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/HttpAuthBaseConfigDto.schema.json",
@@ -7107,27 +6217,18 @@
       "type": "object",
       "properties": {
         "type": {
-          "enum": [
-            "none",
-            "bearer",
-            "oauth2-client-credentials",
-            "mtls"
-          ],
+          "enum": ["none", "bearer", "oauth2-client-credentials", "mtls"],
           "type": "string",
           "description": "Authentication method for the remote KMS service."
         }
       },
-      "required": [
-        "type"
-      ],
+      "required": ["type"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/HttpKmsConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/HttpKmsConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/HttpKmsConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/HttpKmsConfigDto.schema.json",
@@ -7140,9 +6241,7 @@
           "example": "main-vault"
         },
         "type": {
-          "enum": [
-            "http"
-          ],
+          "enum": ["http"],
           "type": "string",
           "description": "Type of the KMS provider.",
           "example": "http"
@@ -7181,19 +6280,13 @@
           "example": false
         }
       },
-      "required": [
-        "id",
-        "type",
-        "baseUrl"
-      ],
+      "required": ["id", "type", "baseUrl"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CscAuthorizeAuthDataDto.schema.json",
-    "fileMatch": [
-      "a://b/CscAuthorizeAuthDataDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CscAuthorizeAuthDataDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CscAuthorizeAuthDataDto.schema.json",
@@ -7211,18 +6304,13 @@
           "example": "123456"
         }
       },
-      "required": [
-        "id",
-        "value"
-      ],
+      "required": ["id", "value"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CscKmsConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/CscKmsConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CscKmsConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CscKmsConfigDto.schema.json",
@@ -7235,9 +6323,7 @@
           "example": "main-vault"
         },
         "type": {
-          "enum": [
-            "csc"
-          ],
+          "enum": ["csc"],
           "type": "string",
           "description": "Type of the KMS provider.",
           "example": "csc"
@@ -7315,22 +6401,13 @@
           }
         }
       },
-      "required": [
-        "id",
-        "type",
-        "baseUrl",
-        "tokenUrl",
-        "clientId",
-        "clientSecret"
-      ],
+      "required": ["id", "type", "baseUrl", "tokenUrl", "clientId", "clientSecret"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/KmsConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KmsConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsConfigDto.schema.json",
@@ -7400,17 +6477,13 @@
           ]
         }
       },
-      "required": [
-        "providers"
-      ],
+      "required": ["providers"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsTenantConfigResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/KmsTenantConfigResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KmsTenantConfigResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsTenantConfigResponseDto.schema.json",
@@ -7436,17 +6509,13 @@
           ]
         }
       },
-      "required": [
-        "effectiveConfig"
-      ],
+      "required": ["effectiveConfig"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CertificateInfoDto.schema.json",
-    "fileMatch": [
-      "a://b/CertificateInfoDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CertificateInfoDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CertificateInfoDto.schema.json",
@@ -7480,17 +6549,13 @@
           "description": "Serial number."
         }
       },
-      "required": [
-        "pem"
-      ],
+      "required": ["pem"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PublicKeyInfoDto.schema.json",
-    "fileMatch": [
-      "a://b/PublicKeyInfoDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/PublicKeyInfoDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PublicKeyInfoDto.schema.json",
@@ -7517,17 +6582,13 @@
           "example": "P-256"
         }
       },
-      "required": [
-        "kty"
-      ],
+      "required": ["kty"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/RotationPolicyResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/RotationPolicyResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyResponseDto.schema.json",
@@ -7552,17 +6613,13 @@
           "description": "Next scheduled rotation date."
         }
       },
-      "required": [
-        "enabled"
-      ],
+      "required": ["enabled"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/KeyChainResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KeyChainResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainResponseDto.schema.json",
@@ -7574,21 +6631,12 @@
           "description": "Unique identifier for the key chain."
         },
         "usageType": {
-          "enum": [
-            "access",
-            "attestation",
-            "trustList",
-            "statusList",
-            "encrypt"
-          ],
+          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"],
           "type": "string",
           "description": "Usage type of the key chain."
         },
         "type": {
-          "enum": [
-            "standalone",
-            "internalChain"
-          ],
+          "enum": ["standalone", "internalChain"],
           "type": "string",
           "description": "Type of key chain (standalone or internalChain)."
         },
@@ -7679,9 +6727,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExportEcJwk.schema.json",
-    "fileMatch": [
-      "a://b/ExportEcJwk*.schema.json"
-    ],
+    "fileMatch": ["a://b/ExportEcJwk*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExportEcJwk.schema.json",
@@ -7720,21 +6766,13 @@
           "description": "Key ID"
         }
       },
-      "required": [
-        "kty",
-        "crv",
-        "x",
-        "y",
-        "d"
-      ],
+      "required": ["kty", "crv", "x", "y", "d"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExportRotationPolicyDto.schema.json",
-    "fileMatch": [
-      "a://b/ExportRotationPolicyDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ExportRotationPolicyDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExportRotationPolicyDto.schema.json",
@@ -7754,17 +6792,13 @@
           "description": "Certificate validity in days."
         }
       },
-      "required": [
-        "enabled"
-      ],
+      "required": ["enabled"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainExportDto.schema.json",
-    "fileMatch": [
-      "a://b/KeyChainExportDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KeyChainExportDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainExportDto.schema.json",
@@ -7780,13 +6814,7 @@
           "description": "Human-readable description."
         },
         "usageType": {
-          "enum": [
-            "access",
-            "attestation",
-            "trustList",
-            "statusList",
-            "encrypt"
-          ],
+          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"],
           "type": "string",
           "description": "Usage type for this key chain."
         },
@@ -7818,19 +6846,13 @@
           ]
         }
       },
-      "required": [
-        "id",
-        "usageType",
-        "key"
-      ],
+      "required": ["id", "usageType", "key"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyCreateDto.schema.json",
-    "fileMatch": [
-      "a://b/RotationPolicyCreateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/RotationPolicyCreateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyCreateDto.schema.json",
@@ -7857,17 +6879,13 @@
           "example": 365
         }
       },
-      "required": [
-        "enabled"
-      ],
+      "required": ["enabled"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainCreateDto.schema.json",
-    "fileMatch": [
-      "a://b/KeyChainCreateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KeyChainCreateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainCreateDto.schema.json",
@@ -7875,22 +6893,13 @@
       "type": "object",
       "properties": {
         "usageType": {
-          "enum": [
-            "access",
-            "attestation",
-            "trustList",
-            "statusList",
-            "encrypt"
-          ],
+          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"],
           "type": "string",
           "description": "Usage type determines the purpose of this key chain (access, attestation, etc.).",
           "example": "attestation"
         },
         "type": {
-          "enum": [
-            "standalone",
-            "internalChain"
-          ],
+          "enum": ["standalone", "internalChain"],
           "type": "string",
           "description": "Type of key chain to create.",
           "example": "internalChain"
@@ -7914,18 +6923,13 @@
           ]
         }
       },
-      "required": [
-        "usageType",
-        "type"
-      ],
+      "required": ["usageType", "type"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EcJwk.schema.json",
-    "fileMatch": [
-      "a://b/EcJwk*.schema.json"
-    ],
+    "fileMatch": ["a://b/EcJwk*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EcJwk.schema.json",
@@ -7954,21 +6958,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "kty",
-        "x",
-        "y",
-        "crv",
-        "d"
-      ],
+      "required": ["kty", "x", "y", "crv", "d"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyImportDto.schema.json",
-    "fileMatch": [
-      "a://b/RotationPolicyImportDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/RotationPolicyImportDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyImportDto.schema.json",
@@ -7995,17 +6991,13 @@
           "example": 365
         }
       },
-      "required": [
-        "enabled"
-      ],
+      "required": ["enabled"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainImportDto.schema.json",
-    "fileMatch": [
-      "a://b/KeyChainImportDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KeyChainImportDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainImportDto.schema.json",
@@ -8029,13 +7021,7 @@
           "description": "Human-readable description."
         },
         "usageType": {
-          "enum": [
-            "access",
-            "attestation",
-            "trustList",
-            "statusList",
-            "encrypt"
-          ],
+          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"],
           "type": "string",
           "description": "Usage type for this key chain."
         },
@@ -8059,18 +7045,13 @@
           ]
         }
       },
-      "required": [
-        "key",
-        "usageType"
-      ],
+      "required": ["key", "usageType"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyUpdateDto.schema.json",
-    "fileMatch": [
-      "a://b/RotationPolicyUpdateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/RotationPolicyUpdateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyUpdateDto.schema.json",
@@ -8099,9 +7080,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainUpdateDto.schema.json",
-    "fileMatch": [
-      "a://b/KeyChainUpdateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KeyChainUpdateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainUpdateDto.schema.json",
@@ -8130,9 +7109,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationRequest.schema.json",
-    "fileMatch": [
-      "a://b/PresentationRequest*.schema.json"
-    ],
+    "fileMatch": ["a://b/PresentationRequest*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationRequest.schema.json",
@@ -8142,10 +7119,7 @@
         "response_type": {
           "type": "string",
           "description": "The type of response expected from the presentation request.",
-          "enum": [
-            "uri",
-            "dc-api"
-          ]
+          "enum": ["uri", "dc-api"]
         },
         "requestId": {
           "type": "string",
@@ -8176,18 +7150,13 @@
           }
         }
       },
-      "required": [
-        "response_type",
-        "requestId"
-      ],
+      "required": ["response_type", "requestId"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FileUploadDto.schema.json",
-    "fileMatch": [
-      "a://b/FileUploadDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/FileUploadDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FileUploadDto.schema.json",
@@ -8199,9 +7168,7 @@
           "format": "binary"
         }
       },
-      "required": [
-        "file"
-      ],
+      "required": ["file"],
       "additionalProperties": false
     }
   }

--- a/apps/client/src/app/utils/schemas.json
+++ b/apps/client/src/app/utils/schemas.json
@@ -1,7 +1,9 @@
 [
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/GrafanaConfigDto.schema.json",
-    "fileMatch": ["a://b/GrafanaConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/GrafanaConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/GrafanaConfigDto.schema.json",
@@ -24,13 +26,18 @@
           "example": "loki"
         }
       },
-      "required": ["tempoUid", "lokiUid"],
+      "required": [
+        "tempoUid",
+        "lokiUid"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FrontendConfigResponseDto.schema.json",
-    "fileMatch": ["a://b/FrontendConfigResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/FrontendConfigResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FrontendConfigResponseDto.schema.json",
@@ -46,13 +53,17 @@
           ]
         }
       },
-      "required": ["grafana"],
+      "required": [
+        "grafana"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RoleDto.schema.json",
-    "fileMatch": ["a://b/RoleDto*.schema.json"],
+    "fileMatch": [
+      "a://b/RoleDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RoleDto.schema.json",
@@ -75,13 +86,17 @@
           "example": "issuance:manage"
         }
       },
-      "required": ["role"],
+      "required": [
+        "role"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientCredentialsDto.schema.json",
-    "fileMatch": ["a://b/ClientCredentialsDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ClientCredentialsDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientCredentialsDto.schema.json",
@@ -99,13 +114,18 @@
           "type": "string"
         }
       },
-      "required": ["client_id", "client_secret"],
+      "required": [
+        "client_id",
+        "client_secret"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TokenResponse.schema.json",
-    "fileMatch": ["a://b/TokenResponse*.schema.json"],
+    "fileMatch": [
+      "a://b/TokenResponse*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TokenResponse.schema.json",
@@ -128,13 +148,20 @@
           "type": "string"
         }
       },
-      "required": ["access_token", "token_type", "expires_in", "state"],
+      "required": [
+        "access_token",
+        "token_type",
+        "expires_in",
+        "state"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ImportTenantDto.schema.json",
-    "fileMatch": ["a://b/ImportTenantDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ImportTenantDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ImportTenantDto.schema.json",
@@ -150,13 +177,17 @@
           "description": "The description of the tenant."
         }
       },
-      "required": ["name"],
+      "required": [
+        "name"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SessionStorageConfig.schema.json",
-    "fileMatch": ["a://b/SessionStorageConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/SessionStorageConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SessionStorageConfig.schema.json",
@@ -172,7 +203,10 @@
         "cleanupMode": {
           "type": "string",
           "description": "Cleanup mode: 'full' deletes everything, 'anonymize' keeps metadata but removes PII.",
-          "enum": ["full", "anonymize"],
+          "enum": [
+            "full",
+            "anonymize"
+          ],
           "default": "full"
         }
       },
@@ -181,7 +215,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListConfig.schema.json",
-    "fileMatch": ["a://b/StatusListConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/StatusListConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListConfig.schema.json",
@@ -197,7 +233,12 @@
         "bits": {
           "type": "number",
           "description": "Bits per status entry: 1 (valid/revoked), 2 (with suspended), 4/8 (extended). If not set, uses global STATUS_BITS.",
-          "enum": [1, 2, 4, 8],
+          "enum": [
+            1,
+            2,
+            4,
+            8
+          ],
           "default": 1
         },
         "ttl": {
@@ -222,7 +263,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TenantEntity.schema.json",
-    "fileMatch": ["a://b/TenantEntity*.schema.json"],
+    "fileMatch": [
+      "a://b/TenantEntity*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TenantEntity.schema.json",
@@ -273,13 +316,20 @@
           }
         }
       },
-      "required": ["id", "name", "status", "clients"],
+      "required": [
+        "id",
+        "name",
+        "status",
+        "clients"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientEntity.schema.json",
-    "fileMatch": ["a://b/ClientEntity*.schema.json"],
+    "fileMatch": [
+      "a://b/ClientEntity*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientEntity.schema.json",
@@ -289,7 +339,10 @@
         "allowedPresentationConfigs": {
           "nullable": true,
           "description": "List of presentation config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": ["age-verification", "kyc-basic"],
+          "example": [
+            "age-verification",
+            "kyc-basic"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -298,7 +351,10 @@
         "allowedIssuanceConfigs": {
           "nullable": true,
           "description": "List of issuance config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": ["pid", "mdl"],
+          "example": [
+            "pid",
+            "mdl"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -346,13 +402,18 @@
           ]
         }
       },
-      "required": ["clientId", "roles"],
+      "required": [
+        "clientId",
+        "roles"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateTenantDto.schema.json",
-    "fileMatch": ["a://b/CreateTenantDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CreateTenantDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateTenantDto.schema.json",
@@ -406,13 +467,18 @@
           }
         }
       },
-      "required": ["id", "name"],
+      "required": [
+        "id",
+        "name"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateTenantDto.schema.json",
-    "fileMatch": ["a://b/UpdateTenantDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateTenantDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateTenantDto.schema.json",
@@ -467,7 +533,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuditLogResponseDto.schema.json",
-    "fileMatch": ["a://b/AuditLogResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/AuditLogResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuditLogResponseDto.schema.json",
@@ -504,7 +572,11 @@
           "type": "string"
         },
         "actorType": {
-          "enum": ["user", "client", "system"],
+          "enum": [
+            "user",
+            "client",
+            "system"
+          ],
           "type": "string"
         },
         "actorId": {
@@ -535,13 +607,21 @@
           "type": "string"
         }
       },
-      "required": ["id", "tenantId", "actionType", "actorType", "timestamp"],
+      "required": [
+        "id",
+        "tenantId",
+        "actionType",
+        "actorType",
+        "timestamp"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientSecretResponseDto.schema.json",
-    "fileMatch": ["a://b/ClientSecretResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ClientSecretResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientSecretResponseDto.schema.json",
@@ -552,13 +632,17 @@
           "type": "string"
         }
       },
-      "required": ["secret"],
+      "required": [
+        "secret"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateClientDto.schema.json",
-    "fileMatch": ["a://b/UpdateClientDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateClientDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateClientDto.schema.json",
@@ -568,7 +652,10 @@
         "allowedPresentationConfigs": {
           "nullable": true,
           "description": "List of presentation config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": ["age-verification", "kyc-basic"],
+          "example": [
+            "age-verification",
+            "kyc-basic"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -577,7 +664,10 @@
         "allowedIssuanceConfigs": {
           "nullable": true,
           "description": "List of issuance config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": ["pid", "mdl"],
+          "example": [
+            "pid",
+            "mdl"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -605,13 +695,17 @@
           }
         }
       },
-      "required": ["roles"],
+      "required": [
+        "roles"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateClientDto.schema.json",
-    "fileMatch": ["a://b/CreateClientDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CreateClientDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateClientDto.schema.json",
@@ -621,7 +715,10 @@
         "allowedPresentationConfigs": {
           "nullable": true,
           "description": "List of presentation config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": ["age-verification", "kyc-basic"],
+          "example": [
+            "age-verification",
+            "kyc-basic"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -630,7 +727,10 @@
         "allowedIssuanceConfigs": {
           "nullable": true,
           "description": "List of issuance config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": ["pid", "mdl"],
+          "example": [
+            "pid",
+            "mdl"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -666,13 +766,18 @@
           }
         }
       },
-      "required": ["clientId", "roles"],
+      "required": [
+        "clientId",
+        "roles"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListImportDto.schema.json",
-    "fileMatch": ["a://b/StatusListImportDto*.schema.json"],
+    "fileMatch": [
+      "a://b/StatusListImportDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListImportDto.schema.json",
@@ -702,18 +807,27 @@
         },
         "bits": {
           "description": "Bits per status value. If not provided, uses tenant or global defaults.",
-          "enum": [1, 2, 4, 8],
+          "enum": [
+            1,
+            2,
+            4,
+            8
+          ],
           "type": "number",
           "example": 1
         }
       },
-      "required": ["id"],
+      "required": [
+        "id"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListAggregationDto.schema.json",
-    "fileMatch": ["a://b/StatusListAggregationDto*.schema.json"],
+    "fileMatch": [
+      "a://b/StatusListAggregationDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListAggregationDto.schema.json",
@@ -732,13 +846,17 @@
           }
         }
       },
-      "required": ["status_lists"],
+      "required": [
+        "status_lists"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateStatusListConfigDto.schema.json",
-    "fileMatch": ["a://b/UpdateStatusListConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateStatusListConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateStatusListConfigDto.schema.json",
@@ -755,7 +873,12 @@
         "bits": {
           "nullable": true,
           "description": "Bits per status entry. Set to null to reset to global default.",
-          "enum": [1, 2, 4, 8],
+          "enum": [
+            1,
+            2,
+            4,
+            8
+          ],
           "type": "number"
         },
         "ttl": {
@@ -781,7 +904,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListResponseDto.schema.json",
-    "fileMatch": ["a://b/StatusListResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/StatusListResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListResponseDto.schema.json",
@@ -812,7 +937,12 @@
         },
         "bits": {
           "description": "Bits per status value",
-          "enum": [1, 2, 4, 8],
+          "enum": [
+            1,
+            2,
+            4,
+            8
+          ],
           "type": "number",
           "example": 1
         },
@@ -865,7 +995,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateStatusListDto.schema.json",
-    "fileMatch": ["a://b/CreateStatusListDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CreateStatusListDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateStatusListDto.schema.json",
@@ -884,7 +1016,12 @@
         },
         "bits": {
           "description": "Bits per status value. More bits allow more status states. Defaults to tenant configuration.",
-          "enum": [1, 2, 4, 8],
+          "enum": [
+            1,
+            2,
+            4,
+            8
+          ],
           "type": "number",
           "example": 1
         },
@@ -900,7 +1037,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateStatusListDto.schema.json",
-    "fileMatch": ["a://b/UpdateStatusListDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateStatusListDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateStatusListDto.schema.json",
@@ -925,7 +1064,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthorizeQueries.schema.json",
-    "fileMatch": ["a://b/AuthorizeQueries*.schema.json"],
+    "fileMatch": [
+      "a://b/AuthorizeQueries*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthorizeQueries.schema.json",
@@ -978,7 +1119,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/OfferRequestDto.schema.json",
-    "fileMatch": ["a://b/OfferRequestDto*.schema.json"],
+    "fileMatch": [
+      "a://b/OfferRequestDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/OfferRequestDto.schema.json",
@@ -986,7 +1129,10 @@
       "type": "object",
       "properties": {
         "response_type": {
-          "enum": ["uri", "dc-api"],
+          "enum": [
+            "uri",
+            "dc-api"
+          ],
           "type": "string",
           "examples": [
             {
@@ -1004,14 +1150,19 @@
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": ["inline"]
+                    "enum": [
+                      "inline"
+                    ]
                   },
                   "claims": {
                     "type": "object",
                     "additionalProperties": true
                   }
                 },
-                "required": ["type", "claims"],
+                "required": [
+                  "type",
+                  "claims"
+                ],
                 "additionalProperties": false
               },
               {
@@ -1019,13 +1170,18 @@
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": ["attributeProvider"]
+                    "enum": [
+                      "attributeProvider"
+                    ]
                   },
                   "attributeProviderId": {
                     "type": "string"
                   }
                 },
-                "required": ["type", "attributeProviderId"],
+                "required": [
+                  "type",
+                  "attributeProviderId"
+                ],
                 "additionalProperties": false
               },
               {
@@ -1033,7 +1189,9 @@
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": ["webhook"]
+                    "enum": [
+                      "webhook"
+                    ]
                   },
                   "webhook": {
                     "type": "object",
@@ -1045,11 +1203,16 @@
                         "type": "object"
                       }
                     },
-                    "required": ["url"],
+                    "required": [
+                      "url"
+                    ],
                     "additionalProperties": false
                   }
                 },
-                "required": ["type", "webhook"],
+                "required": [
+                  "type",
+                  "webhook"
+                ],
                 "additionalProperties": false
               }
             ]
@@ -1067,7 +1230,10 @@
         },
         "flow": {
           "description": "The flow type for the offer request.",
-          "enum": ["authorization_code", "pre_authorized_code"],
+          "enum": [
+            "authorization_code",
+            "pre_authorized_code"
+          ],
           "type": "string"
         },
         "tx_code": {
@@ -1094,13 +1260,19 @@
           "description": "ID of the webhook endpoint to notify about the status of the issuance process."
         }
       },
-      "required": ["response_type", "flow", "credentialConfigurationIds"],
+      "required": [
+        "response_type",
+        "flow",
+        "credentialConfigurationIds"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebHookAuthConfigNone.schema.json",
-    "fileMatch": ["a://b/WebHookAuthConfigNone*.schema.json"],
+    "fileMatch": [
+      "a://b/WebHookAuthConfigNone*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebHookAuthConfigNone.schema.json",
@@ -1110,16 +1282,22 @@
         "type": {
           "type": "string",
           "description": "The type of authentication used for the webhook.",
-          "enum": ["none"]
+          "enum": [
+            "none"
+          ]
         }
       },
-      "required": ["type"],
+      "required": [
+        "type"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ApiKeyConfig.schema.json",
-    "fileMatch": ["a://b/ApiKeyConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/ApiKeyConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ApiKeyConfig.schema.json",
@@ -1135,13 +1313,18 @@
           "description": "The value of the API key to be sent in the header."
         }
       },
-      "required": ["headerName", "value"],
+      "required": [
+        "headerName",
+        "value"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebHookAuthConfigHeader.schema.json",
-    "fileMatch": ["a://b/WebHookAuthConfigHeader*.schema.json"],
+    "fileMatch": [
+      "a://b/WebHookAuthConfigHeader*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebHookAuthConfigHeader.schema.json",
@@ -1151,7 +1334,9 @@
         "type": {
           "type": "string",
           "description": "The type of authentication used for the webhook.",
-          "enum": ["apiKey"]
+          "enum": [
+            "apiKey"
+          ]
         },
         "config": {
           "description": "Configuration for API key authentication.\nThis is required if the type is 'apiKey'.",
@@ -1162,13 +1347,18 @@
           ]
         }
       },
-      "required": ["type", "config"],
+      "required": [
+        "type",
+        "config"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebhookConfig.schema.json",
-    "fileMatch": ["a://b/WebhookConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/WebhookConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebhookConfig.schema.json",
@@ -1198,13 +1388,18 @@
           "description": "The URL to which the webhook will send notifications."
         }
       },
-      "required": ["auth", "url"],
+      "required": [
+        "auth",
+        "url"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TransactionData.schema.json",
-    "fileMatch": ["a://b/TransactionData*.schema.json"],
+    "fileMatch": [
+      "a://b/TransactionData*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TransactionData.schema.json",
@@ -1221,13 +1416,18 @@
           }
         }
       },
-      "required": ["type", "credential_ids"],
+      "required": [
+        "type",
+        "credential_ids"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Session.schema.json",
-    "fileMatch": ["a://b/Session*.schema.json"],
+    "fileMatch": [
+      "a://b/Session*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Session.schema.json",
@@ -1236,7 +1436,13 @@
       "properties": {
         "status": {
           "description": "Status of the session.",
-          "enum": ["active", "fetched", "completed", "expired", "failed"],
+          "enum": [
+            "active",
+            "fetched",
+            "completed",
+            "expired",
+            "failed"
+          ],
           "type": "string"
         },
         "id": {
@@ -1299,6 +1505,7 @@
           ]
         },
         "offer": {
+          "nullable": true,
           "description": "Credential offer object containing details about the credential offer or presentation request.\nEncrypted at rest.",
           "type": "object"
         },
@@ -1405,7 +1612,7 @@
         "consumedAt": {
           "format": "date-time",
           "type": "string",
-          "description": "Timestamp when the session offer was consumed.\nNull if the offer has not yet been consumed."
+          "description": "Timestamp of the first consumption event for the session offer.\nFor OID4VCI this can be URI resolution or later flow completion.\nNull if no consumption event has happened yet."
         }
       },
       "required": [
@@ -1425,7 +1632,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PaginatedSessionResponseDto.schema.json",
-    "fileMatch": ["a://b/PaginatedSessionResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/PaginatedSessionResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PaginatedSessionResponseDto.schema.json",
@@ -1456,13 +1665,21 @@
           "description": "Total number of pages"
         }
       },
-      "required": ["items", "total", "page", "pageSize", "totalPages"],
+      "required": [
+        "items",
+        "total",
+        "page",
+        "pageSize",
+        "totalPages"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SessionLogEntryResponseDto.schema.json",
-    "fileMatch": ["a://b/SessionLogEntryResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/SessionLogEntryResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SessionLogEntryResponseDto.schema.json",
@@ -1485,7 +1702,11 @@
         "level": {
           "type": "string",
           "description": "Log level",
-          "enum": ["info", "warn", "error"]
+          "enum": [
+            "info",
+            "warn",
+            "error"
+          ]
         },
         "stage": {
           "type": "string",
@@ -1501,13 +1722,21 @@
           "description": "Additional structured detail"
         }
       },
-      "required": ["id", "sessionId", "timestamp", "level", "message"],
+      "required": [
+        "id",
+        "sessionId",
+        "timestamp",
+        "level",
+        "message"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusUpdateDto.schema.json",
-    "fileMatch": ["a://b/StatusUpdateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/StatusUpdateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusUpdateDto.schema.json",
@@ -1527,13 +1756,18 @@
           "description": "The status of the credential\n0 = valid, 1 = revoked, 2 = suspended"
         }
       },
-      "required": ["sessionId", "status"],
+      "required": [
+        "sessionId",
+        "status"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateSessionConfigDto.schema.json",
-    "fileMatch": ["a://b/UpdateSessionConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateSessionConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateSessionConfigDto.schema.json",
@@ -1549,7 +1783,10 @@
         },
         "cleanupMode": {
           "description": "Cleanup mode: 'full' deletes everything, 'anonymize' keeps metadata but removes PII.",
-          "enum": ["full", "anonymize"],
+          "enum": [
+            "full",
+            "anonymize"
+          ],
           "type": "string",
           "default": "full"
         }
@@ -1559,7 +1796,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ManagedUserDto.schema.json",
-    "fileMatch": ["a://b/ManagedUserDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ManagedUserDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ManagedUserDto.schema.json",
@@ -1608,13 +1847,20 @@
           "description": "One-time temporary password returned only on user creation."
         }
       },
-      "required": ["id", "username", "enabled", "roles"],
+      "required": [
+        "id",
+        "username",
+        "enabled",
+        "roles"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateUserDto.schema.json",
-    "fileMatch": ["a://b/CreateUserDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CreateUserDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateUserDto.schema.json",
@@ -1656,13 +1902,18 @@
           "example": true
         }
       },
-      "required": ["username", "roles"],
+      "required": [
+        "username",
+        "roles"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateUserDto.schema.json",
-    "fileMatch": ["a://b/UpdateUserDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateUserDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateUserDto.schema.json",
@@ -1714,7 +1965,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodNone.schema.json",
-    "fileMatch": ["a://b/AuthenticationMethodNone*.schema.json"],
+    "fileMatch": [
+      "a://b/AuthenticationMethodNone*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodNone.schema.json",
@@ -1723,16 +1976,22 @@
       "properties": {
         "method": {
           "type": "string",
-          "enum": ["none"]
+          "enum": [
+            "none"
+          ]
         }
       },
-      "required": ["method"],
+      "required": [
+        "method"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationUrlConfig.schema.json",
-    "fileMatch": ["a://b/AuthenticationUrlConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/AuthenticationUrlConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationUrlConfig.schema.json",
@@ -1752,13 +2011,17 @@
           ]
         }
       },
-      "required": ["url"],
+      "required": [
+        "url"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodAuth.schema.json",
-    "fileMatch": ["a://b/AuthenticationMethodAuth*.schema.json"],
+    "fileMatch": [
+      "a://b/AuthenticationMethodAuth*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodAuth.schema.json",
@@ -1767,19 +2030,26 @@
       "properties": {
         "method": {
           "type": "string",
-          "enum": ["auth"]
+          "enum": [
+            "auth"
+          ]
         },
         "config": {
           "$ref": "./AuthenticationUrlConfig.schema.json"
         }
       },
-      "required": ["method", "config"],
+      "required": [
+        "method",
+        "config"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationDuringIssuanceConfig.schema.json",
-    "fileMatch": ["a://b/PresentationDuringIssuanceConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/PresentationDuringIssuanceConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationDuringIssuanceConfig.schema.json",
@@ -1791,13 +2061,17 @@
           "description": "Link to the presentation configuration that is relevant for the issuance process"
         }
       },
-      "required": ["type"],
+      "required": [
+        "type"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodPresentation.schema.json",
-    "fileMatch": ["a://b/AuthenticationMethodPresentation*.schema.json"],
+    "fileMatch": [
+      "a://b/AuthenticationMethodPresentation*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodPresentation.schema.json",
@@ -1806,19 +2080,26 @@
       "properties": {
         "method": {
           "type": "string",
-          "enum": ["presentationDuringIssuance"]
+          "enum": [
+            "presentationDuringIssuance"
+          ]
         },
         "config": {
           "$ref": "./PresentationDuringIssuanceConfig.schema.json"
         }
       },
-      "required": ["method", "config"],
+      "required": [
+        "method",
+        "config"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpstreamOidcConfig.schema.json",
-    "fileMatch": ["a://b/UpstreamOidcConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/UpstreamOidcConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpstreamOidcConfig.schema.json",
@@ -1842,20 +2123,28 @@
         },
         "scopes": {
           "description": "Scopes to request from the upstream provider",
-          "default": ["openid", "profile"],
+          "default": [
+            "openid",
+            "profile"
+          ],
           "type": "array",
           "items": {
             "type": "string"
           }
         }
       },
-      "required": ["issuer", "clientId"],
+      "required": [
+        "issuer",
+        "clientId"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenConfig.schema.json",
-    "fileMatch": ["a://b/ChainedAsTokenConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/ChainedAsTokenConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenConfig.schema.json",
@@ -1871,6 +2160,17 @@
         "signingKeyId": {
           "type": "string",
           "description": "Key ID for token signing"
+        },
+        "refreshTokenEnabled": {
+          "type": "boolean",
+          "description": "Whether refresh tokens should be issued",
+          "default": true
+        },
+        "refreshTokenExpiresInSeconds": {
+          "type": "number",
+          "description": "Refresh token lifetime in seconds",
+          "minimum": 60,
+          "default": 2592000
         }
       },
       "additionalProperties": false
@@ -1878,7 +2178,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ManagedAuthorizationServerConfig.schema.json",
-    "fileMatch": ["a://b/ManagedAuthorizationServerConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/ManagedAuthorizationServerConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ManagedAuthorizationServerConfig.schema.json",
@@ -1896,7 +2198,11 @@
           "example": "PID Authorization Server"
         },
         "type": {
-          "enum": ["external", "oid4vp", "chained"],
+          "enum": [
+            "external",
+            "oid4vp",
+            "chained"
+          ],
           "type": "string",
           "description": "Authorization server implementation type",
           "example": "external"
@@ -1944,13 +2250,17 @@
           "default": false
         }
       },
-      "required": ["type"],
+      "required": [
+        "type"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FederationTrustAnchorConfig.schema.json",
-    "fileMatch": ["a://b/FederationTrustAnchorConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/FederationTrustAnchorConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FederationTrustAnchorConfig.schema.json",
@@ -1968,13 +2278,18 @@
           "example": "https://ta.example.org/.well-known/openid-federation"
         }
       },
-      "required": ["entityId", "entityConfigurationUri"],
+      "required": [
+        "entityId",
+        "entityConfigurationUri"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FederationConfig.schema.json",
-    "fileMatch": ["a://b/FederationConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/FederationConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FederationConfig.schema.json",
@@ -1982,13 +2297,20 @@
       "type": "object",
       "properties": {
         "role": {
-          "enum": ["trust_anchor", "intermediate", "leaf"],
+          "enum": [
+            "trust_anchor",
+            "intermediate",
+            "leaf"
+          ],
           "type": "string",
           "description": "Role this tenant plays in the OpenID Federation topology.",
           "default": "leaf"
         },
         "mode": {
-          "enum": ["federation-only", "hybrid"],
+          "enum": [
+            "federation-only",
+            "hybrid"
+          ],
           "type": "string",
           "description": "Trust decision strategy when both LoTE trust lists and OpenID Federation are configured.",
           "default": "hybrid"
@@ -2016,13 +2338,17 @@
           }
         }
       },
-      "required": ["trustAnchors"],
+      "required": [
+        "trustAnchors"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerProvidedAttestation.schema.json",
-    "fileMatch": ["a://b/IssuerProvidedAttestation*.schema.json"],
+    "fileMatch": [
+      "a://b/IssuerProvidedAttestation*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerProvidedAttestation.schema.json",
@@ -2045,7 +2371,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerRegistrationCertificateConfig.schema.json",
-    "fileMatch": ["a://b/IssuerRegistrationCertificateConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/IssuerRegistrationCertificateConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerRegistrationCertificateConfig.schema.json",
@@ -2058,7 +2386,10 @@
           "default": false
         },
         "mode": {
-          "enum": ["import", "generate"],
+          "enum": [
+            "import",
+            "generate"
+          ],
           "type": "string",
           "description": "import: use an existing JWT, generate: create via registrar from provided attestations and selected credential configurations.",
           "default": "import"
@@ -2097,7 +2428,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerRegistrationCertificateCache.schema.json",
-    "fileMatch": ["a://b/IssuerRegistrationCertificateCache*.schema.json"],
+    "fileMatch": [
+      "a://b/IssuerRegistrationCertificateCache*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerRegistrationCertificateCache.schema.json",
@@ -2130,7 +2463,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayLogo.schema.json",
-    "fileMatch": ["a://b/DisplayLogo*.schema.json"],
+    "fileMatch": [
+      "a://b/DisplayLogo*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayLogo.schema.json",
@@ -2144,13 +2479,17 @@
           "type": "string"
         }
       },
-      "required": ["uri"],
+      "required": [
+        "uri"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayInfo.schema.json",
-    "fileMatch": ["a://b/DisplayInfo*.schema.json"],
+    "fileMatch": [
+      "a://b/DisplayInfo*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayInfo.schema.json",
@@ -2172,7 +2511,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuanceConfig.schema.json",
-    "fileMatch": ["a://b/IssuanceConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/IssuanceConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuanceConfig.schema.json",
@@ -2222,11 +2563,6 @@
             }
           ]
         },
-        "refreshTokenEnabled": {
-          "type": "boolean",
-          "description": "Whether refresh tokens should be issued for OID4VCI token responses.",
-          "default": true
-        },
         "credentialResponseEncryption": {
           "type": "boolean",
           "description": "Whether `credential_response_encryption` should be advertised in the credential issuer metadata.",
@@ -2236,12 +2572,6 @@
           "type": "boolean",
           "description": "Whether `credential_request_encryption` should be advertised in the credential issuer metadata.",
           "default": false
-        },
-        "refreshTokenExpiresInSeconds": {
-          "type": "number",
-          "description": "Refresh token lifetime in seconds. Defaults to 2592000 (30 days).",
-          "default": 2592000,
-          "nullable": true
         },
         "txCodeMaxAttempts": {
           "type": "number",
@@ -2276,10 +2606,6 @@
             "type": "string"
           }
         },
-        "preferredAuthServer": {
-          "type": "string",
-          "description": "The URL of the preferred authorization server for wallet-initiated flows.\nWhen set, this AS is placed first in the `authorization_servers` array\nof the credential issuer metadata, signaling wallets to use it by default.\nMust match one of the configured auth servers, the chained AS URL, or \"built-in\"."
-        },
         "display": {
           "type": "array",
           "items": {
@@ -2297,13 +2623,20 @@
           "description": "The timestamp when the VP request was last updated."
         }
       },
-      "required": ["tenant", "display", "createdAt", "updatedAt"],
+      "required": [
+        "tenant",
+        "display",
+        "createdAt",
+        "updatedAt"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuanceDto.schema.json",
-    "fileMatch": ["a://b/IssuanceDto*.schema.json"],
+    "fileMatch": [
+      "a://b/IssuanceDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuanceDto.schema.json",
@@ -2353,11 +2686,6 @@
             }
           ]
         },
-        "refreshTokenEnabled": {
-          "type": "boolean",
-          "description": "Whether refresh tokens should be issued for OID4VCI token responses.",
-          "default": true
-        },
         "credentialResponseEncryption": {
           "type": "boolean",
           "description": "Whether `credential_response_encryption` should be advertised in the credential issuer metadata.",
@@ -2367,12 +2695,6 @@
           "type": "boolean",
           "description": "Whether `credential_request_encryption` should be advertised in the credential issuer metadata.",
           "default": false
-        },
-        "refreshTokenExpiresInSeconds": {
-          "type": "number",
-          "description": "Refresh token lifetime in seconds. Defaults to 2592000 (30 days).",
-          "default": 2592000,
-          "nullable": true
         },
         "txCodeMaxAttempts": {
           "type": "number",
@@ -2399,10 +2721,6 @@
             "type": "string"
           }
         },
-        "preferredAuthServer": {
-          "type": "string",
-          "description": "The URL of the preferred authorization server for wallet-initiated flows.\nWhen set, this AS is placed first in the `authorization_servers` array\nof the credential issuer metadata, signaling wallets to use it by default.\nMust match one of the configured auth servers, the chained AS URL, or \"built-in\"."
-        },
         "display": {
           "type": "array",
           "items": {
@@ -2410,13 +2728,17 @@
           }
         }
       },
-      "required": ["display"],
+      "required": [
+        "display"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClaimsQuery.schema.json",
-    "fileMatch": ["a://b/ClaimsQuery*.schema.json"],
+    "fileMatch": [
+      "a://b/ClaimsQuery*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClaimsQuery.schema.json",
@@ -2439,13 +2761,17 @@
           }
         }
       },
-      "required": ["path"],
+      "required": [
+        "path"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustedAuthorityQuery.schema.json",
-    "fileMatch": ["a://b/TrustedAuthorityQuery*.schema.json"],
+    "fileMatch": [
+      "a://b/TrustedAuthorityQuery*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustedAuthorityQuery.schema.json",
@@ -2454,7 +2780,10 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["etsi_tl", "openid_federation"]
+          "enum": [
+            "etsi_tl",
+            "openid_federation"
+          ]
         },
         "values": {
           "type": "array",
@@ -2463,19 +2792,34 @@
           }
         }
       },
-      "required": ["type", "values"],
+      "required": [
+        "type",
+        "values"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialQuery.schema.json",
-    "fileMatch": ["a://b/CredentialQuery*.schema.json"],
+    "fileMatch": [
+      "a://b/CredentialQuery*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialQuery.schema.json",
       "title": "CredentialQuery",
       "type": "object",
       "properties": {
+        "claim_sets": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "description": "Ordered alternative claim combinations for this credential query."
+        },
         "id": {
           "type": "string",
           "pattern": "^[A-Za-z0-9_-]+$"
@@ -2502,13 +2846,19 @@
           }
         }
       },
-      "required": ["id", "format", "meta"],
+      "required": [
+        "id",
+        "format",
+        "meta"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialSetQuery.schema.json",
-    "fileMatch": ["a://b/CredentialSetQuery*.schema.json"],
+    "fileMatch": [
+      "a://b/CredentialSetQuery*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialSetQuery.schema.json",
@@ -2528,13 +2878,17 @@
           "type": "boolean"
         }
       },
-      "required": ["options"],
+      "required": [
+        "options"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PolicyCredential.schema.json",
-    "fileMatch": ["a://b/PolicyCredential*.schema.json"],
+    "fileMatch": [
+      "a://b/PolicyCredential*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PolicyCredential.schema.json",
@@ -2560,13 +2914,17 @@
           }
         }
       },
-      "required": ["credentials"],
+      "required": [
+        "credentials"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AttestationBasedPolicy.schema.json",
-    "fileMatch": ["a://b/AttestationBasedPolicy*.schema.json"],
+    "fileMatch": [
+      "a://b/AttestationBasedPolicy*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AttestationBasedPolicy.schema.json",
@@ -2575,7 +2933,9 @@
       "properties": {
         "policy": {
           "type": "string",
-          "enum": ["attestationBased"]
+          "enum": [
+            "attestationBased"
+          ]
         },
         "values": {
           "type": "array",
@@ -2584,13 +2944,18 @@
           }
         }
       },
-      "required": ["policy", "values"],
+      "required": [
+        "policy",
+        "values"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/NoneTrustPolicy.schema.json",
-    "fileMatch": ["a://b/NoneTrustPolicy*.schema.json"],
+    "fileMatch": [
+      "a://b/NoneTrustPolicy*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/NoneTrustPolicy.schema.json",
@@ -2599,16 +2964,22 @@
       "properties": {
         "policy": {
           "type": "string",
-          "enum": ["none"]
+          "enum": [
+            "none"
+          ]
         }
       },
-      "required": ["policy"],
+      "required": [
+        "policy"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AllowListPolicy.schema.json",
-    "fileMatch": ["a://b/AllowListPolicy*.schema.json"],
+    "fileMatch": [
+      "a://b/AllowListPolicy*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AllowListPolicy.schema.json",
@@ -2617,7 +2988,9 @@
       "properties": {
         "policy": {
           "type": "string",
-          "enum": ["allowList"]
+          "enum": [
+            "allowList"
+          ]
         },
         "values": {
           "type": "array",
@@ -2626,13 +2999,18 @@
           }
         }
       },
-      "required": ["policy", "values"],
+      "required": [
+        "policy",
+        "values"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RootOfTrustPolicy.schema.json",
-    "fileMatch": ["a://b/RootOfTrustPolicy*.schema.json"],
+    "fileMatch": [
+      "a://b/RootOfTrustPolicy*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RootOfTrustPolicy.schema.json",
@@ -2641,19 +3019,26 @@
       "properties": {
         "policy": {
           "type": "string",
-          "enum": ["rootOfTrust"]
+          "enum": [
+            "rootOfTrust"
+          ]
         },
         "values": {
           "type": "string"
         }
       },
-      "required": ["policy", "values"],
+      "required": [
+        "policy",
+        "values"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/VCT.schema.json",
-    "fileMatch": ["a://b/VCT*.schema.json"],
+    "fileMatch": [
+      "a://b/VCT*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/VCT.schema.json",
@@ -2687,7 +3072,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IaeActionOpenid4vpPresentation.schema.json",
-    "fileMatch": ["a://b/IaeActionOpenid4vpPresentation*.schema.json"],
+    "fileMatch": [
+      "a://b/IaeActionOpenid4vpPresentation*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IaeActionOpenid4vpPresentation.schema.json",
@@ -2695,7 +3082,9 @@
       "type": "object",
       "properties": {
         "type": {
-          "enum": ["openid4vp_presentation"],
+          "enum": [
+            "openid4vp_presentation"
+          ],
           "type": "string",
           "description": "Action type discriminator",
           "example": "openid4vp_presentation"
@@ -2711,13 +3100,18 @@
           "example": "pid-presentation-config"
         }
       },
-      "required": ["type", "presentationConfigId"],
+      "required": [
+        "type",
+        "presentationConfigId"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IaeActionRedirectToWeb.schema.json",
-    "fileMatch": ["a://b/IaeActionRedirectToWeb*.schema.json"],
+    "fileMatch": [
+      "a://b/IaeActionRedirectToWeb*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IaeActionRedirectToWeb.schema.json",
@@ -2725,7 +3119,9 @@
       "type": "object",
       "properties": {
         "type": {
-          "enum": ["redirect_to_web"],
+          "enum": [
+            "redirect_to_web"
+          ],
           "type": "string",
           "description": "Action type discriminator",
           "example": "redirect_to_web"
@@ -2753,13 +3149,18 @@
           "example": "Please complete the identity verification form"
         }
       },
-      "required": ["type", "url"],
+      "required": [
+        "type",
+        "url"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebhookEndpointEntity.schema.json",
-    "fileMatch": ["a://b/WebhookEndpointEntity*.schema.json"],
+    "fileMatch": [
+      "a://b/WebhookEndpointEntity*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebhookEndpointEntity.schema.json",
@@ -2797,13 +3198,22 @@
           "type": "string"
         }
       },
-      "required": ["id", "auth", "tenantId", "tenant", "name", "url"],
+      "required": [
+        "id",
+        "auth",
+        "tenantId",
+        "tenant",
+        "name",
+        "url"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaUriEntry.schema.json",
-    "fileMatch": ["a://b/SchemaUriEntry*.schema.json"],
+    "fileMatch": [
+      "a://b/SchemaUriEntry*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaUriEntry.schema.json",
@@ -2835,7 +3245,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustAuthorityEntry.schema.json",
-    "fileMatch": ["a://b/TrustAuthorityEntry*.schema.json"],
+    "fileMatch": [
+      "a://b/TrustAuthorityEntry*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustAuthorityEntry.schema.json",
@@ -2847,7 +3259,11 @@
           "description": "Trust list ID to resolve from the database. When set, frameworkType, value, and verificationMethod are derived automatically."
         },
         "frameworkType": {
-          "enum": ["aki", "etsi_tl", "openid_federation"],
+          "enum": [
+            "aki",
+            "etsi_tl",
+            "openid_federation"
+          ],
           "type": "string",
           "description": "Trust framework type (ignored when trustListId is set)"
         },
@@ -2878,7 +3294,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetaConfig.schema.json",
-    "fileMatch": ["a://b/SchemaMetaConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/SchemaMetaConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetaConfig.schema.json",
@@ -2911,7 +3329,12 @@
           "description": "Attestation Level of Security"
         },
         "bindingType": {
-          "enum": ["claim", "key", "biometric", "none"],
+          "enum": [
+            "claim",
+            "key",
+            "biometric",
+            "none"
+          ],
           "type": "string",
           "description": "Cryptographic binding type"
         },
@@ -2935,7 +3358,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EmbeddedDisclosurePolicy.schema.json",
-    "fileMatch": ["a://b/EmbeddedDisclosurePolicy*.schema.json"],
+    "fileMatch": [
+      "a://b/EmbeddedDisclosurePolicy*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EmbeddedDisclosurePolicy.schema.json",
@@ -2946,13 +3371,17 @@
           "type": "string"
         }
       },
-      "required": ["policy"],
+      "required": [
+        "policy"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyAttestationsRequired.schema.json",
-    "fileMatch": ["a://b/KeyAttestationsRequired*.schema.json"],
+    "fileMatch": [
+      "a://b/KeyAttestationsRequired*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyAttestationsRequired.schema.json",
@@ -2961,7 +3390,10 @@
       "properties": {
         "key_storage": {
           "description": "List of required key storage types (e.g., iso_18045_high, iso_18045_moderate)",
-          "example": ["iso_18045_high", "iso_18045_moderate"],
+          "example": [
+            "iso_18045_high",
+            "iso_18045_moderate"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -2969,7 +3401,10 @@
         },
         "user_authentication": {
           "description": "List of required user authentication types (e.g., iso_18045_high, iso_18045_moderate)",
-          "example": ["iso_18045_high", "iso_18045_moderate"],
+          "example": [
+            "iso_18045_high",
+            "iso_18045_moderate"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -2981,7 +3416,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayImage.schema.json",
-    "fileMatch": ["a://b/DisplayImage*.schema.json"],
+    "fileMatch": [
+      "a://b/DisplayImage*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayImage.schema.json",
@@ -2992,13 +3429,17 @@
           "type": "string"
         }
       },
-      "required": ["uri"],
+      "required": [
+        "uri"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Display.schema.json",
-    "fileMatch": ["a://b/Display*.schema.json"],
+    "fileMatch": [
+      "a://b/Display*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Display.schema.json",
@@ -3027,13 +3468,19 @@
           "$ref": "./DisplayImage.schema.json"
         }
       },
-      "required": ["name", "description", "locale"],
+      "required": [
+        "name",
+        "description",
+        "locale"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerMetadataCredentialConfig.schema.json",
-    "fileMatch": ["a://b/IssuerMetadataCredentialConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/IssuerMetadataCredentialConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerMetadataCredentialConfig.schema.json",
@@ -3050,7 +3497,10 @@
         },
         "format": {
           "type": "string",
-          "enum": ["mso_mdoc", "dc+sd-jwt"]
+          "enum": [
+            "mso_mdoc",
+            "dc+sd-jwt"
+          ]
         },
         "display": {
           "type": "array",
@@ -3066,13 +3516,18 @@
           "description": "Document type for mDOC credentials (e.g., \"org.iso.18013.5.1.mDL\").\nOnly applicable when format is \"mso_mdoc\"."
         }
       },
-      "required": ["format", "display"],
+      "required": [
+        "format",
+        "display"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FieldDisplayDto.schema.json",
-    "fileMatch": ["a://b/FieldDisplayDto*.schema.json"],
+    "fileMatch": [
+      "a://b/FieldDisplayDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FieldDisplayDto.schema.json",
@@ -3095,13 +3550,18 @@
           "example": "Primary first name"
         }
       },
-      "required": ["locale", "name"],
+      "required": [
+        "locale",
+        "name"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClaimFieldDefinitionDto.schema.json",
-    "fileMatch": ["a://b/ClaimFieldDefinitionDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ClaimFieldDefinitionDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClaimFieldDefinitionDto.schema.json",
@@ -3111,7 +3571,10 @@
         "path": {
           "type": "array",
           "description": "Path to claim value. For nested child fields this can be relative to the parent path.",
-          "example": ["address", "locality"],
+          "example": [
+            "address",
+            "locality"
+          ],
           "items": {
             "oneOf": [
               {
@@ -3127,7 +3590,14 @@
           }
         },
         "type": {
-          "enum": ["string", "number", "integer", "boolean", "object", "array"],
+          "enum": [
+            "string",
+            "number",
+            "integer",
+            "boolean",
+            "object",
+            "array"
+          ],
           "type": "string",
           "description": "Claim value type"
         },
@@ -3188,13 +3658,18 @@
           }
         }
       },
-      "required": ["path", "type"],
+      "required": [
+        "path",
+        "type"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AttributeProviderEntity.schema.json",
-    "fileMatch": ["a://b/AttributeProviderEntity*.schema.json"],
+    "fileMatch": [
+      "a://b/AttributeProviderEntity*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AttributeProviderEntity.schema.json",
@@ -3231,13 +3706,22 @@
           "type": "string"
         }
       },
-      "required": ["auth", "id", "tenantId", "tenant", "name", "url"],
+      "required": [
+        "auth",
+        "id",
+        "tenantId",
+        "tenant",
+        "name",
+        "url"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainEntity.schema.json",
-    "fileMatch": ["a://b/KeyChainEntity*.schema.json"],
+    "fileMatch": [
+      "a://b/KeyChainEntity*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainEntity.schema.json",
@@ -3267,12 +3751,21 @@
         "usageType": {
           "type": "string",
           "description": "The purpose/role of this key chain in the system.",
-          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"]
+          "enum": [
+            "access",
+            "attestation",
+            "trustList",
+            "statusList",
+            "encrypt"
+          ]
         },
         "usage": {
           "type": "string",
           "description": "The usage type of the keys (sign or encrypt).",
-          "enum": ["sign", "encrypt"]
+          "enum": [
+            "sign",
+            "encrypt"
+          ]
         },
         "kmsProvider": {
           "type": "string",
@@ -3352,7 +3845,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfig.schema.json",
-    "fileMatch": ["a://b/CredentialConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/CredentialConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfig.schema.json",
@@ -3479,20 +3974,30 @@
         "sdJwtTrustFormat": {
           "nullable": true,
           "description": "For SD-JWT credentials: determines whether to include certificate chain (x5c)\nor use federation-based trust (iss claim).\nDefault: \"x5c\" (federation must be explicitly selected)",
-          "enum": ["x5c", "federation"],
+          "enum": [
+            "x5c",
+            "federation"
+          ],
           "type": "string"
         },
         "lifeTime": {
           "type": "number"
         }
       },
-      "required": ["id", "tenant", "config", "fields"],
+      "required": [
+        "id",
+        "tenant",
+        "config",
+        "fields"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfigCreate.schema.json",
-    "fileMatch": ["a://b/CredentialConfigCreate*.schema.json"],
+    "fileMatch": [
+      "a://b/CredentialConfigCreate*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfigCreate.schema.json",
@@ -3602,20 +4107,29 @@
         "sdJwtTrustFormat": {
           "nullable": true,
           "description": "For SD-JWT credentials: determines whether to include certificate chain (x5c)\nor use federation-based trust (iss claim).\nDefault: \"x5c\" (federation must be explicitly selected)",
-          "enum": ["x5c", "federation"],
+          "enum": [
+            "x5c",
+            "federation"
+          ],
           "type": "string"
         },
         "lifeTime": {
           "type": "number"
         }
       },
-      "required": ["id", "config", "fields"],
+      "required": [
+        "id",
+        "config",
+        "fields"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfigUpdate.schema.json",
-    "fileMatch": ["a://b/CredentialConfigUpdate*.schema.json"],
+    "fileMatch": [
+      "a://b/CredentialConfigUpdate*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfigUpdate.schema.json",
@@ -3725,7 +4239,10 @@
         "sdJwtTrustFormat": {
           "nullable": true,
           "description": "For SD-JWT credentials: determines whether to include certificate chain (x5c)\nor use federation-based trust (iss claim).\nDefault: \"x5c\" (federation must be explicitly selected)",
-          "enum": ["x5c", "federation"],
+          "enum": [
+            "x5c",
+            "federation"
+          ],
           "type": "string"
         },
         "lifeTime": {
@@ -3737,7 +4254,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SignSchemaMetaConfigDto.schema.json",
-    "fileMatch": ["a://b/SignSchemaMetaConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/SignSchemaMetaConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SignSchemaMetaConfigDto.schema.json",
@@ -3761,13 +4280,17 @@
           "description": "ID of the credential config to link back after submission. When provided, schemaMeta.id on the credential config is updated with the reserved attestation ID."
         }
       },
-      "required": ["config"],
+      "required": [
+        "config"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SignVersionSchemaMetaConfigDto.schema.json",
-    "fileMatch": ["a://b/SignVersionSchemaMetaConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/SignVersionSchemaMetaConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SignVersionSchemaMetaConfigDto.schema.json",
@@ -3787,13 +4310,17 @@
           "description": "ID of the key chain to use for signing. Defaults to the tenant's default key chain."
         }
       },
-      "required": ["config"],
+      "required": [
+        "config"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/VocabularyEntryDto.schema.json",
-    "fileMatch": ["a://b/VocabularyEntryDto*.schema.json"],
+    "fileMatch": [
+      "a://b/VocabularyEntryDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/VocabularyEntryDto.schema.json",
@@ -3809,7 +4336,10 @@
           "description": "Display label for UI rendering."
         },
         "status": {
-          "enum": ["active", "deprecated"],
+          "enum": [
+            "active",
+            "deprecated"
+          ],
           "type": "string",
           "description": "Vocabulary lifecycle status."
         },
@@ -3818,13 +4348,19 @@
           "description": "Replacement code when status is deprecated."
         }
       },
-      "required": ["code", "label", "status"],
+      "required": [
+        "code",
+        "label",
+        "status"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetadataVocabulariesDto.schema.json",
-    "fileMatch": ["a://b/SchemaMetadataVocabulariesDto*.schema.json"],
+    "fileMatch": [
+      "a://b/SchemaMetadataVocabulariesDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetadataVocabulariesDto.schema.json",
@@ -3850,13 +4386,19 @@
           }
         }
       },
-      "required": ["version", "categories", "tags"],
+      "required": [
+        "version",
+        "categories",
+        "tags"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/MetadataSchemaDto.schema.json",
-    "fileMatch": ["a://b/MetadataSchemaDto*.schema.json"],
+    "fileMatch": [
+      "a://b/MetadataSchemaDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/MetadataSchemaDto.schema.json",
@@ -3868,7 +4410,10 @@
           "description": "Unique identifier for this schema entry"
         },
         "formatIdentifier": {
-          "enum": ["dc+sd-jwt", "mso_mdoc"],
+          "enum": [
+            "dc+sd-jwt",
+            "mso_mdoc"
+          ],
           "type": "string",
           "description": "The credential format identifier"
         },
@@ -3886,13 +4431,18 @@
           "description": "Subresource Integrity hash for the schema"
         }
       },
-      "required": ["id", "formatIdentifier"],
+      "required": [
+        "id",
+        "formatIdentifier"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustAuthorityDto.schema.json",
-    "fileMatch": ["a://b/TrustAuthorityDto*.schema.json"],
+    "fileMatch": [
+      "a://b/TrustAuthorityDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustAuthorityDto.schema.json",
@@ -3906,7 +4456,9 @@
         "frameworkType": {
           "type": "string",
           "description": "Type of trust framework",
-          "enum": ["etsi_tl"]
+          "enum": [
+            "etsi_tl"
+          ]
         },
         "value": {
           "type": "string",
@@ -3918,13 +4470,19 @@
           "description": "Verification method for the trust list signature (e.g., JWK)"
         }
       },
-      "required": ["id", "frameworkType", "value"],
+      "required": [
+        "id",
+        "frameworkType",
+        "value"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AccessCertificateRefDto.schema.json",
-    "fileMatch": ["a://b/AccessCertificateRefDto*.schema.json"],
+    "fileMatch": [
+      "a://b/AccessCertificateRefDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AccessCertificateRefDto.schema.json",
@@ -3947,13 +4505,21 @@
           "type": "string"
         }
       },
-      "required": ["id", "relyingPartyId", "certificate", "revoked", "createdAt"],
+      "required": [
+        "id",
+        "relyingPartyId",
+        "certificate",
+        "revoked",
+        "createdAt"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetadataResponseDto.schema.json",
-    "fileMatch": ["a://b/SchemaMetadataResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/SchemaMetadataResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetadataResponseDto.schema.json",
@@ -3987,7 +4553,12 @@
           "description": "Level of security (LoS) of this attestation"
         },
         "bindingType": {
-          "enum": ["claim", "key", "biometric", "none"],
+          "enum": [
+            "claim",
+            "key",
+            "biometric",
+            "none"
+          ],
           "type": "string",
           "description": "Required binding type between attestation and holder"
         },
@@ -3995,7 +4566,10 @@
           "type": "array",
           "items": {
             "type": "string",
-            "enum": ["dc+sd-jwt", "mso_mdoc"]
+            "enum": [
+              "dc+sd-jwt",
+              "mso_mdoc"
+            ]
           },
           "description": "Credential formats in which this attestation is available"
         },
@@ -4014,7 +4588,15 @@
           }
         },
         "category": {
-          "enum": ["identity", "health", "finance", "education", "mobility", "employment", "other"],
+          "enum": [
+            "identity",
+            "health",
+            "finance",
+            "education",
+            "mobility",
+            "employment",
+            "other"
+          ],
           "type": "string",
           "description": "Domain category for filtering"
         },
@@ -4090,7 +4672,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateSchemaMetadataDto.schema.json",
-    "fileMatch": ["a://b/UpdateSchemaMetadataDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateSchemaMetadataDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateSchemaMetadataDto.schema.json",
@@ -4098,7 +4682,15 @@
       "type": "object",
       "properties": {
         "category": {
-          "enum": ["identity", "health", "finance", "education", "mobility", "employment", "other"],
+          "enum": [
+            "identity",
+            "health",
+            "finance",
+            "education",
+            "mobility",
+            "employment",
+            "other"
+          ],
           "type": "string",
           "description": "Domain category for filtering"
         },
@@ -4127,7 +4719,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeprecateSchemaMetadataDto.schema.json",
-    "fileMatch": ["a://b/DeprecateSchemaMetadataDto*.schema.json"],
+    "fileMatch": [
+      "a://b/DeprecateSchemaMetadataDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeprecateSchemaMetadataDto.schema.json",
@@ -4147,13 +4741,17 @@
           "description": "The version that supersedes this one"
         }
       },
-      "required": ["deprecated"],
+      "required": [
+        "deprecated"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateAttributeProviderDto.schema.json",
-    "fileMatch": ["a://b/CreateAttributeProviderDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CreateAttributeProviderDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateAttributeProviderDto.schema.json",
@@ -4184,13 +4782,20 @@
           "type": "string"
         }
       },
-      "required": ["auth", "id", "name", "url"],
+      "required": [
+        "auth",
+        "id",
+        "name",
+        "url"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateAttributeProviderDto.schema.json",
-    "fileMatch": ["a://b/UpdateAttributeProviderDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateAttributeProviderDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateAttributeProviderDto.schema.json",
@@ -4226,7 +4831,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateWebhookEndpointDto.schema.json",
-    "fileMatch": ["a://b/CreateWebhookEndpointDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CreateWebhookEndpointDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateWebhookEndpointDto.schema.json",
@@ -4258,13 +4865,20 @@
           "type": "string"
         }
       },
-      "required": ["id", "auth", "name", "url"],
+      "required": [
+        "id",
+        "auth",
+        "name",
+        "url"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateWebhookEndpointDto.schema.json",
-    "fileMatch": ["a://b/UpdateWebhookEndpointDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateWebhookEndpointDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateWebhookEndpointDto.schema.json",
@@ -4301,7 +4915,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListEntityInfo.schema.json",
-    "fileMatch": ["a://b/TrustListEntityInfo*.schema.json"],
+    "fileMatch": [
+      "a://b/TrustListEntityInfo*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListEntityInfo.schema.json",
@@ -4333,13 +4949,17 @@
           "type": "string"
         }
       },
-      "required": ["name"],
+      "required": [
+        "name"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InternalTrustListEntity.schema.json",
-    "fileMatch": ["a://b/InternalTrustListEntity*.schema.json"],
+    "fileMatch": [
+      "a://b/InternalTrustListEntity*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InternalTrustListEntity.schema.json",
@@ -4348,7 +4968,9 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["internal"]
+          "enum": [
+            "internal"
+          ]
         },
         "issuerKeyChainId": {
           "type": "string"
@@ -4360,13 +4982,20 @@
           "$ref": "./TrustListEntityInfo.schema.json"
         }
       },
-      "required": ["type", "issuerKeyChainId", "revocationKeyChainId", "info"],
+      "required": [
+        "type",
+        "issuerKeyChainId",
+        "revocationKeyChainId",
+        "info"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExternalTrustListEntity.schema.json",
-    "fileMatch": ["a://b/ExternalTrustListEntity*.schema.json"],
+    "fileMatch": [
+      "a://b/ExternalTrustListEntity*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExternalTrustListEntity.schema.json",
@@ -4375,7 +5004,9 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["external"]
+          "enum": [
+            "external"
+          ]
         },
         "issuerCertPem": {
           "type": "string"
@@ -4387,13 +5018,20 @@
           "$ref": "./TrustListEntityInfo.schema.json"
         }
       },
-      "required": ["type", "issuerCertPem", "revocationCertPem", "info"],
+      "required": [
+        "type",
+        "issuerCertPem",
+        "revocationCertPem",
+        "info"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListCreateDto.schema.json",
-    "fileMatch": ["a://b/TrustListCreateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/TrustListCreateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListCreateDto.schema.json",
@@ -4434,13 +5072,17 @@
           "type": "string"
         }
       },
-      "required": ["entities"],
+      "required": [
+        "entities"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustList.schema.json",
-    "fileMatch": ["a://b/TrustList*.schema.json"],
+    "fileMatch": [
+      "a://b/TrustList*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustList.schema.json",
@@ -4516,7 +5158,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListVersion.schema.json",
-    "fileMatch": ["a://b/TrustListVersion*.schema.json"],
+    "fileMatch": [
+      "a://b/TrustListVersion*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListVersion.schema.json",
@@ -4571,7 +5215,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DCQL.schema.json",
-    "fileMatch": ["a://b/DCQL*.schema.json"],
+    "fileMatch": [
+      "a://b/DCQL*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DCQL.schema.json",
@@ -4591,13 +5237,17 @@
           }
         }
       },
-      "required": ["credentials"],
+      "required": [
+        "credentials"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificatePurpose.schema.json",
-    "fileMatch": ["a://b/RegistrationCertificatePurpose*.schema.json"],
+    "fileMatch": [
+      "a://b/RegistrationCertificatePurpose*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificatePurpose.schema.json",
@@ -4611,13 +5261,18 @@
           "type": "string"
         }
       },
-      "required": ["lang", "content"],
+      "required": [
+        "lang",
+        "content"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateBody.schema.json",
-    "fileMatch": ["a://b/RegistrationCertificateBody*.schema.json"],
+    "fileMatch": [
+      "a://b/RegistrationCertificateBody*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateBody.schema.json",
@@ -4657,7 +5312,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateRequest.schema.json",
-    "fileMatch": ["a://b/RegistrationCertificateRequest*.schema.json"],
+    "fileMatch": [
+      "a://b/RegistrationCertificateRequest*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateRequest.schema.json",
@@ -4686,7 +5343,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationAttachment.schema.json",
-    "fileMatch": ["a://b/PresentationAttachment*.schema.json"],
+    "fileMatch": [
+      "a://b/PresentationAttachment*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationAttachment.schema.json",
@@ -4706,13 +5365,18 @@
           }
         }
       },
-      "required": ["format", "data"],
+      "required": [
+        "format",
+        "data"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfig.schema.json",
-    "fileMatch": ["a://b/PresentationConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/PresentationConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfig.schema.json",
@@ -4821,13 +5485,21 @@
           "description": "Optional ID of the access certificate to use for signing the presentation request.\nIf not provided, the default access certificate for the tenant will be used.\n\nNote: This is intentionally NOT a TypeORM relationship because CertEntity uses\na composite primary key (id + tenantId), and SQLite cannot create foreign keys\nthat reference only part of a composite primary key. The relationship is handled\nat the application level in the service layer."
         }
       },
-      "required": ["id", "tenant", "dcql_query", "createdAt", "updatedAt"],
+      "required": [
+        "id",
+        "tenant",
+        "dcql_query",
+        "createdAt",
+        "updatedAt"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ResolveIssuerMetadataDto.schema.json",
-    "fileMatch": ["a://b/ResolveIssuerMetadataDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ResolveIssuerMetadataDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ResolveIssuerMetadataDto.schema.json",
@@ -4841,13 +5513,17 @@
           "example": "https://issuer.example.com/issuers/tenant-a"
         }
       },
-      "required": ["issuerUrl"],
+      "required": [
+        "issuerUrl"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ResolveSchemaMetadataDto.schema.json",
-    "fileMatch": ["a://b/ResolveSchemaMetadataDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ResolveSchemaMetadataDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ResolveSchemaMetadataDto.schema.json",
@@ -4861,13 +5537,17 @@
           "example": "https://registrar.example.com/schema-metadata/5c0d7dbb-ef2e-448b-b84f-b8103575947b"
         }
       },
-      "required": ["schemaMetadataUrl"],
+      "required": [
+        "schemaMetadataUrl"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfigCreateDto.schema.json",
-    "fileMatch": ["a://b/PresentationConfigCreateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/PresentationConfigCreateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfigCreateDto.schema.json",
@@ -4950,13 +5630,18 @@
           "description": "Optional ID of the access certificate to use for signing the presentation request.\nIf not provided, the default access certificate for the tenant will be used.\n\nNote: This is intentionally NOT a TypeORM relationship because CertEntity uses\na composite primary key (id + tenantId), and SQLite cannot create foreign keys\nthat reference only part of a composite primary key. The relationship is handled\nat the application level in the service layer."
         }
       },
-      "required": ["id", "dcql_query"],
+      "required": [
+        "id",
+        "dcql_query"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfigUpdateDto.schema.json",
-    "fileMatch": ["a://b/PresentationConfigUpdateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/PresentationConfigUpdateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfigUpdateDto.schema.json",
@@ -5044,7 +5729,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateDefaults.schema.json",
-    "fileMatch": ["a://b/RegistrationCertificateDefaults*.schema.json"],
+    "fileMatch": [
+      "a://b/RegistrationCertificateDefaults*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateDefaults.schema.json",
@@ -5067,7 +5754,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrarConfigResponseDto.schema.json",
-    "fileMatch": ["a://b/RegistrarConfigResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/RegistrarConfigResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrarConfigResponseDto.schema.json",
@@ -5115,13 +5804,21 @@
           "example": true
         }
       },
-      "required": ["registrarUrl", "oidcUrl", "clientId", "username", "hasPassword"],
+      "required": [
+        "registrarUrl",
+        "oidcUrl",
+        "clientId",
+        "username",
+        "hasPassword"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateRegistrarConfigDto.schema.json",
-    "fileMatch": ["a://b/CreateRegistrarConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CreateRegistrarConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateRegistrarConfigDto.schema.json",
@@ -5168,13 +5865,21 @@
           ]
         }
       },
-      "required": ["registrarUrl", "oidcUrl", "clientId", "username", "password"],
+      "required": [
+        "registrarUrl",
+        "oidcUrl",
+        "clientId",
+        "username",
+        "password"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateRegistrarConfigDto.schema.json",
-    "fileMatch": ["a://b/UpdateRegistrarConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateRegistrarConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateRegistrarConfigDto.schema.json",
@@ -5226,7 +5931,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateAccessCertificateDto.schema.json",
-    "fileMatch": ["a://b/CreateAccessCertificateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CreateAccessCertificateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateAccessCertificateDto.schema.json",
@@ -5239,13 +5946,17 @@
           "example": "my-signing-key"
         }
       },
-      "required": ["keyId"],
+      "required": [
+        "keyId"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeferredCredentialRequestDto.schema.json",
-    "fileMatch": ["a://b/DeferredCredentialRequestDto*.schema.json"],
+    "fileMatch": [
+      "a://b/DeferredCredentialRequestDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeferredCredentialRequestDto.schema.json",
@@ -5258,13 +5969,17 @@
           "example": "8xLOxBtZp8"
         }
       },
-      "required": ["transaction_id"],
+      "required": [
+        "transaction_id"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/NotificationRequestDto.schema.json",
-    "fileMatch": ["a://b/NotificationRequestDto*.schema.json"],
+    "fileMatch": [
+      "a://b/NotificationRequestDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/NotificationRequestDto.schema.json",
@@ -5276,16 +5991,25 @@
         },
         "event": {
           "type": "string",
-          "enum": ["credential_accepted", "credential_failure", "credential_deleted"]
+          "enum": [
+            "credential_accepted",
+            "credential_failure",
+            "credential_deleted"
+          ]
         }
       },
-      "required": ["notification_id", "event"],
+      "required": [
+        "notification_id",
+        "event"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/OfferResponse.schema.json",
-    "fileMatch": ["a://b/OfferResponse*.schema.json"],
+    "fileMatch": [
+      "a://b/OfferResponse*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/OfferResponse.schema.json",
@@ -5303,13 +6027,18 @@
           "type": "string"
         }
       },
-      "required": ["uri", "session"],
+      "required": [
+        "uri",
+        "session"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CompleteDeferredDto.schema.json",
-    "fileMatch": ["a://b/CompleteDeferredDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CompleteDeferredDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CompleteDeferredDto.schema.json",
@@ -5327,13 +6056,17 @@
           }
         }
       },
-      "required": ["claims"],
+      "required": [
+        "claims"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeferredOperationResponse.schema.json",
-    "fileMatch": ["a://b/DeferredOperationResponse*.schema.json"],
+    "fileMatch": [
+      "a://b/DeferredOperationResponse*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeferredOperationResponse.schema.json",
@@ -5346,7 +6079,13 @@
         },
         "status": {
           "description": "The new status of the transaction",
-          "enum": ["pending", "ready", "retrieved", "expired", "failed"],
+          "enum": [
+            "pending",
+            "ready",
+            "retrieved",
+            "expired",
+            "failed"
+          ],
           "type": "string"
         },
         "message": {
@@ -5354,13 +6093,18 @@
           "description": "Optional message"
         }
       },
-      "required": ["transactionId", "status"],
+      "required": [
+        "transactionId",
+        "status"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FailDeferredDto.schema.json",
-    "fileMatch": ["a://b/FailDeferredDto*.schema.json"],
+    "fileMatch": [
+      "a://b/FailDeferredDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FailDeferredDto.schema.json",
@@ -5378,7 +6122,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EC_Public.schema.json",
-    "fileMatch": ["a://b/EC_Public*.schema.json"],
+    "fileMatch": [
+      "a://b/EC_Public*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EC_Public.schema.json",
@@ -5402,13 +6148,20 @@
           "description": "The y coordinate of the EC public key."
         }
       },
-      "required": ["kty", "crv", "x", "y"],
+      "required": [
+        "kty",
+        "crv",
+        "x",
+        "y"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/JwksResponseDto.schema.json",
-    "fileMatch": ["a://b/JwksResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/JwksResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/JwksResponseDto.schema.json",
@@ -5423,13 +6176,17 @@
           }
         }
       },
-      "required": ["keys"],
+      "required": [
+        "keys"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthorizationResponse.schema.json",
-    "fileMatch": ["a://b/AuthorizationResponse*.schema.json"],
+    "fileMatch": [
+      "a://b/AuthorizationResponse*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthorizationResponse.schema.json",
@@ -5465,7 +6222,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Object.schema.json",
-    "fileMatch": ["a://b/Object*.schema.json"],
+    "fileMatch": [
+      "a://b/Object*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Object.schema.json",
@@ -5477,7 +6236,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ParResponseDto.schema.json",
-    "fileMatch": ["a://b/ParResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ParResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ParResponseDto.schema.json",
@@ -5493,13 +6254,18 @@
           "description": "The expiration time for the request URI in seconds."
         }
       },
-      "required": ["request_uri", "expires_in"],
+      "required": [
+        "request_uri",
+        "expires_in"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationRequestDto.schema.json",
-    "fileMatch": ["a://b/InteractiveAuthorizationRequestDto*.schema.json"],
+    "fileMatch": [
+      "a://b/InteractiveAuthorizationRequestDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationRequestDto.schema.json",
@@ -5572,7 +6338,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationCodeResponseDto.schema.json",
-    "fileMatch": ["a://b/InteractiveAuthorizationCodeResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/InteractiveAuthorizationCodeResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationCodeResponseDto.schema.json",
@@ -5590,13 +6358,18 @@
           "example": "auth-code-123"
         }
       },
-      "required": ["status", "code"],
+      "required": [
+        "status",
+        "code"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationErrorResponseDto.schema.json",
-    "fileMatch": ["a://b/InteractiveAuthorizationErrorResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/InteractiveAuthorizationErrorResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationErrorResponseDto.schema.json",
@@ -5614,13 +6387,17 @@
           "example": "Missing required parameter: interaction_types_supported"
         }
       },
-      "required": ["error"],
+      "required": [
+        "error"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsParResponseDto.schema.json",
-    "fileMatch": ["a://b/ChainedAsParResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ChainedAsParResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsParResponseDto.schema.json",
@@ -5638,13 +6415,18 @@
           "example": 600
         }
       },
-      "required": ["request_uri", "expires_in"],
+      "required": [
+        "request_uri",
+        "expires_in"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsErrorResponseDto.schema.json",
-    "fileMatch": ["a://b/ChainedAsErrorResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ChainedAsErrorResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsErrorResponseDto.schema.json",
@@ -5661,13 +6443,17 @@
           "description": "Human-readable error description"
         }
       },
-      "required": ["error"],
+      "required": [
+        "error"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenRequestDto.schema.json",
-    "fileMatch": ["a://b/ChainedAsTokenRequestDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ChainedAsTokenRequestDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenRequestDto.schema.json",
@@ -5700,13 +6486,17 @@
           "description": "PKCE code verifier"
         }
       },
-      "required": ["grant_type"],
+      "required": [
+        "grant_type"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenResponseDto.schema.json",
-    "fileMatch": ["a://b/ChainedAsTokenResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ChainedAsTokenResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenResponseDto.schema.json",
@@ -5751,13 +6541,19 @@
           "description": "Refresh token (issued when refresh tokens are enabled)"
         }
       },
-      "required": ["access_token", "token_type", "expires_in"],
+      "required": [
+        "access_token",
+        "token_type",
+        "expires_in"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProviderCapabilitiesDto.schema.json",
-    "fileMatch": ["a://b/KmsProviderCapabilitiesDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KmsProviderCapabilitiesDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProviderCapabilitiesDto.schema.json",
@@ -5781,7 +6577,9 @@
         },
         "supportedAlgs": {
           "description": "Signing algorithms supported by the provider.",
-          "example": ["ES256"],
+          "example": [
+            "ES256"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -5793,13 +6591,21 @@
           "example": "ES256"
         }
       },
-      "required": ["canImport", "canCreate", "canDelete", "supportedAlgs", "defaultAlg"],
+      "required": [
+        "canImport",
+        "canCreate",
+        "canDelete",
+        "supportedAlgs",
+        "defaultAlg"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProviderInfoDto.schema.json",
-    "fileMatch": ["a://b/KmsProviderInfoDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KmsProviderInfoDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProviderInfoDto.schema.json",
@@ -5830,13 +6636,19 @@
           ]
         }
       },
-      "required": ["name", "type", "capabilities"],
+      "required": [
+        "name",
+        "type",
+        "capabilities"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProvidersResponseDto.schema.json",
-    "fileMatch": ["a://b/KmsProvidersResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KmsProvidersResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProvidersResponseDto.schema.json",
@@ -5856,13 +6668,18 @@
           "example": "db"
         }
       },
-      "required": ["providers", "default"],
+      "required": [
+        "providers",
+        "default"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DbKmsConfigDto.schema.json",
-    "fileMatch": ["a://b/DbKmsConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/DbKmsConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DbKmsConfigDto.schema.json",
@@ -5875,7 +6692,9 @@
           "example": "main-vault"
         },
         "type": {
-          "enum": ["db"],
+          "enum": [
+            "db"
+          ],
           "type": "string",
           "description": "Type of the KMS provider.",
           "example": "db"
@@ -5886,13 +6705,18 @@
           "example": "Production HashiCorp Vault for signing keys"
         }
       },
-      "required": ["id", "type"],
+      "required": [
+        "id",
+        "type"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/VaultKmsConfigDto.schema.json",
-    "fileMatch": ["a://b/VaultKmsConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/VaultKmsConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/VaultKmsConfigDto.schema.json",
@@ -5905,7 +6729,9 @@
           "example": "main-vault"
         },
         "type": {
-          "enum": ["vault"],
+          "enum": [
+            "vault"
+          ],
           "type": "string",
           "description": "Type of the KMS provider.",
           "example": "vault"
@@ -5926,13 +6752,20 @@
           "example": "${VAULT_TOKEN}"
         }
       },
-      "required": ["id", "type", "vaultUrl", "vaultToken"],
+      "required": [
+        "id",
+        "type",
+        "vaultUrl",
+        "vaultToken"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AwsKmsConfigDto.schema.json",
-    "fileMatch": ["a://b/AwsKmsConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/AwsKmsConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AwsKmsConfigDto.schema.json",
@@ -5945,7 +6778,9 @@
           "example": "main-vault"
         },
         "type": {
-          "enum": ["aws-kms"],
+          "enum": [
+            "aws-kms"
+          ],
           "type": "string",
           "description": "Type of the KMS provider.",
           "example": "aws-kms"
@@ -5971,13 +6806,19 @@
           "example": "${AWS_SECRET_ACCESS_KEY}"
         }
       },
-      "required": ["id", "type", "region"],
+      "required": [
+        "id",
+        "type",
+        "region"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Pkcs11KmsConfigDto.schema.json",
-    "fileMatch": ["a://b/Pkcs11KmsConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/Pkcs11KmsConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Pkcs11KmsConfigDto.schema.json",
@@ -5990,7 +6831,9 @@
           "example": "main-vault"
         },
         "type": {
-          "enum": ["pkcs11"],
+          "enum": [
+            "pkcs11"
+          ],
           "type": "string",
           "description": "Type of the KMS provider.",
           "example": "pkcs11"
@@ -6021,13 +6864,21 @@
           "example": false
         }
       },
-      "required": ["id", "type", "library", "slot", "pin"],
+      "required": [
+        "id",
+        "type",
+        "library",
+        "slot",
+        "pin"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/HttpAuthBaseConfigDto.schema.json",
-    "fileMatch": ["a://b/HttpAuthBaseConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/HttpAuthBaseConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/HttpAuthBaseConfigDto.schema.json",
@@ -6035,18 +6886,27 @@
       "type": "object",
       "properties": {
         "type": {
-          "enum": ["none", "bearer", "oauth2-client-credentials", "mtls"],
+          "enum": [
+            "none",
+            "bearer",
+            "oauth2-client-credentials",
+            "mtls"
+          ],
           "type": "string",
           "description": "Authentication method for the remote KMS service."
         }
       },
-      "required": ["type"],
+      "required": [
+        "type"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/HttpKmsConfigDto.schema.json",
-    "fileMatch": ["a://b/HttpKmsConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/HttpKmsConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/HttpKmsConfigDto.schema.json",
@@ -6059,7 +6919,9 @@
           "example": "main-vault"
         },
         "type": {
-          "enum": ["http"],
+          "enum": [
+            "http"
+          ],
           "type": "string",
           "description": "Type of the KMS provider.",
           "example": "http"
@@ -6098,13 +6960,19 @@
           "example": false
         }
       },
-      "required": ["id", "type", "baseUrl"],
+      "required": [
+        "id",
+        "type",
+        "baseUrl"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CscAuthorizeAuthDataDto.schema.json",
-    "fileMatch": ["a://b/CscAuthorizeAuthDataDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CscAuthorizeAuthDataDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CscAuthorizeAuthDataDto.schema.json",
@@ -6122,13 +6990,18 @@
           "example": "123456"
         }
       },
-      "required": ["id", "value"],
+      "required": [
+        "id",
+        "value"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CscKmsConfigDto.schema.json",
-    "fileMatch": ["a://b/CscKmsConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CscKmsConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CscKmsConfigDto.schema.json",
@@ -6141,7 +7014,9 @@
           "example": "main-vault"
         },
         "type": {
-          "enum": ["csc"],
+          "enum": [
+            "csc"
+          ],
           "type": "string",
           "description": "Type of the KMS provider.",
           "example": "csc"
@@ -6219,13 +7094,22 @@
           }
         }
       },
-      "required": ["id", "type", "baseUrl", "tokenUrl", "clientId", "clientSecret"],
+      "required": [
+        "id",
+        "type",
+        "baseUrl",
+        "tokenUrl",
+        "clientId",
+        "clientSecret"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsConfigDto.schema.json",
-    "fileMatch": ["a://b/KmsConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KmsConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsConfigDto.schema.json",
@@ -6295,13 +7179,17 @@
           ]
         }
       },
-      "required": ["providers"],
+      "required": [
+        "providers"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsTenantConfigResponseDto.schema.json",
-    "fileMatch": ["a://b/KmsTenantConfigResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KmsTenantConfigResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsTenantConfigResponseDto.schema.json",
@@ -6327,13 +7215,17 @@
           ]
         }
       },
-      "required": ["effectiveConfig"],
+      "required": [
+        "effectiveConfig"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CertificateInfoDto.schema.json",
-    "fileMatch": ["a://b/CertificateInfoDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CertificateInfoDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CertificateInfoDto.schema.json",
@@ -6367,13 +7259,17 @@
           "description": "Serial number."
         }
       },
-      "required": ["pem"],
+      "required": [
+        "pem"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PublicKeyInfoDto.schema.json",
-    "fileMatch": ["a://b/PublicKeyInfoDto*.schema.json"],
+    "fileMatch": [
+      "a://b/PublicKeyInfoDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PublicKeyInfoDto.schema.json",
@@ -6400,13 +7296,17 @@
           "example": "P-256"
         }
       },
-      "required": ["kty"],
+      "required": [
+        "kty"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyResponseDto.schema.json",
-    "fileMatch": ["a://b/RotationPolicyResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/RotationPolicyResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyResponseDto.schema.json",
@@ -6431,13 +7331,17 @@
           "description": "Next scheduled rotation date."
         }
       },
-      "required": ["enabled"],
+      "required": [
+        "enabled"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainResponseDto.schema.json",
-    "fileMatch": ["a://b/KeyChainResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KeyChainResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainResponseDto.schema.json",
@@ -6449,12 +7353,21 @@
           "description": "Unique identifier for the key chain."
         },
         "usageType": {
-          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"],
+          "enum": [
+            "access",
+            "attestation",
+            "trustList",
+            "statusList",
+            "encrypt"
+          ],
           "type": "string",
           "description": "Usage type of the key chain."
         },
         "type": {
-          "enum": ["standalone", "internalChain"],
+          "enum": [
+            "standalone",
+            "internalChain"
+          ],
           "type": "string",
           "description": "Type of key chain (standalone or internalChain)."
         },
@@ -6545,7 +7458,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExportEcJwk.schema.json",
-    "fileMatch": ["a://b/ExportEcJwk*.schema.json"],
+    "fileMatch": [
+      "a://b/ExportEcJwk*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExportEcJwk.schema.json",
@@ -6584,13 +7499,21 @@
           "description": "Key ID"
         }
       },
-      "required": ["kty", "crv", "x", "y", "d"],
+      "required": [
+        "kty",
+        "crv",
+        "x",
+        "y",
+        "d"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExportRotationPolicyDto.schema.json",
-    "fileMatch": ["a://b/ExportRotationPolicyDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ExportRotationPolicyDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExportRotationPolicyDto.schema.json",
@@ -6610,13 +7533,17 @@
           "description": "Certificate validity in days."
         }
       },
-      "required": ["enabled"],
+      "required": [
+        "enabled"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainExportDto.schema.json",
-    "fileMatch": ["a://b/KeyChainExportDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KeyChainExportDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainExportDto.schema.json",
@@ -6632,7 +7559,13 @@
           "description": "Human-readable description."
         },
         "usageType": {
-          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"],
+          "enum": [
+            "access",
+            "attestation",
+            "trustList",
+            "statusList",
+            "encrypt"
+          ],
           "type": "string",
           "description": "Usage type for this key chain."
         },
@@ -6664,13 +7597,19 @@
           ]
         }
       },
-      "required": ["id", "usageType", "key"],
+      "required": [
+        "id",
+        "usageType",
+        "key"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyCreateDto.schema.json",
-    "fileMatch": ["a://b/RotationPolicyCreateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/RotationPolicyCreateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyCreateDto.schema.json",
@@ -6697,13 +7636,17 @@
           "example": 365
         }
       },
-      "required": ["enabled"],
+      "required": [
+        "enabled"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainCreateDto.schema.json",
-    "fileMatch": ["a://b/KeyChainCreateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KeyChainCreateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainCreateDto.schema.json",
@@ -6711,13 +7654,22 @@
       "type": "object",
       "properties": {
         "usageType": {
-          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"],
+          "enum": [
+            "access",
+            "attestation",
+            "trustList",
+            "statusList",
+            "encrypt"
+          ],
           "type": "string",
           "description": "Usage type determines the purpose of this key chain (access, attestation, etc.).",
           "example": "attestation"
         },
         "type": {
-          "enum": ["standalone", "internalChain"],
+          "enum": [
+            "standalone",
+            "internalChain"
+          ],
           "type": "string",
           "description": "Type of key chain to create.",
           "example": "internalChain"
@@ -6741,13 +7693,18 @@
           ]
         }
       },
-      "required": ["usageType", "type"],
+      "required": [
+        "usageType",
+        "type"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EcJwk.schema.json",
-    "fileMatch": ["a://b/EcJwk*.schema.json"],
+    "fileMatch": [
+      "a://b/EcJwk*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EcJwk.schema.json",
@@ -6776,13 +7733,21 @@
           "type": "string"
         }
       },
-      "required": ["kty", "x", "y", "crv", "d"],
+      "required": [
+        "kty",
+        "x",
+        "y",
+        "crv",
+        "d"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyImportDto.schema.json",
-    "fileMatch": ["a://b/RotationPolicyImportDto*.schema.json"],
+    "fileMatch": [
+      "a://b/RotationPolicyImportDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyImportDto.schema.json",
@@ -6809,13 +7774,17 @@
           "example": 365
         }
       },
-      "required": ["enabled"],
+      "required": [
+        "enabled"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainImportDto.schema.json",
-    "fileMatch": ["a://b/KeyChainImportDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KeyChainImportDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainImportDto.schema.json",
@@ -6839,7 +7808,13 @@
           "description": "Human-readable description."
         },
         "usageType": {
-          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"],
+          "enum": [
+            "access",
+            "attestation",
+            "trustList",
+            "statusList",
+            "encrypt"
+          ],
           "type": "string",
           "description": "Usage type for this key chain."
         },
@@ -6863,13 +7838,18 @@
           ]
         }
       },
-      "required": ["key", "usageType"],
+      "required": [
+        "key",
+        "usageType"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyUpdateDto.schema.json",
-    "fileMatch": ["a://b/RotationPolicyUpdateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/RotationPolicyUpdateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyUpdateDto.schema.json",
@@ -6898,7 +7878,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainUpdateDto.schema.json",
-    "fileMatch": ["a://b/KeyChainUpdateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KeyChainUpdateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainUpdateDto.schema.json",
@@ -6927,7 +7909,9 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationRequest.schema.json",
-    "fileMatch": ["a://b/PresentationRequest*.schema.json"],
+    "fileMatch": [
+      "a://b/PresentationRequest*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationRequest.schema.json",
@@ -6937,7 +7921,10 @@
         "response_type": {
           "type": "string",
           "description": "The type of response expected from the presentation request.",
-          "enum": ["uri", "dc-api"]
+          "enum": [
+            "uri",
+            "dc-api"
+          ]
         },
         "requestId": {
           "type": "string",
@@ -6968,13 +7955,18 @@
           }
         }
       },
-      "required": ["response_type", "requestId"],
+      "required": [
+        "response_type",
+        "requestId"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FileUploadDto.schema.json",
-    "fileMatch": ["a://b/FileUploadDto*.schema.json"],
+    "fileMatch": [
+      "a://b/FileUploadDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FileUploadDto.schema.json",
@@ -6986,7 +7978,9 @@
           "format": "binary"
         }
       },
-      "required": ["file"],
+      "required": [
+        "file"
+      ],
       "additionalProperties": false
     }
   }

--- a/apps/client/src/app/utils/schemas.json
+++ b/apps/client/src/app/utils/schemas.json
@@ -1,9 +1,7 @@
 [
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/GrafanaConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/GrafanaConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/GrafanaConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/GrafanaConfigDto.schema.json",
@@ -26,18 +24,13 @@
           "example": "loki"
         }
       },
-      "required": [
-        "tempoUid",
-        "lokiUid"
-      ],
+      "required": ["tempoUid", "lokiUid"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FrontendConfigResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/FrontendConfigResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/FrontendConfigResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FrontendConfigResponseDto.schema.json",
@@ -53,17 +46,13 @@
           ]
         }
       },
-      "required": [
-        "grafana"
-      ],
+      "required": ["grafana"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RoleDto.schema.json",
-    "fileMatch": [
-      "a://b/RoleDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/RoleDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RoleDto.schema.json",
@@ -86,17 +75,13 @@
           "example": "issuance:manage"
         }
       },
-      "required": [
-        "role"
-      ],
+      "required": ["role"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientCredentialsDto.schema.json",
-    "fileMatch": [
-      "a://b/ClientCredentialsDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ClientCredentialsDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientCredentialsDto.schema.json",
@@ -114,18 +99,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "client_id",
-        "client_secret"
-      ],
+      "required": ["client_id", "client_secret"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TokenResponse.schema.json",
-    "fileMatch": [
-      "a://b/TokenResponse*.schema.json"
-    ],
+    "fileMatch": ["a://b/TokenResponse*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TokenResponse.schema.json",
@@ -148,20 +128,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "access_token",
-        "token_type",
-        "expires_in",
-        "state"
-      ],
+      "required": ["access_token", "token_type", "expires_in", "state"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ImportTenantDto.schema.json",
-    "fileMatch": [
-      "a://b/ImportTenantDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ImportTenantDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ImportTenantDto.schema.json",
@@ -177,17 +150,13 @@
           "description": "The description of the tenant."
         }
       },
-      "required": [
-        "name"
-      ],
+      "required": ["name"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SessionStorageConfig.schema.json",
-    "fileMatch": [
-      "a://b/SessionStorageConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/SessionStorageConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SessionStorageConfig.schema.json",
@@ -203,10 +172,7 @@
         "cleanupMode": {
           "type": "string",
           "description": "Cleanup mode: 'full' deletes everything, 'anonymize' keeps metadata but removes PII.",
-          "enum": [
-            "full",
-            "anonymize"
-          ],
+          "enum": ["full", "anonymize"],
           "default": "full"
         }
       },
@@ -215,9 +181,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListConfig.schema.json",
-    "fileMatch": [
-      "a://b/StatusListConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/StatusListConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListConfig.schema.json",
@@ -233,12 +197,7 @@
         "bits": {
           "type": "number",
           "description": "Bits per status entry: 1 (valid/revoked), 2 (with suspended), 4/8 (extended). If not set, uses global STATUS_BITS.",
-          "enum": [
-            1,
-            2,
-            4,
-            8
-          ],
+          "enum": [1, 2, 4, 8],
           "default": 1
         },
         "ttl": {
@@ -263,9 +222,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TenantEntity.schema.json",
-    "fileMatch": [
-      "a://b/TenantEntity*.schema.json"
-    ],
+    "fileMatch": ["a://b/TenantEntity*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TenantEntity.schema.json",
@@ -316,20 +273,13 @@
           }
         }
       },
-      "required": [
-        "id",
-        "name",
-        "status",
-        "clients"
-      ],
+      "required": ["id", "name", "status", "clients"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientEntity.schema.json",
-    "fileMatch": [
-      "a://b/ClientEntity*.schema.json"
-    ],
+    "fileMatch": ["a://b/ClientEntity*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientEntity.schema.json",
@@ -339,10 +289,7 @@
         "allowedPresentationConfigs": {
           "nullable": true,
           "description": "List of presentation config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": [
-            "age-verification",
-            "kyc-basic"
-          ],
+          "example": ["age-verification", "kyc-basic"],
           "type": "array",
           "items": {
             "type": "string"
@@ -351,10 +298,7 @@
         "allowedIssuanceConfigs": {
           "nullable": true,
           "description": "List of issuance config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": [
-            "pid",
-            "mdl"
-          ],
+          "example": ["pid", "mdl"],
           "type": "array",
           "items": {
             "type": "string"
@@ -402,18 +346,13 @@
           ]
         }
       },
-      "required": [
-        "clientId",
-        "roles"
-      ],
+      "required": ["clientId", "roles"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateTenantDto.schema.json",
-    "fileMatch": [
-      "a://b/CreateTenantDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CreateTenantDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateTenantDto.schema.json",
@@ -467,18 +406,13 @@
           }
         }
       },
-      "required": [
-        "id",
-        "name"
-      ],
+      "required": ["id", "name"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateTenantDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateTenantDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateTenantDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateTenantDto.schema.json",
@@ -533,9 +467,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuditLogResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/AuditLogResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/AuditLogResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuditLogResponseDto.schema.json",
@@ -572,11 +504,7 @@
           "type": "string"
         },
         "actorType": {
-          "enum": [
-            "user",
-            "client",
-            "system"
-          ],
+          "enum": ["user", "client", "system"],
           "type": "string"
         },
         "actorId": {
@@ -607,21 +535,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "id",
-        "tenantId",
-        "actionType",
-        "actorType",
-        "timestamp"
-      ],
+      "required": ["id", "tenantId", "actionType", "actorType", "timestamp"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientSecretResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/ClientSecretResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ClientSecretResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientSecretResponseDto.schema.json",
@@ -632,17 +552,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "secret"
-      ],
+      "required": ["secret"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateClientDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateClientDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateClientDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateClientDto.schema.json",
@@ -652,10 +568,7 @@
         "allowedPresentationConfigs": {
           "nullable": true,
           "description": "List of presentation config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": [
-            "age-verification",
-            "kyc-basic"
-          ],
+          "example": ["age-verification", "kyc-basic"],
           "type": "array",
           "items": {
             "type": "string"
@@ -664,10 +577,7 @@
         "allowedIssuanceConfigs": {
           "nullable": true,
           "description": "List of issuance config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": [
-            "pid",
-            "mdl"
-          ],
+          "example": ["pid", "mdl"],
           "type": "array",
           "items": {
             "type": "string"
@@ -695,17 +605,13 @@
           }
         }
       },
-      "required": [
-        "roles"
-      ],
+      "required": ["roles"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateClientDto.schema.json",
-    "fileMatch": [
-      "a://b/CreateClientDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CreateClientDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateClientDto.schema.json",
@@ -715,10 +621,7 @@
         "allowedPresentationConfigs": {
           "nullable": true,
           "description": "List of presentation config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": [
-            "age-verification",
-            "kyc-basic"
-          ],
+          "example": ["age-verification", "kyc-basic"],
           "type": "array",
           "items": {
             "type": "string"
@@ -727,10 +630,7 @@
         "allowedIssuanceConfigs": {
           "nullable": true,
           "description": "List of issuance config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": [
-            "pid",
-            "mdl"
-          ],
+          "example": ["pid", "mdl"],
           "type": "array",
           "items": {
             "type": "string"
@@ -766,18 +666,13 @@
           }
         }
       },
-      "required": [
-        "clientId",
-        "roles"
-      ],
+      "required": ["clientId", "roles"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListImportDto.schema.json",
-    "fileMatch": [
-      "a://b/StatusListImportDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/StatusListImportDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListImportDto.schema.json",
@@ -807,27 +702,18 @@
         },
         "bits": {
           "description": "Bits per status value. If not provided, uses tenant or global defaults.",
-          "enum": [
-            1,
-            2,
-            4,
-            8
-          ],
+          "enum": [1, 2, 4, 8],
           "type": "number",
           "example": 1
         }
       },
-      "required": [
-        "id"
-      ],
+      "required": ["id"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListAggregationDto.schema.json",
-    "fileMatch": [
-      "a://b/StatusListAggregationDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/StatusListAggregationDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListAggregationDto.schema.json",
@@ -846,17 +732,13 @@
           }
         }
       },
-      "required": [
-        "status_lists"
-      ],
+      "required": ["status_lists"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateStatusListConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateStatusListConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateStatusListConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateStatusListConfigDto.schema.json",
@@ -873,12 +755,7 @@
         "bits": {
           "nullable": true,
           "description": "Bits per status entry. Set to null to reset to global default.",
-          "enum": [
-            1,
-            2,
-            4,
-            8
-          ],
+          "enum": [1, 2, 4, 8],
           "type": "number"
         },
         "ttl": {
@@ -904,9 +781,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/StatusListResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/StatusListResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListResponseDto.schema.json",
@@ -937,12 +812,7 @@
         },
         "bits": {
           "description": "Bits per status value",
-          "enum": [
-            1,
-            2,
-            4,
-            8
-          ],
+          "enum": [1, 2, 4, 8],
           "type": "number",
           "example": 1
         },
@@ -995,9 +865,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateStatusListDto.schema.json",
-    "fileMatch": [
-      "a://b/CreateStatusListDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CreateStatusListDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateStatusListDto.schema.json",
@@ -1016,12 +884,7 @@
         },
         "bits": {
           "description": "Bits per status value. More bits allow more status states. Defaults to tenant configuration.",
-          "enum": [
-            1,
-            2,
-            4,
-            8
-          ],
+          "enum": [1, 2, 4, 8],
           "type": "number",
           "example": 1
         },
@@ -1037,9 +900,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateStatusListDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateStatusListDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateStatusListDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateStatusListDto.schema.json",
@@ -1064,9 +925,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthorizeQueries.schema.json",
-    "fileMatch": [
-      "a://b/AuthorizeQueries*.schema.json"
-    ],
+    "fileMatch": ["a://b/AuthorizeQueries*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthorizeQueries.schema.json",
@@ -1119,9 +978,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/OfferRequestDto.schema.json",
-    "fileMatch": [
-      "a://b/OfferRequestDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/OfferRequestDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/OfferRequestDto.schema.json",
@@ -1129,10 +986,7 @@
       "type": "object",
       "properties": {
         "response_type": {
-          "enum": [
-            "uri",
-            "dc-api"
-          ],
+          "enum": ["uri", "dc-api"],
           "type": "string",
           "examples": [
             {
@@ -1150,19 +1004,14 @@
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "inline"
-                    ]
+                    "enum": ["inline"]
                   },
                   "claims": {
                     "type": "object",
                     "additionalProperties": true
                   }
                 },
-                "required": [
-                  "type",
-                  "claims"
-                ],
+                "required": ["type", "claims"],
                 "additionalProperties": false
               },
               {
@@ -1170,18 +1019,13 @@
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "attributeProvider"
-                    ]
+                    "enum": ["attributeProvider"]
                   },
                   "attributeProviderId": {
                     "type": "string"
                   }
                 },
-                "required": [
-                  "type",
-                  "attributeProviderId"
-                ],
+                "required": ["type", "attributeProviderId"],
                 "additionalProperties": false
               },
               {
@@ -1189,9 +1033,7 @@
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "webhook"
-                    ]
+                    "enum": ["webhook"]
                   },
                   "webhook": {
                     "type": "object",
@@ -1203,16 +1045,11 @@
                         "type": "object"
                       }
                     },
-                    "required": [
-                      "url"
-                    ],
+                    "required": ["url"],
                     "additionalProperties": false
                   }
                 },
-                "required": [
-                  "type",
-                  "webhook"
-                ],
+                "required": ["type", "webhook"],
                 "additionalProperties": false
               }
             ]
@@ -1230,10 +1067,7 @@
         },
         "flow": {
           "description": "The flow type for the offer request.",
-          "enum": [
-            "authorization_code",
-            "pre_authorized_code"
-          ],
+          "enum": ["authorization_code", "pre_authorized_code"],
           "type": "string"
         },
         "tx_code": {
@@ -1260,19 +1094,13 @@
           "description": "ID of the webhook endpoint to notify about the status of the issuance process."
         }
       },
-      "required": [
-        "response_type",
-        "flow",
-        "credentialConfigurationIds"
-      ],
+      "required": ["response_type", "flow", "credentialConfigurationIds"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebHookAuthConfigNone.schema.json",
-    "fileMatch": [
-      "a://b/WebHookAuthConfigNone*.schema.json"
-    ],
+    "fileMatch": ["a://b/WebHookAuthConfigNone*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebHookAuthConfigNone.schema.json",
@@ -1282,22 +1110,16 @@
         "type": {
           "type": "string",
           "description": "The type of authentication used for the webhook.",
-          "enum": [
-            "none"
-          ]
+          "enum": ["none"]
         }
       },
-      "required": [
-        "type"
-      ],
+      "required": ["type"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ApiKeyConfig.schema.json",
-    "fileMatch": [
-      "a://b/ApiKeyConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/ApiKeyConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ApiKeyConfig.schema.json",
@@ -1313,18 +1135,13 @@
           "description": "The value of the API key to be sent in the header."
         }
       },
-      "required": [
-        "headerName",
-        "value"
-      ],
+      "required": ["headerName", "value"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebHookAuthConfigHeader.schema.json",
-    "fileMatch": [
-      "a://b/WebHookAuthConfigHeader*.schema.json"
-    ],
+    "fileMatch": ["a://b/WebHookAuthConfigHeader*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebHookAuthConfigHeader.schema.json",
@@ -1334,9 +1151,7 @@
         "type": {
           "type": "string",
           "description": "The type of authentication used for the webhook.",
-          "enum": [
-            "apiKey"
-          ]
+          "enum": ["apiKey"]
         },
         "config": {
           "description": "Configuration for API key authentication.\nThis is required if the type is 'apiKey'.",
@@ -1347,18 +1162,13 @@
           ]
         }
       },
-      "required": [
-        "type",
-        "config"
-      ],
+      "required": ["type", "config"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebhookConfig.schema.json",
-    "fileMatch": [
-      "a://b/WebhookConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/WebhookConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebhookConfig.schema.json",
@@ -1388,18 +1198,13 @@
           "description": "The URL to which the webhook will send notifications."
         }
       },
-      "required": [
-        "auth",
-        "url"
-      ],
+      "required": ["auth", "url"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TransactionData.schema.json",
-    "fileMatch": [
-      "a://b/TransactionData*.schema.json"
-    ],
+    "fileMatch": ["a://b/TransactionData*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TransactionData.schema.json",
@@ -1416,18 +1221,13 @@
           }
         }
       },
-      "required": [
-        "type",
-        "credential_ids"
-      ],
+      "required": ["type", "credential_ids"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Session.schema.json",
-    "fileMatch": [
-      "a://b/Session*.schema.json"
-    ],
+    "fileMatch": ["a://b/Session*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Session.schema.json",
@@ -1436,13 +1236,7 @@
       "properties": {
         "status": {
           "description": "Status of the session.",
-          "enum": [
-            "active",
-            "fetched",
-            "completed",
-            "expired",
-            "failed"
-          ],
+          "enum": ["active", "fetched", "completed", "expired", "failed"],
           "type": "string"
         },
         "id": {
@@ -1632,9 +1426,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PaginatedSessionResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/PaginatedSessionResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/PaginatedSessionResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PaginatedSessionResponseDto.schema.json",
@@ -1665,21 +1457,13 @@
           "description": "Total number of pages"
         }
       },
-      "required": [
-        "items",
-        "total",
-        "page",
-        "pageSize",
-        "totalPages"
-      ],
+      "required": ["items", "total", "page", "pageSize", "totalPages"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SessionLogEntryResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/SessionLogEntryResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/SessionLogEntryResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SessionLogEntryResponseDto.schema.json",
@@ -1702,11 +1486,7 @@
         "level": {
           "type": "string",
           "description": "Log level",
-          "enum": [
-            "info",
-            "warn",
-            "error"
-          ]
+          "enum": ["info", "warn", "error"]
         },
         "stage": {
           "type": "string",
@@ -1722,21 +1502,13 @@
           "description": "Additional structured detail"
         }
       },
-      "required": [
-        "id",
-        "sessionId",
-        "timestamp",
-        "level",
-        "message"
-      ],
+      "required": ["id", "sessionId", "timestamp", "level", "message"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusUpdateDto.schema.json",
-    "fileMatch": [
-      "a://b/StatusUpdateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/StatusUpdateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusUpdateDto.schema.json",
@@ -1756,18 +1528,13 @@
           "description": "The status of the credential\n0 = valid, 1 = revoked, 2 = suspended"
         }
       },
-      "required": [
-        "sessionId",
-        "status"
-      ],
+      "required": ["sessionId", "status"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateSessionConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateSessionConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateSessionConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateSessionConfigDto.schema.json",
@@ -1783,10 +1550,7 @@
         },
         "cleanupMode": {
           "description": "Cleanup mode: 'full' deletes everything, 'anonymize' keeps metadata but removes PII.",
-          "enum": [
-            "full",
-            "anonymize"
-          ],
+          "enum": ["full", "anonymize"],
           "type": "string",
           "default": "full"
         }
@@ -1796,9 +1560,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ManagedUserDto.schema.json",
-    "fileMatch": [
-      "a://b/ManagedUserDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ManagedUserDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ManagedUserDto.schema.json",
@@ -1847,20 +1609,13 @@
           "description": "One-time temporary password returned only on user creation."
         }
       },
-      "required": [
-        "id",
-        "username",
-        "enabled",
-        "roles"
-      ],
+      "required": ["id", "username", "enabled", "roles"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateUserDto.schema.json",
-    "fileMatch": [
-      "a://b/CreateUserDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CreateUserDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateUserDto.schema.json",
@@ -1902,18 +1657,13 @@
           "example": true
         }
       },
-      "required": [
-        "username",
-        "roles"
-      ],
+      "required": ["username", "roles"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateUserDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateUserDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateUserDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateUserDto.schema.json",
@@ -1965,9 +1715,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodNone.schema.json",
-    "fileMatch": [
-      "a://b/AuthenticationMethodNone*.schema.json"
-    ],
+    "fileMatch": ["a://b/AuthenticationMethodNone*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodNone.schema.json",
@@ -1976,22 +1724,16 @@
       "properties": {
         "method": {
           "type": "string",
-          "enum": [
-            "none"
-          ]
+          "enum": ["none"]
         }
       },
-      "required": [
-        "method"
-      ],
+      "required": ["method"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationUrlConfig.schema.json",
-    "fileMatch": [
-      "a://b/AuthenticationUrlConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/AuthenticationUrlConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationUrlConfig.schema.json",
@@ -2011,17 +1753,13 @@
           ]
         }
       },
-      "required": [
-        "url"
-      ],
+      "required": ["url"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodAuth.schema.json",
-    "fileMatch": [
-      "a://b/AuthenticationMethodAuth*.schema.json"
-    ],
+    "fileMatch": ["a://b/AuthenticationMethodAuth*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodAuth.schema.json",
@@ -2030,26 +1768,19 @@
       "properties": {
         "method": {
           "type": "string",
-          "enum": [
-            "auth"
-          ]
+          "enum": ["auth"]
         },
         "config": {
           "$ref": "./AuthenticationUrlConfig.schema.json"
         }
       },
-      "required": [
-        "method",
-        "config"
-      ],
+      "required": ["method", "config"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationDuringIssuanceConfig.schema.json",
-    "fileMatch": [
-      "a://b/PresentationDuringIssuanceConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/PresentationDuringIssuanceConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationDuringIssuanceConfig.schema.json",
@@ -2061,17 +1792,13 @@
           "description": "Link to the presentation configuration that is relevant for the issuance process"
         }
       },
-      "required": [
-        "type"
-      ],
+      "required": ["type"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodPresentation.schema.json",
-    "fileMatch": [
-      "a://b/AuthenticationMethodPresentation*.schema.json"
-    ],
+    "fileMatch": ["a://b/AuthenticationMethodPresentation*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodPresentation.schema.json",
@@ -2080,26 +1807,19 @@
       "properties": {
         "method": {
           "type": "string",
-          "enum": [
-            "presentationDuringIssuance"
-          ]
+          "enum": ["presentationDuringIssuance"]
         },
         "config": {
           "$ref": "./PresentationDuringIssuanceConfig.schema.json"
         }
       },
-      "required": [
-        "method",
-        "config"
-      ],
+      "required": ["method", "config"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpstreamOidcConfig.schema.json",
-    "fileMatch": [
-      "a://b/UpstreamOidcConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpstreamOidcConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpstreamOidcConfig.schema.json",
@@ -2123,28 +1843,20 @@
         },
         "scopes": {
           "description": "Scopes to request from the upstream provider",
-          "default": [
-            "openid",
-            "profile"
-          ],
+          "default": ["openid", "profile"],
           "type": "array",
           "items": {
             "type": "string"
           }
         }
       },
-      "required": [
-        "issuer",
-        "clientId"
-      ],
+      "required": ["issuer", "clientId"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenConfig.schema.json",
-    "fileMatch": [
-      "a://b/ChainedAsTokenConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/ChainedAsTokenConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenConfig.schema.json",
@@ -2178,9 +1890,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ManagedAuthorizationServerConfig.schema.json",
-    "fileMatch": [
-      "a://b/ManagedAuthorizationServerConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/ManagedAuthorizationServerConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ManagedAuthorizationServerConfig.schema.json",
@@ -2198,12 +1908,7 @@
           "example": "PID Authorization Server"
         },
         "type": {
-          "enum": [
-            "external",
-            "oid4vp",
-            "chained",
-            "built-in"
-          ],
+          "enum": ["external", "oid4vp", "chained", "built-in"],
           "type": "string",
           "description": "Authorization server implementation type",
           "example": "external"
@@ -2251,17 +1956,13 @@
           "default": false
         }
       },
-      "required": [
-        "type"
-      ],
+      "required": ["type"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FederationTrustAnchorConfig.schema.json",
-    "fileMatch": [
-      "a://b/FederationTrustAnchorConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/FederationTrustAnchorConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FederationTrustAnchorConfig.schema.json",
@@ -2279,18 +1980,13 @@
           "example": "https://ta.example.org/.well-known/openid-federation"
         }
       },
-      "required": [
-        "entityId",
-        "entityConfigurationUri"
-      ],
+      "required": ["entityId", "entityConfigurationUri"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FederationConfig.schema.json",
-    "fileMatch": [
-      "a://b/FederationConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/FederationConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FederationConfig.schema.json",
@@ -2298,20 +1994,13 @@
       "type": "object",
       "properties": {
         "role": {
-          "enum": [
-            "trust_anchor",
-            "intermediate",
-            "leaf"
-          ],
+          "enum": ["trust_anchor", "intermediate", "leaf"],
           "type": "string",
           "description": "Role this tenant plays in the OpenID Federation topology.",
           "default": "leaf"
         },
         "mode": {
-          "enum": [
-            "federation-only",
-            "hybrid"
-          ],
+          "enum": ["federation-only", "hybrid"],
           "type": "string",
           "description": "Trust decision strategy when both LoTE trust lists and OpenID Federation are configured.",
           "default": "hybrid"
@@ -2339,17 +2028,13 @@
           }
         }
       },
-      "required": [
-        "trustAnchors"
-      ],
+      "required": ["trustAnchors"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerProvidedAttestation.schema.json",
-    "fileMatch": [
-      "a://b/IssuerProvidedAttestation*.schema.json"
-    ],
+    "fileMatch": ["a://b/IssuerProvidedAttestation*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerProvidedAttestation.schema.json",
@@ -2372,9 +2057,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerRegistrationCertificateConfig.schema.json",
-    "fileMatch": [
-      "a://b/IssuerRegistrationCertificateConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/IssuerRegistrationCertificateConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerRegistrationCertificateConfig.schema.json",
@@ -2387,10 +2070,7 @@
           "default": false
         },
         "mode": {
-          "enum": [
-            "import",
-            "generate"
-          ],
+          "enum": ["import", "generate"],
           "type": "string",
           "description": "import: use an existing JWT, generate: create via registrar from provided attestations and selected credential configurations.",
           "default": "import"
@@ -2429,9 +2109,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerRegistrationCertificateCache.schema.json",
-    "fileMatch": [
-      "a://b/IssuerRegistrationCertificateCache*.schema.json"
-    ],
+    "fileMatch": ["a://b/IssuerRegistrationCertificateCache*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerRegistrationCertificateCache.schema.json",
@@ -2464,9 +2142,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayLogo.schema.json",
-    "fileMatch": [
-      "a://b/DisplayLogo*.schema.json"
-    ],
+    "fileMatch": ["a://b/DisplayLogo*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayLogo.schema.json",
@@ -2480,17 +2156,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "uri"
-      ],
+      "required": ["uri"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayInfo.schema.json",
-    "fileMatch": [
-      "a://b/DisplayInfo*.schema.json"
-    ],
+    "fileMatch": ["a://b/DisplayInfo*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayInfo.schema.json",
@@ -2512,9 +2184,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuanceConfig.schema.json",
-    "fileMatch": [
-      "a://b/IssuanceConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/IssuanceConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuanceConfig.schema.json",
@@ -2624,20 +2294,13 @@
           "description": "The timestamp when the VP request was last updated."
         }
       },
-      "required": [
-        "tenant",
-        "display",
-        "createdAt",
-        "updatedAt"
-      ],
+      "required": ["tenant", "display", "createdAt", "updatedAt"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuanceDto.schema.json",
-    "fileMatch": [
-      "a://b/IssuanceDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/IssuanceDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuanceDto.schema.json",
@@ -2729,17 +2392,13 @@
           }
         }
       },
-      "required": [
-        "display"
-      ],
+      "required": ["display"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClaimsQuery.schema.json",
-    "fileMatch": [
-      "a://b/ClaimsQuery*.schema.json"
-    ],
+    "fileMatch": ["a://b/ClaimsQuery*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClaimsQuery.schema.json",
@@ -2762,17 +2421,13 @@
           }
         }
       },
-      "required": [
-        "path"
-      ],
+      "required": ["path"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustedAuthorityQuery.schema.json",
-    "fileMatch": [
-      "a://b/TrustedAuthorityQuery*.schema.json"
-    ],
+    "fileMatch": ["a://b/TrustedAuthorityQuery*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustedAuthorityQuery.schema.json",
@@ -2781,10 +2436,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": [
-            "etsi_tl",
-            "openid_federation"
-          ]
+          "enum": ["etsi_tl", "openid_federation"]
         },
         "values": {
           "type": "array",
@@ -2793,18 +2445,13 @@
           }
         }
       },
-      "required": [
-        "type",
-        "values"
-      ],
+      "required": ["type", "values"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialQuery.schema.json",
-    "fileMatch": [
-      "a://b/CredentialQuery*.schema.json"
-    ],
+    "fileMatch": ["a://b/CredentialQuery*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialQuery.schema.json",
@@ -2847,19 +2494,13 @@
           }
         }
       },
-      "required": [
-        "id",
-        "format",
-        "meta"
-      ],
+      "required": ["id", "format", "meta"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialSetQuery.schema.json",
-    "fileMatch": [
-      "a://b/CredentialSetQuery*.schema.json"
-    ],
+    "fileMatch": ["a://b/CredentialSetQuery*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialSetQuery.schema.json",
@@ -2879,17 +2520,13 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "options"
-      ],
+      "required": ["options"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PolicyCredential.schema.json",
-    "fileMatch": [
-      "a://b/PolicyCredential*.schema.json"
-    ],
+    "fileMatch": ["a://b/PolicyCredential*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PolicyCredential.schema.json",
@@ -2915,17 +2552,13 @@
           }
         }
       },
-      "required": [
-        "credentials"
-      ],
+      "required": ["credentials"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AttestationBasedPolicy.schema.json",
-    "fileMatch": [
-      "a://b/AttestationBasedPolicy*.schema.json"
-    ],
+    "fileMatch": ["a://b/AttestationBasedPolicy*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AttestationBasedPolicy.schema.json",
@@ -2934,9 +2567,7 @@
       "properties": {
         "policy": {
           "type": "string",
-          "enum": [
-            "attestationBased"
-          ]
+          "enum": ["attestationBased"]
         },
         "values": {
           "type": "array",
@@ -2945,18 +2576,13 @@
           }
         }
       },
-      "required": [
-        "policy",
-        "values"
-      ],
+      "required": ["policy", "values"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/NoneTrustPolicy.schema.json",
-    "fileMatch": [
-      "a://b/NoneTrustPolicy*.schema.json"
-    ],
+    "fileMatch": ["a://b/NoneTrustPolicy*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/NoneTrustPolicy.schema.json",
@@ -2965,22 +2591,16 @@
       "properties": {
         "policy": {
           "type": "string",
-          "enum": [
-            "none"
-          ]
+          "enum": ["none"]
         }
       },
-      "required": [
-        "policy"
-      ],
+      "required": ["policy"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AllowListPolicy.schema.json",
-    "fileMatch": [
-      "a://b/AllowListPolicy*.schema.json"
-    ],
+    "fileMatch": ["a://b/AllowListPolicy*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AllowListPolicy.schema.json",
@@ -2989,9 +2609,7 @@
       "properties": {
         "policy": {
           "type": "string",
-          "enum": [
-            "allowList"
-          ]
+          "enum": ["allowList"]
         },
         "values": {
           "type": "array",
@@ -3000,18 +2618,13 @@
           }
         }
       },
-      "required": [
-        "policy",
-        "values"
-      ],
+      "required": ["policy", "values"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RootOfTrustPolicy.schema.json",
-    "fileMatch": [
-      "a://b/RootOfTrustPolicy*.schema.json"
-    ],
+    "fileMatch": ["a://b/RootOfTrustPolicy*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RootOfTrustPolicy.schema.json",
@@ -3020,26 +2633,19 @@
       "properties": {
         "policy": {
           "type": "string",
-          "enum": [
-            "rootOfTrust"
-          ]
+          "enum": ["rootOfTrust"]
         },
         "values": {
           "type": "string"
         }
       },
-      "required": [
-        "policy",
-        "values"
-      ],
+      "required": ["policy", "values"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/VCT.schema.json",
-    "fileMatch": [
-      "a://b/VCT*.schema.json"
-    ],
+    "fileMatch": ["a://b/VCT*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/VCT.schema.json",
@@ -3073,9 +2679,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IaeActionOpenid4vpPresentation.schema.json",
-    "fileMatch": [
-      "a://b/IaeActionOpenid4vpPresentation*.schema.json"
-    ],
+    "fileMatch": ["a://b/IaeActionOpenid4vpPresentation*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IaeActionOpenid4vpPresentation.schema.json",
@@ -3083,9 +2687,7 @@
       "type": "object",
       "properties": {
         "type": {
-          "enum": [
-            "openid4vp_presentation"
-          ],
+          "enum": ["openid4vp_presentation"],
           "type": "string",
           "description": "Action type discriminator",
           "example": "openid4vp_presentation"
@@ -3101,18 +2703,13 @@
           "example": "pid-presentation-config"
         }
       },
-      "required": [
-        "type",
-        "presentationConfigId"
-      ],
+      "required": ["type", "presentationConfigId"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IaeActionRedirectToWeb.schema.json",
-    "fileMatch": [
-      "a://b/IaeActionRedirectToWeb*.schema.json"
-    ],
+    "fileMatch": ["a://b/IaeActionRedirectToWeb*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IaeActionRedirectToWeb.schema.json",
@@ -3120,9 +2717,7 @@
       "type": "object",
       "properties": {
         "type": {
-          "enum": [
-            "redirect_to_web"
-          ],
+          "enum": ["redirect_to_web"],
           "type": "string",
           "description": "Action type discriminator",
           "example": "redirect_to_web"
@@ -3150,18 +2745,13 @@
           "example": "Please complete the identity verification form"
         }
       },
-      "required": [
-        "type",
-        "url"
-      ],
+      "required": ["type", "url"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebhookEndpointEntity.schema.json",
-    "fileMatch": [
-      "a://b/WebhookEndpointEntity*.schema.json"
-    ],
+    "fileMatch": ["a://b/WebhookEndpointEntity*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebhookEndpointEntity.schema.json",
@@ -3199,22 +2789,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "id",
-        "auth",
-        "tenantId",
-        "tenant",
-        "name",
-        "url"
-      ],
+      "required": ["id", "auth", "tenantId", "tenant", "name", "url"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaUriEntry.schema.json",
-    "fileMatch": [
-      "a://b/SchemaUriEntry*.schema.json"
-    ],
+    "fileMatch": ["a://b/SchemaUriEntry*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaUriEntry.schema.json",
@@ -3246,9 +2827,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustAuthorityEntry.schema.json",
-    "fileMatch": [
-      "a://b/TrustAuthorityEntry*.schema.json"
-    ],
+    "fileMatch": ["a://b/TrustAuthorityEntry*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustAuthorityEntry.schema.json",
@@ -3260,11 +2839,7 @@
           "description": "Trust list ID to resolve from the database. When set, frameworkType, value, and verificationMethod are derived automatically."
         },
         "frameworkType": {
-          "enum": [
-            "aki",
-            "etsi_tl",
-            "openid_federation"
-          ],
+          "enum": ["aki", "etsi_tl", "openid_federation"],
           "type": "string",
           "description": "Trust framework type (ignored when trustListId is set)"
         },
@@ -3295,9 +2870,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetaConfig.schema.json",
-    "fileMatch": [
-      "a://b/SchemaMetaConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/SchemaMetaConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetaConfig.schema.json",
@@ -3330,12 +2903,7 @@
           "description": "Attestation Level of Security"
         },
         "bindingType": {
-          "enum": [
-            "claim",
-            "key",
-            "biometric",
-            "none"
-          ],
+          "enum": ["claim", "key", "biometric", "none"],
           "type": "string",
           "description": "Cryptographic binding type"
         },
@@ -3359,9 +2927,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EmbeddedDisclosurePolicy.schema.json",
-    "fileMatch": [
-      "a://b/EmbeddedDisclosurePolicy*.schema.json"
-    ],
+    "fileMatch": ["a://b/EmbeddedDisclosurePolicy*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EmbeddedDisclosurePolicy.schema.json",
@@ -3372,17 +2938,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "policy"
-      ],
+      "required": ["policy"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyAttestationsRequired.schema.json",
-    "fileMatch": [
-      "a://b/KeyAttestationsRequired*.schema.json"
-    ],
+    "fileMatch": ["a://b/KeyAttestationsRequired*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyAttestationsRequired.schema.json",
@@ -3391,10 +2953,7 @@
       "properties": {
         "key_storage": {
           "description": "List of required key storage types (e.g., iso_18045_high, iso_18045_moderate)",
-          "example": [
-            "iso_18045_high",
-            "iso_18045_moderate"
-          ],
+          "example": ["iso_18045_high", "iso_18045_moderate"],
           "type": "array",
           "items": {
             "type": "string"
@@ -3402,10 +2961,7 @@
         },
         "user_authentication": {
           "description": "List of required user authentication types (e.g., iso_18045_high, iso_18045_moderate)",
-          "example": [
-            "iso_18045_high",
-            "iso_18045_moderate"
-          ],
+          "example": ["iso_18045_high", "iso_18045_moderate"],
           "type": "array",
           "items": {
             "type": "string"
@@ -3417,9 +2973,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayImage.schema.json",
-    "fileMatch": [
-      "a://b/DisplayImage*.schema.json"
-    ],
+    "fileMatch": ["a://b/DisplayImage*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayImage.schema.json",
@@ -3430,17 +2984,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "uri"
-      ],
+      "required": ["uri"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Display.schema.json",
-    "fileMatch": [
-      "a://b/Display*.schema.json"
-    ],
+    "fileMatch": ["a://b/Display*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Display.schema.json",
@@ -3469,19 +3019,13 @@
           "$ref": "./DisplayImage.schema.json"
         }
       },
-      "required": [
-        "name",
-        "description",
-        "locale"
-      ],
+      "required": ["name", "description", "locale"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerMetadataCredentialConfig.schema.json",
-    "fileMatch": [
-      "a://b/IssuerMetadataCredentialConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/IssuerMetadataCredentialConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerMetadataCredentialConfig.schema.json",
@@ -3498,10 +3042,7 @@
         },
         "format": {
           "type": "string",
-          "enum": [
-            "mso_mdoc",
-            "dc+sd-jwt"
-          ]
+          "enum": ["mso_mdoc", "dc+sd-jwt"]
         },
         "display": {
           "type": "array",
@@ -3517,18 +3058,13 @@
           "description": "Document type for mDOC credentials (e.g., \"org.iso.18013.5.1.mDL\").\nOnly applicable when format is \"mso_mdoc\"."
         }
       },
-      "required": [
-        "format",
-        "display"
-      ],
+      "required": ["format", "display"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FieldDisplayDto.schema.json",
-    "fileMatch": [
-      "a://b/FieldDisplayDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/FieldDisplayDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FieldDisplayDto.schema.json",
@@ -3551,18 +3087,13 @@
           "example": "Primary first name"
         }
       },
-      "required": [
-        "locale",
-        "name"
-      ],
+      "required": ["locale", "name"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClaimFieldDefinitionDto.schema.json",
-    "fileMatch": [
-      "a://b/ClaimFieldDefinitionDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ClaimFieldDefinitionDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClaimFieldDefinitionDto.schema.json",
@@ -3572,10 +3103,7 @@
         "path": {
           "type": "array",
           "description": "Path to claim value. For nested child fields this can be relative to the parent path.",
-          "example": [
-            "address",
-            "locality"
-          ],
+          "example": ["address", "locality"],
           "items": {
             "oneOf": [
               {
@@ -3591,14 +3119,7 @@
           }
         },
         "type": {
-          "enum": [
-            "string",
-            "number",
-            "integer",
-            "boolean",
-            "object",
-            "array"
-          ],
+          "enum": ["string", "number", "integer", "boolean", "object", "array"],
           "type": "string",
           "description": "Claim value type"
         },
@@ -3659,18 +3180,13 @@
           }
         }
       },
-      "required": [
-        "path",
-        "type"
-      ],
+      "required": ["path", "type"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AttributeProviderEntity.schema.json",
-    "fileMatch": [
-      "a://b/AttributeProviderEntity*.schema.json"
-    ],
+    "fileMatch": ["a://b/AttributeProviderEntity*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AttributeProviderEntity.schema.json",
@@ -3707,22 +3223,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "auth",
-        "id",
-        "tenantId",
-        "tenant",
-        "name",
-        "url"
-      ],
+      "required": ["auth", "id", "tenantId", "tenant", "name", "url"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainEntity.schema.json",
-    "fileMatch": [
-      "a://b/KeyChainEntity*.schema.json"
-    ],
+    "fileMatch": ["a://b/KeyChainEntity*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainEntity.schema.json",
@@ -3752,21 +3259,12 @@
         "usageType": {
           "type": "string",
           "description": "The purpose/role of this key chain in the system.",
-          "enum": [
-            "access",
-            "attestation",
-            "trustList",
-            "statusList",
-            "encrypt"
-          ]
+          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"]
         },
         "usage": {
           "type": "string",
           "description": "The usage type of the keys (sign or encrypt).",
-          "enum": [
-            "sign",
-            "encrypt"
-          ]
+          "enum": ["sign", "encrypt"]
         },
         "kmsProvider": {
           "type": "string",
@@ -3846,9 +3344,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfig.schema.json",
-    "fileMatch": [
-      "a://b/CredentialConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/CredentialConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfig.schema.json",
@@ -3975,30 +3471,20 @@
         "sdJwtTrustFormat": {
           "nullable": true,
           "description": "For SD-JWT credentials: determines whether to include certificate chain (x5c)\nor use federation-based trust (iss claim).\nDefault: \"x5c\" (federation must be explicitly selected)",
-          "enum": [
-            "x5c",
-            "federation"
-          ],
+          "enum": ["x5c", "federation"],
           "type": "string"
         },
         "lifeTime": {
           "type": "number"
         }
       },
-      "required": [
-        "id",
-        "tenant",
-        "config",
-        "fields"
-      ],
+      "required": ["id", "tenant", "config", "fields"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfigCreate.schema.json",
-    "fileMatch": [
-      "a://b/CredentialConfigCreate*.schema.json"
-    ],
+    "fileMatch": ["a://b/CredentialConfigCreate*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfigCreate.schema.json",
@@ -4108,29 +3594,20 @@
         "sdJwtTrustFormat": {
           "nullable": true,
           "description": "For SD-JWT credentials: determines whether to include certificate chain (x5c)\nor use federation-based trust (iss claim).\nDefault: \"x5c\" (federation must be explicitly selected)",
-          "enum": [
-            "x5c",
-            "federation"
-          ],
+          "enum": ["x5c", "federation"],
           "type": "string"
         },
         "lifeTime": {
           "type": "number"
         }
       },
-      "required": [
-        "id",
-        "config",
-        "fields"
-      ],
+      "required": ["id", "config", "fields"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfigUpdate.schema.json",
-    "fileMatch": [
-      "a://b/CredentialConfigUpdate*.schema.json"
-    ],
+    "fileMatch": ["a://b/CredentialConfigUpdate*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfigUpdate.schema.json",
@@ -4240,10 +3717,7 @@
         "sdJwtTrustFormat": {
           "nullable": true,
           "description": "For SD-JWT credentials: determines whether to include certificate chain (x5c)\nor use federation-based trust (iss claim).\nDefault: \"x5c\" (federation must be explicitly selected)",
-          "enum": [
-            "x5c",
-            "federation"
-          ],
+          "enum": ["x5c", "federation"],
           "type": "string"
         },
         "lifeTime": {
@@ -4255,9 +3729,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SignSchemaMetaConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/SignSchemaMetaConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/SignSchemaMetaConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SignSchemaMetaConfigDto.schema.json",
@@ -4281,17 +3753,13 @@
           "description": "ID of the credential config to link back after submission. When provided, schemaMeta.id on the credential config is updated with the reserved attestation ID."
         }
       },
-      "required": [
-        "config"
-      ],
+      "required": ["config"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SignVersionSchemaMetaConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/SignVersionSchemaMetaConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/SignVersionSchemaMetaConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SignVersionSchemaMetaConfigDto.schema.json",
@@ -4311,17 +3779,13 @@
           "description": "ID of the key chain to use for signing. Defaults to the tenant's default key chain."
         }
       },
-      "required": [
-        "config"
-      ],
+      "required": ["config"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/VocabularyEntryDto.schema.json",
-    "fileMatch": [
-      "a://b/VocabularyEntryDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/VocabularyEntryDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/VocabularyEntryDto.schema.json",
@@ -4337,10 +3801,7 @@
           "description": "Display label for UI rendering."
         },
         "status": {
-          "enum": [
-            "active",
-            "deprecated"
-          ],
+          "enum": ["active", "deprecated"],
           "type": "string",
           "description": "Vocabulary lifecycle status."
         },
@@ -4349,19 +3810,13 @@
           "description": "Replacement code when status is deprecated."
         }
       },
-      "required": [
-        "code",
-        "label",
-        "status"
-      ],
+      "required": ["code", "label", "status"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetadataVocabulariesDto.schema.json",
-    "fileMatch": [
-      "a://b/SchemaMetadataVocabulariesDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/SchemaMetadataVocabulariesDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetadataVocabulariesDto.schema.json",
@@ -4387,19 +3842,13 @@
           }
         }
       },
-      "required": [
-        "version",
-        "categories",
-        "tags"
-      ],
+      "required": ["version", "categories", "tags"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/MetadataSchemaDto.schema.json",
-    "fileMatch": [
-      "a://b/MetadataSchemaDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/MetadataSchemaDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/MetadataSchemaDto.schema.json",
@@ -4411,10 +3860,7 @@
           "description": "Unique identifier for this schema entry"
         },
         "formatIdentifier": {
-          "enum": [
-            "dc+sd-jwt",
-            "mso_mdoc"
-          ],
+          "enum": ["dc+sd-jwt", "mso_mdoc"],
           "type": "string",
           "description": "The credential format identifier"
         },
@@ -4432,18 +3878,13 @@
           "description": "Subresource Integrity hash for the schema"
         }
       },
-      "required": [
-        "id",
-        "formatIdentifier"
-      ],
+      "required": ["id", "formatIdentifier"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustAuthorityDto.schema.json",
-    "fileMatch": [
-      "a://b/TrustAuthorityDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/TrustAuthorityDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustAuthorityDto.schema.json",
@@ -4457,9 +3898,7 @@
         "frameworkType": {
           "type": "string",
           "description": "Type of trust framework",
-          "enum": [
-            "etsi_tl"
-          ]
+          "enum": ["etsi_tl"]
         },
         "value": {
           "type": "string",
@@ -4471,19 +3910,13 @@
           "description": "Verification method for the trust list signature (e.g., JWK)"
         }
       },
-      "required": [
-        "id",
-        "frameworkType",
-        "value"
-      ],
+      "required": ["id", "frameworkType", "value"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AccessCertificateRefDto.schema.json",
-    "fileMatch": [
-      "a://b/AccessCertificateRefDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/AccessCertificateRefDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AccessCertificateRefDto.schema.json",
@@ -4506,21 +3939,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "id",
-        "relyingPartyId",
-        "certificate",
-        "revoked",
-        "createdAt"
-      ],
+      "required": ["id", "relyingPartyId", "certificate", "revoked", "createdAt"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetadataResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/SchemaMetadataResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/SchemaMetadataResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetadataResponseDto.schema.json",
@@ -4554,12 +3979,7 @@
           "description": "Level of security (LoS) of this attestation"
         },
         "bindingType": {
-          "enum": [
-            "claim",
-            "key",
-            "biometric",
-            "none"
-          ],
+          "enum": ["claim", "key", "biometric", "none"],
           "type": "string",
           "description": "Required binding type between attestation and holder"
         },
@@ -4567,10 +3987,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "enum": [
-              "dc+sd-jwt",
-              "mso_mdoc"
-            ]
+            "enum": ["dc+sd-jwt", "mso_mdoc"]
           },
           "description": "Credential formats in which this attestation is available"
         },
@@ -4589,15 +4006,7 @@
           }
         },
         "category": {
-          "enum": [
-            "identity",
-            "health",
-            "finance",
-            "education",
-            "mobility",
-            "employment",
-            "other"
-          ],
+          "enum": ["identity", "health", "finance", "education", "mobility", "employment", "other"],
           "type": "string",
           "description": "Domain category for filtering"
         },
@@ -4673,9 +4082,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateSchemaMetadataDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateSchemaMetadataDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateSchemaMetadataDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateSchemaMetadataDto.schema.json",
@@ -4683,15 +4090,7 @@
       "type": "object",
       "properties": {
         "category": {
-          "enum": [
-            "identity",
-            "health",
-            "finance",
-            "education",
-            "mobility",
-            "employment",
-            "other"
-          ],
+          "enum": ["identity", "health", "finance", "education", "mobility", "employment", "other"],
           "type": "string",
           "description": "Domain category for filtering"
         },
@@ -4720,9 +4119,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeprecateSchemaMetadataDto.schema.json",
-    "fileMatch": [
-      "a://b/DeprecateSchemaMetadataDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/DeprecateSchemaMetadataDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeprecateSchemaMetadataDto.schema.json",
@@ -4742,17 +4139,13 @@
           "description": "The version that supersedes this one"
         }
       },
-      "required": [
-        "deprecated"
-      ],
+      "required": ["deprecated"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateAttributeProviderDto.schema.json",
-    "fileMatch": [
-      "a://b/CreateAttributeProviderDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CreateAttributeProviderDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateAttributeProviderDto.schema.json",
@@ -4783,20 +4176,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "auth",
-        "id",
-        "name",
-        "url"
-      ],
+      "required": ["auth", "id", "name", "url"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateAttributeProviderDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateAttributeProviderDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateAttributeProviderDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateAttributeProviderDto.schema.json",
@@ -4832,9 +4218,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateWebhookEndpointDto.schema.json",
-    "fileMatch": [
-      "a://b/CreateWebhookEndpointDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CreateWebhookEndpointDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateWebhookEndpointDto.schema.json",
@@ -4866,20 +4250,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "id",
-        "auth",
-        "name",
-        "url"
-      ],
+      "required": ["id", "auth", "name", "url"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateWebhookEndpointDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateWebhookEndpointDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateWebhookEndpointDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateWebhookEndpointDto.schema.json",
@@ -4916,9 +4293,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListEntityInfo.schema.json",
-    "fileMatch": [
-      "a://b/TrustListEntityInfo*.schema.json"
-    ],
+    "fileMatch": ["a://b/TrustListEntityInfo*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListEntityInfo.schema.json",
@@ -4950,17 +4325,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "name"
-      ],
+      "required": ["name"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InternalTrustListEntity.schema.json",
-    "fileMatch": [
-      "a://b/InternalTrustListEntity*.schema.json"
-    ],
+    "fileMatch": ["a://b/InternalTrustListEntity*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InternalTrustListEntity.schema.json",
@@ -4969,9 +4340,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": [
-            "internal"
-          ]
+          "enum": ["internal"]
         },
         "issuerKeyChainId": {
           "type": "string"
@@ -4983,20 +4352,13 @@
           "$ref": "./TrustListEntityInfo.schema.json"
         }
       },
-      "required": [
-        "type",
-        "issuerKeyChainId",
-        "revocationKeyChainId",
-        "info"
-      ],
+      "required": ["type", "issuerKeyChainId", "revocationKeyChainId", "info"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExternalTrustListEntity.schema.json",
-    "fileMatch": [
-      "a://b/ExternalTrustListEntity*.schema.json"
-    ],
+    "fileMatch": ["a://b/ExternalTrustListEntity*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExternalTrustListEntity.schema.json",
@@ -5005,9 +4367,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": [
-            "external"
-          ]
+          "enum": ["external"]
         },
         "issuerCertPem": {
           "type": "string"
@@ -5019,20 +4379,13 @@
           "$ref": "./TrustListEntityInfo.schema.json"
         }
       },
-      "required": [
-        "type",
-        "issuerCertPem",
-        "revocationCertPem",
-        "info"
-      ],
+      "required": ["type", "issuerCertPem", "revocationCertPem", "info"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListCreateDto.schema.json",
-    "fileMatch": [
-      "a://b/TrustListCreateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/TrustListCreateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListCreateDto.schema.json",
@@ -5073,17 +4426,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "entities"
-      ],
+      "required": ["entities"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustList.schema.json",
-    "fileMatch": [
-      "a://b/TrustList*.schema.json"
-    ],
+    "fileMatch": ["a://b/TrustList*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustList.schema.json",
@@ -5159,9 +4508,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListVersion.schema.json",
-    "fileMatch": [
-      "a://b/TrustListVersion*.schema.json"
-    ],
+    "fileMatch": ["a://b/TrustListVersion*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListVersion.schema.json",
@@ -5216,9 +4563,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DCQL.schema.json",
-    "fileMatch": [
-      "a://b/DCQL*.schema.json"
-    ],
+    "fileMatch": ["a://b/DCQL*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DCQL.schema.json",
@@ -5238,17 +4583,13 @@
           }
         }
       },
-      "required": [
-        "credentials"
-      ],
+      "required": ["credentials"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificatePurpose.schema.json",
-    "fileMatch": [
-      "a://b/RegistrationCertificatePurpose*.schema.json"
-    ],
+    "fileMatch": ["a://b/RegistrationCertificatePurpose*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificatePurpose.schema.json",
@@ -5262,18 +4603,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "lang",
-        "content"
-      ],
+      "required": ["lang", "content"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateBody.schema.json",
-    "fileMatch": [
-      "a://b/RegistrationCertificateBody*.schema.json"
-    ],
+    "fileMatch": ["a://b/RegistrationCertificateBody*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateBody.schema.json",
@@ -5313,9 +4649,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateRequest.schema.json",
-    "fileMatch": [
-      "a://b/RegistrationCertificateRequest*.schema.json"
-    ],
+    "fileMatch": ["a://b/RegistrationCertificateRequest*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateRequest.schema.json",
@@ -5344,9 +4678,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationAttachment.schema.json",
-    "fileMatch": [
-      "a://b/PresentationAttachment*.schema.json"
-    ],
+    "fileMatch": ["a://b/PresentationAttachment*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationAttachment.schema.json",
@@ -5366,18 +4698,13 @@
           }
         }
       },
-      "required": [
-        "format",
-        "data"
-      ],
+      "required": ["format", "data"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfig.schema.json",
-    "fileMatch": [
-      "a://b/PresentationConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/PresentationConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfig.schema.json",
@@ -5486,21 +4813,13 @@
           "description": "Optional ID of the access certificate to use for signing the presentation request.\nIf not provided, the default access certificate for the tenant will be used.\n\nNote: This is intentionally NOT a TypeORM relationship because CertEntity uses\na composite primary key (id + tenantId), and SQLite cannot create foreign keys\nthat reference only part of a composite primary key. The relationship is handled\nat the application level in the service layer."
         }
       },
-      "required": [
-        "id",
-        "tenant",
-        "dcql_query",
-        "createdAt",
-        "updatedAt"
-      ],
+      "required": ["id", "tenant", "dcql_query", "createdAt", "updatedAt"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ResolveIssuerMetadataDto.schema.json",
-    "fileMatch": [
-      "a://b/ResolveIssuerMetadataDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ResolveIssuerMetadataDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ResolveIssuerMetadataDto.schema.json",
@@ -5514,17 +4833,13 @@
           "example": "https://issuer.example.com/issuers/tenant-a"
         }
       },
-      "required": [
-        "issuerUrl"
-      ],
+      "required": ["issuerUrl"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ResolveSchemaMetadataDto.schema.json",
-    "fileMatch": [
-      "a://b/ResolveSchemaMetadataDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ResolveSchemaMetadataDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ResolveSchemaMetadataDto.schema.json",
@@ -5538,17 +4853,13 @@
           "example": "https://registrar.example.com/schema-metadata/5c0d7dbb-ef2e-448b-b84f-b8103575947b"
         }
       },
-      "required": [
-        "schemaMetadataUrl"
-      ],
+      "required": ["schemaMetadataUrl"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfigCreateDto.schema.json",
-    "fileMatch": [
-      "a://b/PresentationConfigCreateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/PresentationConfigCreateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfigCreateDto.schema.json",
@@ -5631,18 +4942,13 @@
           "description": "Optional ID of the access certificate to use for signing the presentation request.\nIf not provided, the default access certificate for the tenant will be used.\n\nNote: This is intentionally NOT a TypeORM relationship because CertEntity uses\na composite primary key (id + tenantId), and SQLite cannot create foreign keys\nthat reference only part of a composite primary key. The relationship is handled\nat the application level in the service layer."
         }
       },
-      "required": [
-        "id",
-        "dcql_query"
-      ],
+      "required": ["id", "dcql_query"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfigUpdateDto.schema.json",
-    "fileMatch": [
-      "a://b/PresentationConfigUpdateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/PresentationConfigUpdateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfigUpdateDto.schema.json",
@@ -5730,9 +5036,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateDefaults.schema.json",
-    "fileMatch": [
-      "a://b/RegistrationCertificateDefaults*.schema.json"
-    ],
+    "fileMatch": ["a://b/RegistrationCertificateDefaults*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateDefaults.schema.json",
@@ -5755,9 +5059,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrarConfigResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/RegistrarConfigResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/RegistrarConfigResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrarConfigResponseDto.schema.json",
@@ -5805,21 +5107,13 @@
           "example": true
         }
       },
-      "required": [
-        "registrarUrl",
-        "oidcUrl",
-        "clientId",
-        "username",
-        "hasPassword"
-      ],
+      "required": ["registrarUrl", "oidcUrl", "clientId", "username", "hasPassword"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateRegistrarConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/CreateRegistrarConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CreateRegistrarConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateRegistrarConfigDto.schema.json",
@@ -5866,21 +5160,13 @@
           ]
         }
       },
-      "required": [
-        "registrarUrl",
-        "oidcUrl",
-        "clientId",
-        "username",
-        "password"
-      ],
+      "required": ["registrarUrl", "oidcUrl", "clientId", "username", "password"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateRegistrarConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateRegistrarConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateRegistrarConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateRegistrarConfigDto.schema.json",
@@ -5932,9 +5218,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateAccessCertificateDto.schema.json",
-    "fileMatch": [
-      "a://b/CreateAccessCertificateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CreateAccessCertificateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateAccessCertificateDto.schema.json",
@@ -5947,17 +5231,13 @@
           "example": "my-signing-key"
         }
       },
-      "required": [
-        "keyId"
-      ],
+      "required": ["keyId"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeferredCredentialRequestDto.schema.json",
-    "fileMatch": [
-      "a://b/DeferredCredentialRequestDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/DeferredCredentialRequestDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeferredCredentialRequestDto.schema.json",
@@ -5970,17 +5250,13 @@
           "example": "8xLOxBtZp8"
         }
       },
-      "required": [
-        "transaction_id"
-      ],
+      "required": ["transaction_id"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/NotificationRequestDto.schema.json",
-    "fileMatch": [
-      "a://b/NotificationRequestDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/NotificationRequestDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/NotificationRequestDto.schema.json",
@@ -5992,25 +5268,16 @@
         },
         "event": {
           "type": "string",
-          "enum": [
-            "credential_accepted",
-            "credential_failure",
-            "credential_deleted"
-          ]
+          "enum": ["credential_accepted", "credential_failure", "credential_deleted"]
         }
       },
-      "required": [
-        "notification_id",
-        "event"
-      ],
+      "required": ["notification_id", "event"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/OfferResponse.schema.json",
-    "fileMatch": [
-      "a://b/OfferResponse*.schema.json"
-    ],
+    "fileMatch": ["a://b/OfferResponse*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/OfferResponse.schema.json",
@@ -6028,18 +5295,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "uri",
-        "session"
-      ],
+      "required": ["uri", "session"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CompleteDeferredDto.schema.json",
-    "fileMatch": [
-      "a://b/CompleteDeferredDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CompleteDeferredDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CompleteDeferredDto.schema.json",
@@ -6057,17 +5319,13 @@
           }
         }
       },
-      "required": [
-        "claims"
-      ],
+      "required": ["claims"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeferredOperationResponse.schema.json",
-    "fileMatch": [
-      "a://b/DeferredOperationResponse*.schema.json"
-    ],
+    "fileMatch": ["a://b/DeferredOperationResponse*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeferredOperationResponse.schema.json",
@@ -6080,13 +5338,7 @@
         },
         "status": {
           "description": "The new status of the transaction",
-          "enum": [
-            "pending",
-            "ready",
-            "retrieved",
-            "expired",
-            "failed"
-          ],
+          "enum": ["pending", "ready", "retrieved", "expired", "failed"],
           "type": "string"
         },
         "message": {
@@ -6094,18 +5346,13 @@
           "description": "Optional message"
         }
       },
-      "required": [
-        "transactionId",
-        "status"
-      ],
+      "required": ["transactionId", "status"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FailDeferredDto.schema.json",
-    "fileMatch": [
-      "a://b/FailDeferredDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/FailDeferredDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FailDeferredDto.schema.json",
@@ -6123,9 +5370,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EC_Public.schema.json",
-    "fileMatch": [
-      "a://b/EC_Public*.schema.json"
-    ],
+    "fileMatch": ["a://b/EC_Public*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EC_Public.schema.json",
@@ -6149,20 +5394,13 @@
           "description": "The y coordinate of the EC public key."
         }
       },
-      "required": [
-        "kty",
-        "crv",
-        "x",
-        "y"
-      ],
+      "required": ["kty", "crv", "x", "y"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/JwksResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/JwksResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/JwksResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/JwksResponseDto.schema.json",
@@ -6177,17 +5415,13 @@
           }
         }
       },
-      "required": [
-        "keys"
-      ],
+      "required": ["keys"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthorizationResponse.schema.json",
-    "fileMatch": [
-      "a://b/AuthorizationResponse*.schema.json"
-    ],
+    "fileMatch": ["a://b/AuthorizationResponse*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthorizationResponse.schema.json",
@@ -6223,9 +5457,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Object.schema.json",
-    "fileMatch": [
-      "a://b/Object*.schema.json"
-    ],
+    "fileMatch": ["a://b/Object*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Object.schema.json",
@@ -6237,9 +5469,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ParResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/ParResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ParResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ParResponseDto.schema.json",
@@ -6255,18 +5485,13 @@
           "description": "The expiration time for the request URI in seconds."
         }
       },
-      "required": [
-        "request_uri",
-        "expires_in"
-      ],
+      "required": ["request_uri", "expires_in"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationRequestDto.schema.json",
-    "fileMatch": [
-      "a://b/InteractiveAuthorizationRequestDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/InteractiveAuthorizationRequestDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationRequestDto.schema.json",
@@ -6339,9 +5564,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationCodeResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/InteractiveAuthorizationCodeResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/InteractiveAuthorizationCodeResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationCodeResponseDto.schema.json",
@@ -6359,18 +5582,13 @@
           "example": "auth-code-123"
         }
       },
-      "required": [
-        "status",
-        "code"
-      ],
+      "required": ["status", "code"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationErrorResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/InteractiveAuthorizationErrorResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/InteractiveAuthorizationErrorResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationErrorResponseDto.schema.json",
@@ -6388,17 +5606,13 @@
           "example": "Missing required parameter: interaction_types_supported"
         }
       },
-      "required": [
-        "error"
-      ],
+      "required": ["error"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsParResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/ChainedAsParResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ChainedAsParResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsParResponseDto.schema.json",
@@ -6416,18 +5630,13 @@
           "example": 600
         }
       },
-      "required": [
-        "request_uri",
-        "expires_in"
-      ],
+      "required": ["request_uri", "expires_in"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsErrorResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/ChainedAsErrorResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ChainedAsErrorResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsErrorResponseDto.schema.json",
@@ -6444,17 +5653,13 @@
           "description": "Human-readable error description"
         }
       },
-      "required": [
-        "error"
-      ],
+      "required": ["error"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenRequestDto.schema.json",
-    "fileMatch": [
-      "a://b/ChainedAsTokenRequestDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ChainedAsTokenRequestDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenRequestDto.schema.json",
@@ -6487,17 +5692,13 @@
           "description": "PKCE code verifier"
         }
       },
-      "required": [
-        "grant_type"
-      ],
+      "required": ["grant_type"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/ChainedAsTokenResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ChainedAsTokenResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenResponseDto.schema.json",
@@ -6542,19 +5743,13 @@
           "description": "Refresh token (issued when refresh tokens are enabled)"
         }
       },
-      "required": [
-        "access_token",
-        "token_type",
-        "expires_in"
-      ],
+      "required": ["access_token", "token_type", "expires_in"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProviderCapabilitiesDto.schema.json",
-    "fileMatch": [
-      "a://b/KmsProviderCapabilitiesDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KmsProviderCapabilitiesDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProviderCapabilitiesDto.schema.json",
@@ -6578,9 +5773,7 @@
         },
         "supportedAlgs": {
           "description": "Signing algorithms supported by the provider.",
-          "example": [
-            "ES256"
-          ],
+          "example": ["ES256"],
           "type": "array",
           "items": {
             "type": "string"
@@ -6592,21 +5785,13 @@
           "example": "ES256"
         }
       },
-      "required": [
-        "canImport",
-        "canCreate",
-        "canDelete",
-        "supportedAlgs",
-        "defaultAlg"
-      ],
+      "required": ["canImport", "canCreate", "canDelete", "supportedAlgs", "defaultAlg"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProviderInfoDto.schema.json",
-    "fileMatch": [
-      "a://b/KmsProviderInfoDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KmsProviderInfoDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProviderInfoDto.schema.json",
@@ -6637,19 +5822,13 @@
           ]
         }
       },
-      "required": [
-        "name",
-        "type",
-        "capabilities"
-      ],
+      "required": ["name", "type", "capabilities"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProvidersResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/KmsProvidersResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KmsProvidersResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProvidersResponseDto.schema.json",
@@ -6669,18 +5848,13 @@
           "example": "db"
         }
       },
-      "required": [
-        "providers",
-        "default"
-      ],
+      "required": ["providers", "default"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DbKmsConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/DbKmsConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/DbKmsConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DbKmsConfigDto.schema.json",
@@ -6693,9 +5867,7 @@
           "example": "main-vault"
         },
         "type": {
-          "enum": [
-            "db"
-          ],
+          "enum": ["db"],
           "type": "string",
           "description": "Type of the KMS provider.",
           "example": "db"
@@ -6706,18 +5878,13 @@
           "example": "Production HashiCorp Vault for signing keys"
         }
       },
-      "required": [
-        "id",
-        "type"
-      ],
+      "required": ["id", "type"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/VaultKmsConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/VaultKmsConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/VaultKmsConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/VaultKmsConfigDto.schema.json",
@@ -6730,9 +5897,7 @@
           "example": "main-vault"
         },
         "type": {
-          "enum": [
-            "vault"
-          ],
+          "enum": ["vault"],
           "type": "string",
           "description": "Type of the KMS provider.",
           "example": "vault"
@@ -6753,20 +5918,13 @@
           "example": "${VAULT_TOKEN}"
         }
       },
-      "required": [
-        "id",
-        "type",
-        "vaultUrl",
-        "vaultToken"
-      ],
+      "required": ["id", "type", "vaultUrl", "vaultToken"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AwsKmsConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/AwsKmsConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/AwsKmsConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AwsKmsConfigDto.schema.json",
@@ -6779,9 +5937,7 @@
           "example": "main-vault"
         },
         "type": {
-          "enum": [
-            "aws-kms"
-          ],
+          "enum": ["aws-kms"],
           "type": "string",
           "description": "Type of the KMS provider.",
           "example": "aws-kms"
@@ -6807,19 +5963,13 @@
           "example": "${AWS_SECRET_ACCESS_KEY}"
         }
       },
-      "required": [
-        "id",
-        "type",
-        "region"
-      ],
+      "required": ["id", "type", "region"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Pkcs11KmsConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/Pkcs11KmsConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/Pkcs11KmsConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Pkcs11KmsConfigDto.schema.json",
@@ -6832,9 +5982,7 @@
           "example": "main-vault"
         },
         "type": {
-          "enum": [
-            "pkcs11"
-          ],
+          "enum": ["pkcs11"],
           "type": "string",
           "description": "Type of the KMS provider.",
           "example": "pkcs11"
@@ -6865,21 +6013,13 @@
           "example": false
         }
       },
-      "required": [
-        "id",
-        "type",
-        "library",
-        "slot",
-        "pin"
-      ],
+      "required": ["id", "type", "library", "slot", "pin"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/HttpAuthBaseConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/HttpAuthBaseConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/HttpAuthBaseConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/HttpAuthBaseConfigDto.schema.json",
@@ -6887,27 +6027,18 @@
       "type": "object",
       "properties": {
         "type": {
-          "enum": [
-            "none",
-            "bearer",
-            "oauth2-client-credentials",
-            "mtls"
-          ],
+          "enum": ["none", "bearer", "oauth2-client-credentials", "mtls"],
           "type": "string",
           "description": "Authentication method for the remote KMS service."
         }
       },
-      "required": [
-        "type"
-      ],
+      "required": ["type"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/HttpKmsConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/HttpKmsConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/HttpKmsConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/HttpKmsConfigDto.schema.json",
@@ -6920,9 +6051,7 @@
           "example": "main-vault"
         },
         "type": {
-          "enum": [
-            "http"
-          ],
+          "enum": ["http"],
           "type": "string",
           "description": "Type of the KMS provider.",
           "example": "http"
@@ -6961,19 +6090,13 @@
           "example": false
         }
       },
-      "required": [
-        "id",
-        "type",
-        "baseUrl"
-      ],
+      "required": ["id", "type", "baseUrl"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CscAuthorizeAuthDataDto.schema.json",
-    "fileMatch": [
-      "a://b/CscAuthorizeAuthDataDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CscAuthorizeAuthDataDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CscAuthorizeAuthDataDto.schema.json",
@@ -6991,18 +6114,13 @@
           "example": "123456"
         }
       },
-      "required": [
-        "id",
-        "value"
-      ],
+      "required": ["id", "value"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CscKmsConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/CscKmsConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CscKmsConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CscKmsConfigDto.schema.json",
@@ -7015,9 +6133,7 @@
           "example": "main-vault"
         },
         "type": {
-          "enum": [
-            "csc"
-          ],
+          "enum": ["csc"],
           "type": "string",
           "description": "Type of the KMS provider.",
           "example": "csc"
@@ -7095,22 +6211,13 @@
           }
         }
       },
-      "required": [
-        "id",
-        "type",
-        "baseUrl",
-        "tokenUrl",
-        "clientId",
-        "clientSecret"
-      ],
+      "required": ["id", "type", "baseUrl", "tokenUrl", "clientId", "clientSecret"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/KmsConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KmsConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsConfigDto.schema.json",
@@ -7180,17 +6287,13 @@
           ]
         }
       },
-      "required": [
-        "providers"
-      ],
+      "required": ["providers"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsTenantConfigResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/KmsTenantConfigResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KmsTenantConfigResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsTenantConfigResponseDto.schema.json",
@@ -7216,17 +6319,13 @@
           ]
         }
       },
-      "required": [
-        "effectiveConfig"
-      ],
+      "required": ["effectiveConfig"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CertificateInfoDto.schema.json",
-    "fileMatch": [
-      "a://b/CertificateInfoDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CertificateInfoDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CertificateInfoDto.schema.json",
@@ -7260,17 +6359,13 @@
           "description": "Serial number."
         }
       },
-      "required": [
-        "pem"
-      ],
+      "required": ["pem"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PublicKeyInfoDto.schema.json",
-    "fileMatch": [
-      "a://b/PublicKeyInfoDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/PublicKeyInfoDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PublicKeyInfoDto.schema.json",
@@ -7297,17 +6392,13 @@
           "example": "P-256"
         }
       },
-      "required": [
-        "kty"
-      ],
+      "required": ["kty"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/RotationPolicyResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/RotationPolicyResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyResponseDto.schema.json",
@@ -7332,17 +6423,13 @@
           "description": "Next scheduled rotation date."
         }
       },
-      "required": [
-        "enabled"
-      ],
+      "required": ["enabled"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/KeyChainResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KeyChainResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainResponseDto.schema.json",
@@ -7354,21 +6441,12 @@
           "description": "Unique identifier for the key chain."
         },
         "usageType": {
-          "enum": [
-            "access",
-            "attestation",
-            "trustList",
-            "statusList",
-            "encrypt"
-          ],
+          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"],
           "type": "string",
           "description": "Usage type of the key chain."
         },
         "type": {
-          "enum": [
-            "standalone",
-            "internalChain"
-          ],
+          "enum": ["standalone", "internalChain"],
           "type": "string",
           "description": "Type of key chain (standalone or internalChain)."
         },
@@ -7459,9 +6537,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExportEcJwk.schema.json",
-    "fileMatch": [
-      "a://b/ExportEcJwk*.schema.json"
-    ],
+    "fileMatch": ["a://b/ExportEcJwk*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExportEcJwk.schema.json",
@@ -7500,21 +6576,13 @@
           "description": "Key ID"
         }
       },
-      "required": [
-        "kty",
-        "crv",
-        "x",
-        "y",
-        "d"
-      ],
+      "required": ["kty", "crv", "x", "y", "d"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExportRotationPolicyDto.schema.json",
-    "fileMatch": [
-      "a://b/ExportRotationPolicyDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ExportRotationPolicyDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExportRotationPolicyDto.schema.json",
@@ -7534,17 +6602,13 @@
           "description": "Certificate validity in days."
         }
       },
-      "required": [
-        "enabled"
-      ],
+      "required": ["enabled"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainExportDto.schema.json",
-    "fileMatch": [
-      "a://b/KeyChainExportDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KeyChainExportDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainExportDto.schema.json",
@@ -7560,13 +6624,7 @@
           "description": "Human-readable description."
         },
         "usageType": {
-          "enum": [
-            "access",
-            "attestation",
-            "trustList",
-            "statusList",
-            "encrypt"
-          ],
+          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"],
           "type": "string",
           "description": "Usage type for this key chain."
         },
@@ -7598,19 +6656,13 @@
           ]
         }
       },
-      "required": [
-        "id",
-        "usageType",
-        "key"
-      ],
+      "required": ["id", "usageType", "key"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyCreateDto.schema.json",
-    "fileMatch": [
-      "a://b/RotationPolicyCreateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/RotationPolicyCreateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyCreateDto.schema.json",
@@ -7637,17 +6689,13 @@
           "example": 365
         }
       },
-      "required": [
-        "enabled"
-      ],
+      "required": ["enabled"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainCreateDto.schema.json",
-    "fileMatch": [
-      "a://b/KeyChainCreateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KeyChainCreateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainCreateDto.schema.json",
@@ -7655,22 +6703,13 @@
       "type": "object",
       "properties": {
         "usageType": {
-          "enum": [
-            "access",
-            "attestation",
-            "trustList",
-            "statusList",
-            "encrypt"
-          ],
+          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"],
           "type": "string",
           "description": "Usage type determines the purpose of this key chain (access, attestation, etc.).",
           "example": "attestation"
         },
         "type": {
-          "enum": [
-            "standalone",
-            "internalChain"
-          ],
+          "enum": ["standalone", "internalChain"],
           "type": "string",
           "description": "Type of key chain to create.",
           "example": "internalChain"
@@ -7694,18 +6733,13 @@
           ]
         }
       },
-      "required": [
-        "usageType",
-        "type"
-      ],
+      "required": ["usageType", "type"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EcJwk.schema.json",
-    "fileMatch": [
-      "a://b/EcJwk*.schema.json"
-    ],
+    "fileMatch": ["a://b/EcJwk*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EcJwk.schema.json",
@@ -7734,21 +6768,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "kty",
-        "x",
-        "y",
-        "crv",
-        "d"
-      ],
+      "required": ["kty", "x", "y", "crv", "d"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyImportDto.schema.json",
-    "fileMatch": [
-      "a://b/RotationPolicyImportDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/RotationPolicyImportDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyImportDto.schema.json",
@@ -7775,17 +6801,13 @@
           "example": 365
         }
       },
-      "required": [
-        "enabled"
-      ],
+      "required": ["enabled"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainImportDto.schema.json",
-    "fileMatch": [
-      "a://b/KeyChainImportDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KeyChainImportDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainImportDto.schema.json",
@@ -7809,13 +6831,7 @@
           "description": "Human-readable description."
         },
         "usageType": {
-          "enum": [
-            "access",
-            "attestation",
-            "trustList",
-            "statusList",
-            "encrypt"
-          ],
+          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"],
           "type": "string",
           "description": "Usage type for this key chain."
         },
@@ -7839,18 +6855,13 @@
           ]
         }
       },
-      "required": [
-        "key",
-        "usageType"
-      ],
+      "required": ["key", "usageType"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyUpdateDto.schema.json",
-    "fileMatch": [
-      "a://b/RotationPolicyUpdateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/RotationPolicyUpdateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyUpdateDto.schema.json",
@@ -7879,9 +6890,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainUpdateDto.schema.json",
-    "fileMatch": [
-      "a://b/KeyChainUpdateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KeyChainUpdateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainUpdateDto.schema.json",
@@ -7910,9 +6919,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationRequest.schema.json",
-    "fileMatch": [
-      "a://b/PresentationRequest*.schema.json"
-    ],
+    "fileMatch": ["a://b/PresentationRequest*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationRequest.schema.json",
@@ -7922,10 +6929,7 @@
         "response_type": {
           "type": "string",
           "description": "The type of response expected from the presentation request.",
-          "enum": [
-            "uri",
-            "dc-api"
-          ]
+          "enum": ["uri", "dc-api"]
         },
         "requestId": {
           "type": "string",
@@ -7956,18 +6960,13 @@
           }
         }
       },
-      "required": [
-        "response_type",
-        "requestId"
-      ],
+      "required": ["response_type", "requestId"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FileUploadDto.schema.json",
-    "fileMatch": [
-      "a://b/FileUploadDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/FileUploadDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FileUploadDto.schema.json",
@@ -7979,9 +6978,7 @@
           "format": "binary"
         }
       },
-      "required": [
-        "file"
-      ],
+      "required": ["file"],
       "additionalProperties": false
     }
   }

--- a/apps/client/src/app/utils/schemas.json
+++ b/apps/client/src/app/utils/schemas.json
@@ -1,9 +1,7 @@
 [
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/GrafanaConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/GrafanaConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/GrafanaConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/GrafanaConfigDto.schema.json",
@@ -26,18 +24,13 @@
           "example": "loki"
         }
       },
-      "required": [
-        "tempoUid",
-        "lokiUid"
-      ],
+      "required": ["tempoUid", "lokiUid"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FrontendConfigResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/FrontendConfigResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/FrontendConfigResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FrontendConfigResponseDto.schema.json",
@@ -53,17 +46,13 @@
           ]
         }
       },
-      "required": [
-        "grafana"
-      ],
+      "required": ["grafana"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RoleDto.schema.json",
-    "fileMatch": [
-      "a://b/RoleDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/RoleDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RoleDto.schema.json",
@@ -86,17 +75,13 @@
           "example": "issuance:manage"
         }
       },
-      "required": [
-        "role"
-      ],
+      "required": ["role"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientCredentialsDto.schema.json",
-    "fileMatch": [
-      "a://b/ClientCredentialsDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ClientCredentialsDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientCredentialsDto.schema.json",
@@ -114,18 +99,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "client_id",
-        "client_secret"
-      ],
+      "required": ["client_id", "client_secret"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TokenResponse.schema.json",
-    "fileMatch": [
-      "a://b/TokenResponse*.schema.json"
-    ],
+    "fileMatch": ["a://b/TokenResponse*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TokenResponse.schema.json",
@@ -148,20 +128,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "access_token",
-        "token_type",
-        "expires_in",
-        "state"
-      ],
+      "required": ["access_token", "token_type", "expires_in", "state"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ImportTenantDto.schema.json",
-    "fileMatch": [
-      "a://b/ImportTenantDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ImportTenantDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ImportTenantDto.schema.json",
@@ -177,17 +150,13 @@
           "description": "The description of the tenant."
         }
       },
-      "required": [
-        "name"
-      ],
+      "required": ["name"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SessionStorageConfig.schema.json",
-    "fileMatch": [
-      "a://b/SessionStorageConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/SessionStorageConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SessionStorageConfig.schema.json",
@@ -203,10 +172,7 @@
         "cleanupMode": {
           "type": "string",
           "description": "Cleanup mode: 'full' deletes everything, 'anonymize' keeps metadata but removes PII.",
-          "enum": [
-            "full",
-            "anonymize"
-          ],
+          "enum": ["full", "anonymize"],
           "default": "full"
         }
       },
@@ -215,9 +181,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListConfig.schema.json",
-    "fileMatch": [
-      "a://b/StatusListConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/StatusListConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListConfig.schema.json",
@@ -233,12 +197,7 @@
         "bits": {
           "type": "number",
           "description": "Bits per status entry: 1 (valid/revoked), 2 (with suspended), 4/8 (extended). If not set, uses global STATUS_BITS.",
-          "enum": [
-            1,
-            2,
-            4,
-            8
-          ],
+          "enum": [1, 2, 4, 8],
           "default": 1
         },
         "ttl": {
@@ -263,9 +222,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TenantEntity.schema.json",
-    "fileMatch": [
-      "a://b/TenantEntity*.schema.json"
-    ],
+    "fileMatch": ["a://b/TenantEntity*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TenantEntity.schema.json",
@@ -316,20 +273,13 @@
           }
         }
       },
-      "required": [
-        "id",
-        "name",
-        "status",
-        "clients"
-      ],
+      "required": ["id", "name", "status", "clients"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientEntity.schema.json",
-    "fileMatch": [
-      "a://b/ClientEntity*.schema.json"
-    ],
+    "fileMatch": ["a://b/ClientEntity*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientEntity.schema.json",
@@ -339,10 +289,7 @@
         "allowedPresentationConfigs": {
           "nullable": true,
           "description": "List of presentation config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": [
-            "age-verification",
-            "kyc-basic"
-          ],
+          "example": ["age-verification", "kyc-basic"],
           "type": "array",
           "items": {
             "type": "string"
@@ -351,10 +298,7 @@
         "allowedIssuanceConfigs": {
           "nullable": true,
           "description": "List of issuance config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": [
-            "pid",
-            "mdl"
-          ],
+          "example": ["pid", "mdl"],
           "type": "array",
           "items": {
             "type": "string"
@@ -402,18 +346,13 @@
           ]
         }
       },
-      "required": [
-        "clientId",
-        "roles"
-      ],
+      "required": ["clientId", "roles"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateTenantDto.schema.json",
-    "fileMatch": [
-      "a://b/CreateTenantDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CreateTenantDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateTenantDto.schema.json",
@@ -467,18 +406,13 @@
           }
         }
       },
-      "required": [
-        "id",
-        "name"
-      ],
+      "required": ["id", "name"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateTenantDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateTenantDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateTenantDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateTenantDto.schema.json",
@@ -533,9 +467,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuditLogResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/AuditLogResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/AuditLogResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuditLogResponseDto.schema.json",
@@ -572,11 +504,7 @@
           "type": "string"
         },
         "actorType": {
-          "enum": [
-            "user",
-            "client",
-            "system"
-          ],
+          "enum": ["user", "client", "system"],
           "type": "string"
         },
         "actorId": {
@@ -607,21 +535,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "id",
-        "tenantId",
-        "actionType",
-        "actorType",
-        "timestamp"
-      ],
+      "required": ["id", "tenantId", "actionType", "actorType", "timestamp"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientSecretResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/ClientSecretResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ClientSecretResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClientSecretResponseDto.schema.json",
@@ -632,17 +552,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "secret"
-      ],
+      "required": ["secret"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateClientDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateClientDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateClientDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateClientDto.schema.json",
@@ -652,10 +568,7 @@
         "allowedPresentationConfigs": {
           "nullable": true,
           "description": "List of presentation config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": [
-            "age-verification",
-            "kyc-basic"
-          ],
+          "example": ["age-verification", "kyc-basic"],
           "type": "array",
           "items": {
             "type": "string"
@@ -664,10 +577,7 @@
         "allowedIssuanceConfigs": {
           "nullable": true,
           "description": "List of issuance config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": [
-            "pid",
-            "mdl"
-          ],
+          "example": ["pid", "mdl"],
           "type": "array",
           "items": {
             "type": "string"
@@ -695,17 +605,13 @@
           }
         }
       },
-      "required": [
-        "roles"
-      ],
+      "required": ["roles"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateClientDto.schema.json",
-    "fileMatch": [
-      "a://b/CreateClientDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CreateClientDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateClientDto.schema.json",
@@ -715,10 +621,7 @@
         "allowedPresentationConfigs": {
           "nullable": true,
           "description": "List of presentation config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": [
-            "age-verification",
-            "kyc-basic"
-          ],
+          "example": ["age-verification", "kyc-basic"],
           "type": "array",
           "items": {
             "type": "string"
@@ -727,10 +630,7 @@
         "allowedIssuanceConfigs": {
           "nullable": true,
           "description": "List of issuance config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": [
-            "pid",
-            "mdl"
-          ],
+          "example": ["pid", "mdl"],
           "type": "array",
           "items": {
             "type": "string"
@@ -766,18 +666,13 @@
           }
         }
       },
-      "required": [
-        "clientId",
-        "roles"
-      ],
+      "required": ["clientId", "roles"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListImportDto.schema.json",
-    "fileMatch": [
-      "a://b/StatusListImportDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/StatusListImportDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListImportDto.schema.json",
@@ -807,27 +702,18 @@
         },
         "bits": {
           "description": "Bits per status value. If not provided, uses tenant or global defaults.",
-          "enum": [
-            1,
-            2,
-            4,
-            8
-          ],
+          "enum": [1, 2, 4, 8],
           "type": "number",
           "example": 1
         }
       },
-      "required": [
-        "id"
-      ],
+      "required": ["id"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListAggregationDto.schema.json",
-    "fileMatch": [
-      "a://b/StatusListAggregationDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/StatusListAggregationDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListAggregationDto.schema.json",
@@ -846,17 +732,13 @@
           }
         }
       },
-      "required": [
-        "status_lists"
-      ],
+      "required": ["status_lists"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateStatusListConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateStatusListConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateStatusListConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateStatusListConfigDto.schema.json",
@@ -873,12 +755,7 @@
         "bits": {
           "nullable": true,
           "description": "Bits per status entry. Set to null to reset to global default.",
-          "enum": [
-            1,
-            2,
-            4,
-            8
-          ],
+          "enum": [1, 2, 4, 8],
           "type": "number"
         },
         "ttl": {
@@ -904,9 +781,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/StatusListResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/StatusListResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusListResponseDto.schema.json",
@@ -937,12 +812,7 @@
         },
         "bits": {
           "description": "Bits per status value",
-          "enum": [
-            1,
-            2,
-            4,
-            8
-          ],
+          "enum": [1, 2, 4, 8],
           "type": "number",
           "example": 1
         },
@@ -995,9 +865,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateStatusListDto.schema.json",
-    "fileMatch": [
-      "a://b/CreateStatusListDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CreateStatusListDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateStatusListDto.schema.json",
@@ -1016,12 +884,7 @@
         },
         "bits": {
           "description": "Bits per status value. More bits allow more status states. Defaults to tenant configuration.",
-          "enum": [
-            1,
-            2,
-            4,
-            8
-          ],
+          "enum": [1, 2, 4, 8],
           "type": "number",
           "example": 1
         },
@@ -1037,9 +900,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateStatusListDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateStatusListDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateStatusListDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateStatusListDto.schema.json",
@@ -1064,9 +925,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthorizeQueries.schema.json",
-    "fileMatch": [
-      "a://b/AuthorizeQueries*.schema.json"
-    ],
+    "fileMatch": ["a://b/AuthorizeQueries*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthorizeQueries.schema.json",
@@ -1119,9 +978,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/OfferRequestDto.schema.json",
-    "fileMatch": [
-      "a://b/OfferRequestDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/OfferRequestDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/OfferRequestDto.schema.json",
@@ -1129,10 +986,7 @@
       "type": "object",
       "properties": {
         "response_type": {
-          "enum": [
-            "uri",
-            "dc-api"
-          ],
+          "enum": ["uri", "dc-api"],
           "type": "string",
           "examples": [
             {
@@ -1150,19 +1004,14 @@
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "inline"
-                    ]
+                    "enum": ["inline"]
                   },
                   "claims": {
                     "type": "object",
                     "additionalProperties": true
                   }
                 },
-                "required": [
-                  "type",
-                  "claims"
-                ],
+                "required": ["type", "claims"],
                 "additionalProperties": false
               },
               {
@@ -1170,18 +1019,13 @@
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "attributeProvider"
-                    ]
+                    "enum": ["attributeProvider"]
                   },
                   "attributeProviderId": {
                     "type": "string"
                   }
                 },
-                "required": [
-                  "type",
-                  "attributeProviderId"
-                ],
+                "required": ["type", "attributeProviderId"],
                 "additionalProperties": false
               },
               {
@@ -1189,9 +1033,7 @@
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "webhook"
-                    ]
+                    "enum": ["webhook"]
                   },
                   "webhook": {
                     "type": "object",
@@ -1203,16 +1045,11 @@
                         "type": "object"
                       }
                     },
-                    "required": [
-                      "url"
-                    ],
+                    "required": ["url"],
                     "additionalProperties": false
                   }
                 },
-                "required": [
-                  "type",
-                  "webhook"
-                ],
+                "required": ["type", "webhook"],
                 "additionalProperties": false
               }
             ]
@@ -1230,10 +1067,7 @@
         },
         "flow": {
           "description": "The flow type for the offer request.",
-          "enum": [
-            "authorization_code",
-            "pre_authorized_code"
-          ],
+          "enum": ["authorization_code", "pre_authorized_code"],
           "type": "string"
         },
         "tx_code": {
@@ -1260,19 +1094,13 @@
           "description": "ID of the webhook endpoint to notify about the status of the issuance process."
         }
       },
-      "required": [
-        "response_type",
-        "flow",
-        "credentialConfigurationIds"
-      ],
+      "required": ["response_type", "flow", "credentialConfigurationIds"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebHookAuthConfigNone.schema.json",
-    "fileMatch": [
-      "a://b/WebHookAuthConfigNone*.schema.json"
-    ],
+    "fileMatch": ["a://b/WebHookAuthConfigNone*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebHookAuthConfigNone.schema.json",
@@ -1282,22 +1110,16 @@
         "type": {
           "type": "string",
           "description": "The type of authentication used for the webhook.",
-          "enum": [
-            "none"
-          ]
+          "enum": ["none"]
         }
       },
-      "required": [
-        "type"
-      ],
+      "required": ["type"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ApiKeyConfig.schema.json",
-    "fileMatch": [
-      "a://b/ApiKeyConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/ApiKeyConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ApiKeyConfig.schema.json",
@@ -1313,18 +1135,13 @@
           "description": "The value of the API key to be sent in the header."
         }
       },
-      "required": [
-        "headerName",
-        "value"
-      ],
+      "required": ["headerName", "value"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebHookAuthConfigHeader.schema.json",
-    "fileMatch": [
-      "a://b/WebHookAuthConfigHeader*.schema.json"
-    ],
+    "fileMatch": ["a://b/WebHookAuthConfigHeader*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebHookAuthConfigHeader.schema.json",
@@ -1334,9 +1151,7 @@
         "type": {
           "type": "string",
           "description": "The type of authentication used for the webhook.",
-          "enum": [
-            "apiKey"
-          ]
+          "enum": ["apiKey"]
         },
         "config": {
           "description": "Configuration for API key authentication.\nThis is required if the type is 'apiKey'.",
@@ -1347,18 +1162,13 @@
           ]
         }
       },
-      "required": [
-        "type",
-        "config"
-      ],
+      "required": ["type", "config"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebhookConfig.schema.json",
-    "fileMatch": [
-      "a://b/WebhookConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/WebhookConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebhookConfig.schema.json",
@@ -1388,18 +1198,13 @@
           "description": "The URL to which the webhook will send notifications."
         }
       },
-      "required": [
-        "auth",
-        "url"
-      ],
+      "required": ["auth", "url"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TransactionData.schema.json",
-    "fileMatch": [
-      "a://b/TransactionData*.schema.json"
-    ],
+    "fileMatch": ["a://b/TransactionData*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TransactionData.schema.json",
@@ -1416,18 +1221,13 @@
           }
         }
       },
-      "required": [
-        "type",
-        "credential_ids"
-      ],
+      "required": ["type", "credential_ids"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Session.schema.json",
-    "fileMatch": [
-      "a://b/Session*.schema.json"
-    ],
+    "fileMatch": ["a://b/Session*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Session.schema.json",
@@ -1436,13 +1236,7 @@
       "properties": {
         "status": {
           "description": "Status of the session.",
-          "enum": [
-            "active",
-            "fetched",
-            "completed",
-            "expired",
-            "failed"
-          ],
+          "enum": ["active", "fetched", "completed", "expired", "failed"],
           "type": "string"
         },
         "id": {
@@ -1632,9 +1426,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PaginatedSessionResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/PaginatedSessionResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/PaginatedSessionResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PaginatedSessionResponseDto.schema.json",
@@ -1665,21 +1457,13 @@
           "description": "Total number of pages"
         }
       },
-      "required": [
-        "items",
-        "total",
-        "page",
-        "pageSize",
-        "totalPages"
-      ],
+      "required": ["items", "total", "page", "pageSize", "totalPages"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SessionLogEntryResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/SessionLogEntryResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/SessionLogEntryResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SessionLogEntryResponseDto.schema.json",
@@ -1702,11 +1486,7 @@
         "level": {
           "type": "string",
           "description": "Log level",
-          "enum": [
-            "info",
-            "warn",
-            "error"
-          ]
+          "enum": ["info", "warn", "error"]
         },
         "stage": {
           "type": "string",
@@ -1722,21 +1502,13 @@
           "description": "Additional structured detail"
         }
       },
-      "required": [
-        "id",
-        "sessionId",
-        "timestamp",
-        "level",
-        "message"
-      ],
+      "required": ["id", "sessionId", "timestamp", "level", "message"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusUpdateDto.schema.json",
-    "fileMatch": [
-      "a://b/StatusUpdateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/StatusUpdateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/StatusUpdateDto.schema.json",
@@ -1756,18 +1528,13 @@
           "description": "The status of the credential\n0 = valid, 1 = revoked, 2 = suspended"
         }
       },
-      "required": [
-        "sessionId",
-        "status"
-      ],
+      "required": ["sessionId", "status"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateSessionConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateSessionConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateSessionConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateSessionConfigDto.schema.json",
@@ -1783,10 +1550,7 @@
         },
         "cleanupMode": {
           "description": "Cleanup mode: 'full' deletes everything, 'anonymize' keeps metadata but removes PII.",
-          "enum": [
-            "full",
-            "anonymize"
-          ],
+          "enum": ["full", "anonymize"],
           "type": "string",
           "default": "full"
         }
@@ -1796,9 +1560,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ManagedUserDto.schema.json",
-    "fileMatch": [
-      "a://b/ManagedUserDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ManagedUserDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ManagedUserDto.schema.json",
@@ -1847,20 +1609,13 @@
           "description": "One-time temporary password returned only on user creation."
         }
       },
-      "required": [
-        "id",
-        "username",
-        "enabled",
-        "roles"
-      ],
+      "required": ["id", "username", "enabled", "roles"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateUserDto.schema.json",
-    "fileMatch": [
-      "a://b/CreateUserDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CreateUserDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateUserDto.schema.json",
@@ -1902,18 +1657,13 @@
           "example": true
         }
       },
-      "required": [
-        "username",
-        "roles"
-      ],
+      "required": ["username", "roles"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateUserDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateUserDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateUserDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateUserDto.schema.json",
@@ -1965,9 +1715,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodNone.schema.json",
-    "fileMatch": [
-      "a://b/AuthenticationMethodNone*.schema.json"
-    ],
+    "fileMatch": ["a://b/AuthenticationMethodNone*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodNone.schema.json",
@@ -1976,22 +1724,16 @@
       "properties": {
         "method": {
           "type": "string",
-          "enum": [
-            "none"
-          ]
+          "enum": ["none"]
         }
       },
-      "required": [
-        "method"
-      ],
+      "required": ["method"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationUrlConfig.schema.json",
-    "fileMatch": [
-      "a://b/AuthenticationUrlConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/AuthenticationUrlConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationUrlConfig.schema.json",
@@ -2011,17 +1753,13 @@
           ]
         }
       },
-      "required": [
-        "url"
-      ],
+      "required": ["url"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodAuth.schema.json",
-    "fileMatch": [
-      "a://b/AuthenticationMethodAuth*.schema.json"
-    ],
+    "fileMatch": ["a://b/AuthenticationMethodAuth*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodAuth.schema.json",
@@ -2030,26 +1768,19 @@
       "properties": {
         "method": {
           "type": "string",
-          "enum": [
-            "auth"
-          ]
+          "enum": ["auth"]
         },
         "config": {
           "$ref": "./AuthenticationUrlConfig.schema.json"
         }
       },
-      "required": [
-        "method",
-        "config"
-      ],
+      "required": ["method", "config"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationDuringIssuanceConfig.schema.json",
-    "fileMatch": [
-      "a://b/PresentationDuringIssuanceConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/PresentationDuringIssuanceConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationDuringIssuanceConfig.schema.json",
@@ -2061,17 +1792,13 @@
           "description": "Link to the presentation configuration that is relevant for the issuance process"
         }
       },
-      "required": [
-        "type"
-      ],
+      "required": ["type"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodPresentation.schema.json",
-    "fileMatch": [
-      "a://b/AuthenticationMethodPresentation*.schema.json"
-    ],
+    "fileMatch": ["a://b/AuthenticationMethodPresentation*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthenticationMethodPresentation.schema.json",
@@ -2080,26 +1807,19 @@
       "properties": {
         "method": {
           "type": "string",
-          "enum": [
-            "presentationDuringIssuance"
-          ]
+          "enum": ["presentationDuringIssuance"]
         },
         "config": {
           "$ref": "./PresentationDuringIssuanceConfig.schema.json"
         }
       },
-      "required": [
-        "method",
-        "config"
-      ],
+      "required": ["method", "config"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpstreamOidcConfig.schema.json",
-    "fileMatch": [
-      "a://b/UpstreamOidcConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpstreamOidcConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpstreamOidcConfig.schema.json",
@@ -2123,28 +1843,20 @@
         },
         "scopes": {
           "description": "Scopes to request from the upstream provider",
-          "default": [
-            "openid",
-            "profile"
-          ],
+          "default": ["openid", "profile"],
           "type": "array",
           "items": {
             "type": "string"
           }
         }
       },
-      "required": [
-        "issuer",
-        "clientId"
-      ],
+      "required": ["issuer", "clientId"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenConfig.schema.json",
-    "fileMatch": [
-      "a://b/ChainedAsTokenConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/ChainedAsTokenConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenConfig.schema.json",
@@ -2178,9 +1890,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ManagedAuthorizationServerConfig.schema.json",
-    "fileMatch": [
-      "a://b/ManagedAuthorizationServerConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/ManagedAuthorizationServerConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ManagedAuthorizationServerConfig.schema.json",
@@ -2198,11 +1908,7 @@
           "example": "PID Authorization Server"
         },
         "type": {
-          "enum": [
-            "external",
-            "oid4vp",
-            "chained"
-          ],
+          "enum": ["external", "oid4vp", "chained"],
           "type": "string",
           "description": "Authorization server implementation type",
           "example": "external"
@@ -2250,17 +1956,13 @@
           "default": false
         }
       },
-      "required": [
-        "type"
-      ],
+      "required": ["type"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FederationTrustAnchorConfig.schema.json",
-    "fileMatch": [
-      "a://b/FederationTrustAnchorConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/FederationTrustAnchorConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FederationTrustAnchorConfig.schema.json",
@@ -2278,18 +1980,13 @@
           "example": "https://ta.example.org/.well-known/openid-federation"
         }
       },
-      "required": [
-        "entityId",
-        "entityConfigurationUri"
-      ],
+      "required": ["entityId", "entityConfigurationUri"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FederationConfig.schema.json",
-    "fileMatch": [
-      "a://b/FederationConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/FederationConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FederationConfig.schema.json",
@@ -2297,20 +1994,13 @@
       "type": "object",
       "properties": {
         "role": {
-          "enum": [
-            "trust_anchor",
-            "intermediate",
-            "leaf"
-          ],
+          "enum": ["trust_anchor", "intermediate", "leaf"],
           "type": "string",
           "description": "Role this tenant plays in the OpenID Federation topology.",
           "default": "leaf"
         },
         "mode": {
-          "enum": [
-            "federation-only",
-            "hybrid"
-          ],
+          "enum": ["federation-only", "hybrid"],
           "type": "string",
           "description": "Trust decision strategy when both LoTE trust lists and OpenID Federation are configured.",
           "default": "hybrid"
@@ -2338,17 +2028,13 @@
           }
         }
       },
-      "required": [
-        "trustAnchors"
-      ],
+      "required": ["trustAnchors"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerProvidedAttestation.schema.json",
-    "fileMatch": [
-      "a://b/IssuerProvidedAttestation*.schema.json"
-    ],
+    "fileMatch": ["a://b/IssuerProvidedAttestation*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerProvidedAttestation.schema.json",
@@ -2371,9 +2057,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerRegistrationCertificateConfig.schema.json",
-    "fileMatch": [
-      "a://b/IssuerRegistrationCertificateConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/IssuerRegistrationCertificateConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerRegistrationCertificateConfig.schema.json",
@@ -2386,10 +2070,7 @@
           "default": false
         },
         "mode": {
-          "enum": [
-            "import",
-            "generate"
-          ],
+          "enum": ["import", "generate"],
           "type": "string",
           "description": "import: use an existing JWT, generate: create via registrar from provided attestations and selected credential configurations.",
           "default": "import"
@@ -2428,9 +2109,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerRegistrationCertificateCache.schema.json",
-    "fileMatch": [
-      "a://b/IssuerRegistrationCertificateCache*.schema.json"
-    ],
+    "fileMatch": ["a://b/IssuerRegistrationCertificateCache*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerRegistrationCertificateCache.schema.json",
@@ -2463,9 +2142,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayLogo.schema.json",
-    "fileMatch": [
-      "a://b/DisplayLogo*.schema.json"
-    ],
+    "fileMatch": ["a://b/DisplayLogo*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayLogo.schema.json",
@@ -2479,17 +2156,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "uri"
-      ],
+      "required": ["uri"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayInfo.schema.json",
-    "fileMatch": [
-      "a://b/DisplayInfo*.schema.json"
-    ],
+    "fileMatch": ["a://b/DisplayInfo*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayInfo.schema.json",
@@ -2511,9 +2184,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuanceConfig.schema.json",
-    "fileMatch": [
-      "a://b/IssuanceConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/IssuanceConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuanceConfig.schema.json",
@@ -2623,20 +2294,13 @@
           "description": "The timestamp when the VP request was last updated."
         }
       },
-      "required": [
-        "tenant",
-        "display",
-        "createdAt",
-        "updatedAt"
-      ],
+      "required": ["tenant", "display", "createdAt", "updatedAt"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuanceDto.schema.json",
-    "fileMatch": [
-      "a://b/IssuanceDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/IssuanceDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuanceDto.schema.json",
@@ -2728,17 +2392,13 @@
           }
         }
       },
-      "required": [
-        "display"
-      ],
+      "required": ["display"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClaimsQuery.schema.json",
-    "fileMatch": [
-      "a://b/ClaimsQuery*.schema.json"
-    ],
+    "fileMatch": ["a://b/ClaimsQuery*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClaimsQuery.schema.json",
@@ -2761,17 +2421,13 @@
           }
         }
       },
-      "required": [
-        "path"
-      ],
+      "required": ["path"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustedAuthorityQuery.schema.json",
-    "fileMatch": [
-      "a://b/TrustedAuthorityQuery*.schema.json"
-    ],
+    "fileMatch": ["a://b/TrustedAuthorityQuery*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustedAuthorityQuery.schema.json",
@@ -2780,10 +2436,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": [
-            "etsi_tl",
-            "openid_federation"
-          ]
+          "enum": ["etsi_tl", "openid_federation"]
         },
         "values": {
           "type": "array",
@@ -2792,18 +2445,13 @@
           }
         }
       },
-      "required": [
-        "type",
-        "values"
-      ],
+      "required": ["type", "values"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialQuery.schema.json",
-    "fileMatch": [
-      "a://b/CredentialQuery*.schema.json"
-    ],
+    "fileMatch": ["a://b/CredentialQuery*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialQuery.schema.json",
@@ -2846,19 +2494,13 @@
           }
         }
       },
-      "required": [
-        "id",
-        "format",
-        "meta"
-      ],
+      "required": ["id", "format", "meta"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialSetQuery.schema.json",
-    "fileMatch": [
-      "a://b/CredentialSetQuery*.schema.json"
-    ],
+    "fileMatch": ["a://b/CredentialSetQuery*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialSetQuery.schema.json",
@@ -2878,17 +2520,13 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "options"
-      ],
+      "required": ["options"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PolicyCredential.schema.json",
-    "fileMatch": [
-      "a://b/PolicyCredential*.schema.json"
-    ],
+    "fileMatch": ["a://b/PolicyCredential*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PolicyCredential.schema.json",
@@ -2914,17 +2552,13 @@
           }
         }
       },
-      "required": [
-        "credentials"
-      ],
+      "required": ["credentials"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AttestationBasedPolicy.schema.json",
-    "fileMatch": [
-      "a://b/AttestationBasedPolicy*.schema.json"
-    ],
+    "fileMatch": ["a://b/AttestationBasedPolicy*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AttestationBasedPolicy.schema.json",
@@ -2933,9 +2567,7 @@
       "properties": {
         "policy": {
           "type": "string",
-          "enum": [
-            "attestationBased"
-          ]
+          "enum": ["attestationBased"]
         },
         "values": {
           "type": "array",
@@ -2944,18 +2576,13 @@
           }
         }
       },
-      "required": [
-        "policy",
-        "values"
-      ],
+      "required": ["policy", "values"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/NoneTrustPolicy.schema.json",
-    "fileMatch": [
-      "a://b/NoneTrustPolicy*.schema.json"
-    ],
+    "fileMatch": ["a://b/NoneTrustPolicy*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/NoneTrustPolicy.schema.json",
@@ -2964,22 +2591,16 @@
       "properties": {
         "policy": {
           "type": "string",
-          "enum": [
-            "none"
-          ]
+          "enum": ["none"]
         }
       },
-      "required": [
-        "policy"
-      ],
+      "required": ["policy"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AllowListPolicy.schema.json",
-    "fileMatch": [
-      "a://b/AllowListPolicy*.schema.json"
-    ],
+    "fileMatch": ["a://b/AllowListPolicy*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AllowListPolicy.schema.json",
@@ -2988,9 +2609,7 @@
       "properties": {
         "policy": {
           "type": "string",
-          "enum": [
-            "allowList"
-          ]
+          "enum": ["allowList"]
         },
         "values": {
           "type": "array",
@@ -2999,18 +2618,13 @@
           }
         }
       },
-      "required": [
-        "policy",
-        "values"
-      ],
+      "required": ["policy", "values"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RootOfTrustPolicy.schema.json",
-    "fileMatch": [
-      "a://b/RootOfTrustPolicy*.schema.json"
-    ],
+    "fileMatch": ["a://b/RootOfTrustPolicy*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RootOfTrustPolicy.schema.json",
@@ -3019,26 +2633,19 @@
       "properties": {
         "policy": {
           "type": "string",
-          "enum": [
-            "rootOfTrust"
-          ]
+          "enum": ["rootOfTrust"]
         },
         "values": {
           "type": "string"
         }
       },
-      "required": [
-        "policy",
-        "values"
-      ],
+      "required": ["policy", "values"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/VCT.schema.json",
-    "fileMatch": [
-      "a://b/VCT*.schema.json"
-    ],
+    "fileMatch": ["a://b/VCT*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/VCT.schema.json",
@@ -3072,9 +2679,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IaeActionOpenid4vpPresentation.schema.json",
-    "fileMatch": [
-      "a://b/IaeActionOpenid4vpPresentation*.schema.json"
-    ],
+    "fileMatch": ["a://b/IaeActionOpenid4vpPresentation*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IaeActionOpenid4vpPresentation.schema.json",
@@ -3082,9 +2687,7 @@
       "type": "object",
       "properties": {
         "type": {
-          "enum": [
-            "openid4vp_presentation"
-          ],
+          "enum": ["openid4vp_presentation"],
           "type": "string",
           "description": "Action type discriminator",
           "example": "openid4vp_presentation"
@@ -3100,18 +2703,13 @@
           "example": "pid-presentation-config"
         }
       },
-      "required": [
-        "type",
-        "presentationConfigId"
-      ],
+      "required": ["type", "presentationConfigId"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IaeActionRedirectToWeb.schema.json",
-    "fileMatch": [
-      "a://b/IaeActionRedirectToWeb*.schema.json"
-    ],
+    "fileMatch": ["a://b/IaeActionRedirectToWeb*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IaeActionRedirectToWeb.schema.json",
@@ -3119,9 +2717,7 @@
       "type": "object",
       "properties": {
         "type": {
-          "enum": [
-            "redirect_to_web"
-          ],
+          "enum": ["redirect_to_web"],
           "type": "string",
           "description": "Action type discriminator",
           "example": "redirect_to_web"
@@ -3149,18 +2745,13 @@
           "example": "Please complete the identity verification form"
         }
       },
-      "required": [
-        "type",
-        "url"
-      ],
+      "required": ["type", "url"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebhookEndpointEntity.schema.json",
-    "fileMatch": [
-      "a://b/WebhookEndpointEntity*.schema.json"
-    ],
+    "fileMatch": ["a://b/WebhookEndpointEntity*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/WebhookEndpointEntity.schema.json",
@@ -3198,22 +2789,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "id",
-        "auth",
-        "tenantId",
-        "tenant",
-        "name",
-        "url"
-      ],
+      "required": ["id", "auth", "tenantId", "tenant", "name", "url"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaUriEntry.schema.json",
-    "fileMatch": [
-      "a://b/SchemaUriEntry*.schema.json"
-    ],
+    "fileMatch": ["a://b/SchemaUriEntry*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaUriEntry.schema.json",
@@ -3245,9 +2827,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustAuthorityEntry.schema.json",
-    "fileMatch": [
-      "a://b/TrustAuthorityEntry*.schema.json"
-    ],
+    "fileMatch": ["a://b/TrustAuthorityEntry*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustAuthorityEntry.schema.json",
@@ -3259,11 +2839,7 @@
           "description": "Trust list ID to resolve from the database. When set, frameworkType, value, and verificationMethod are derived automatically."
         },
         "frameworkType": {
-          "enum": [
-            "aki",
-            "etsi_tl",
-            "openid_federation"
-          ],
+          "enum": ["aki", "etsi_tl", "openid_federation"],
           "type": "string",
           "description": "Trust framework type (ignored when trustListId is set)"
         },
@@ -3294,9 +2870,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetaConfig.schema.json",
-    "fileMatch": [
-      "a://b/SchemaMetaConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/SchemaMetaConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetaConfig.schema.json",
@@ -3329,12 +2903,7 @@
           "description": "Attestation Level of Security"
         },
         "bindingType": {
-          "enum": [
-            "claim",
-            "key",
-            "biometric",
-            "none"
-          ],
+          "enum": ["claim", "key", "biometric", "none"],
           "type": "string",
           "description": "Cryptographic binding type"
         },
@@ -3358,9 +2927,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EmbeddedDisclosurePolicy.schema.json",
-    "fileMatch": [
-      "a://b/EmbeddedDisclosurePolicy*.schema.json"
-    ],
+    "fileMatch": ["a://b/EmbeddedDisclosurePolicy*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EmbeddedDisclosurePolicy.schema.json",
@@ -3371,17 +2938,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "policy"
-      ],
+      "required": ["policy"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyAttestationsRequired.schema.json",
-    "fileMatch": [
-      "a://b/KeyAttestationsRequired*.schema.json"
-    ],
+    "fileMatch": ["a://b/KeyAttestationsRequired*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyAttestationsRequired.schema.json",
@@ -3390,10 +2953,7 @@
       "properties": {
         "key_storage": {
           "description": "List of required key storage types (e.g., iso_18045_high, iso_18045_moderate)",
-          "example": [
-            "iso_18045_high",
-            "iso_18045_moderate"
-          ],
+          "example": ["iso_18045_high", "iso_18045_moderate"],
           "type": "array",
           "items": {
             "type": "string"
@@ -3401,10 +2961,7 @@
         },
         "user_authentication": {
           "description": "List of required user authentication types (e.g., iso_18045_high, iso_18045_moderate)",
-          "example": [
-            "iso_18045_high",
-            "iso_18045_moderate"
-          ],
+          "example": ["iso_18045_high", "iso_18045_moderate"],
           "type": "array",
           "items": {
             "type": "string"
@@ -3416,9 +2973,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayImage.schema.json",
-    "fileMatch": [
-      "a://b/DisplayImage*.schema.json"
-    ],
+    "fileMatch": ["a://b/DisplayImage*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DisplayImage.schema.json",
@@ -3429,17 +2984,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "uri"
-      ],
+      "required": ["uri"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Display.schema.json",
-    "fileMatch": [
-      "a://b/Display*.schema.json"
-    ],
+    "fileMatch": ["a://b/Display*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Display.schema.json",
@@ -3468,19 +3019,13 @@
           "$ref": "./DisplayImage.schema.json"
         }
       },
-      "required": [
-        "name",
-        "description",
-        "locale"
-      ],
+      "required": ["name", "description", "locale"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerMetadataCredentialConfig.schema.json",
-    "fileMatch": [
-      "a://b/IssuerMetadataCredentialConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/IssuerMetadataCredentialConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/IssuerMetadataCredentialConfig.schema.json",
@@ -3497,10 +3042,7 @@
         },
         "format": {
           "type": "string",
-          "enum": [
-            "mso_mdoc",
-            "dc+sd-jwt"
-          ]
+          "enum": ["mso_mdoc", "dc+sd-jwt"]
         },
         "display": {
           "type": "array",
@@ -3516,18 +3058,13 @@
           "description": "Document type for mDOC credentials (e.g., \"org.iso.18013.5.1.mDL\").\nOnly applicable when format is \"mso_mdoc\"."
         }
       },
-      "required": [
-        "format",
-        "display"
-      ],
+      "required": ["format", "display"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FieldDisplayDto.schema.json",
-    "fileMatch": [
-      "a://b/FieldDisplayDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/FieldDisplayDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FieldDisplayDto.schema.json",
@@ -3550,18 +3087,13 @@
           "example": "Primary first name"
         }
       },
-      "required": [
-        "locale",
-        "name"
-      ],
+      "required": ["locale", "name"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClaimFieldDefinitionDto.schema.json",
-    "fileMatch": [
-      "a://b/ClaimFieldDefinitionDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ClaimFieldDefinitionDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ClaimFieldDefinitionDto.schema.json",
@@ -3571,10 +3103,7 @@
         "path": {
           "type": "array",
           "description": "Path to claim value. For nested child fields this can be relative to the parent path.",
-          "example": [
-            "address",
-            "locality"
-          ],
+          "example": ["address", "locality"],
           "items": {
             "oneOf": [
               {
@@ -3590,14 +3119,7 @@
           }
         },
         "type": {
-          "enum": [
-            "string",
-            "number",
-            "integer",
-            "boolean",
-            "object",
-            "array"
-          ],
+          "enum": ["string", "number", "integer", "boolean", "object", "array"],
           "type": "string",
           "description": "Claim value type"
         },
@@ -3658,18 +3180,13 @@
           }
         }
       },
-      "required": [
-        "path",
-        "type"
-      ],
+      "required": ["path", "type"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AttributeProviderEntity.schema.json",
-    "fileMatch": [
-      "a://b/AttributeProviderEntity*.schema.json"
-    ],
+    "fileMatch": ["a://b/AttributeProviderEntity*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AttributeProviderEntity.schema.json",
@@ -3706,22 +3223,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "auth",
-        "id",
-        "tenantId",
-        "tenant",
-        "name",
-        "url"
-      ],
+      "required": ["auth", "id", "tenantId", "tenant", "name", "url"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainEntity.schema.json",
-    "fileMatch": [
-      "a://b/KeyChainEntity*.schema.json"
-    ],
+    "fileMatch": ["a://b/KeyChainEntity*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainEntity.schema.json",
@@ -3751,21 +3259,12 @@
         "usageType": {
           "type": "string",
           "description": "The purpose/role of this key chain in the system.",
-          "enum": [
-            "access",
-            "attestation",
-            "trustList",
-            "statusList",
-            "encrypt"
-          ]
+          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"]
         },
         "usage": {
           "type": "string",
           "description": "The usage type of the keys (sign or encrypt).",
-          "enum": [
-            "sign",
-            "encrypt"
-          ]
+          "enum": ["sign", "encrypt"]
         },
         "kmsProvider": {
           "type": "string",
@@ -3845,9 +3344,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfig.schema.json",
-    "fileMatch": [
-      "a://b/CredentialConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/CredentialConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfig.schema.json",
@@ -3974,30 +3471,20 @@
         "sdJwtTrustFormat": {
           "nullable": true,
           "description": "For SD-JWT credentials: determines whether to include certificate chain (x5c)\nor use federation-based trust (iss claim).\nDefault: \"x5c\" (federation must be explicitly selected)",
-          "enum": [
-            "x5c",
-            "federation"
-          ],
+          "enum": ["x5c", "federation"],
           "type": "string"
         },
         "lifeTime": {
           "type": "number"
         }
       },
-      "required": [
-        "id",
-        "tenant",
-        "config",
-        "fields"
-      ],
+      "required": ["id", "tenant", "config", "fields"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfigCreate.schema.json",
-    "fileMatch": [
-      "a://b/CredentialConfigCreate*.schema.json"
-    ],
+    "fileMatch": ["a://b/CredentialConfigCreate*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfigCreate.schema.json",
@@ -4107,29 +3594,20 @@
         "sdJwtTrustFormat": {
           "nullable": true,
           "description": "For SD-JWT credentials: determines whether to include certificate chain (x5c)\nor use federation-based trust (iss claim).\nDefault: \"x5c\" (federation must be explicitly selected)",
-          "enum": [
-            "x5c",
-            "federation"
-          ],
+          "enum": ["x5c", "federation"],
           "type": "string"
         },
         "lifeTime": {
           "type": "number"
         }
       },
-      "required": [
-        "id",
-        "config",
-        "fields"
-      ],
+      "required": ["id", "config", "fields"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfigUpdate.schema.json",
-    "fileMatch": [
-      "a://b/CredentialConfigUpdate*.schema.json"
-    ],
+    "fileMatch": ["a://b/CredentialConfigUpdate*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CredentialConfigUpdate.schema.json",
@@ -4239,10 +3717,7 @@
         "sdJwtTrustFormat": {
           "nullable": true,
           "description": "For SD-JWT credentials: determines whether to include certificate chain (x5c)\nor use federation-based trust (iss claim).\nDefault: \"x5c\" (federation must be explicitly selected)",
-          "enum": [
-            "x5c",
-            "federation"
-          ],
+          "enum": ["x5c", "federation"],
           "type": "string"
         },
         "lifeTime": {
@@ -4254,9 +3729,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SignSchemaMetaConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/SignSchemaMetaConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/SignSchemaMetaConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SignSchemaMetaConfigDto.schema.json",
@@ -4280,17 +3753,13 @@
           "description": "ID of the credential config to link back after submission. When provided, schemaMeta.id on the credential config is updated with the reserved attestation ID."
         }
       },
-      "required": [
-        "config"
-      ],
+      "required": ["config"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SignVersionSchemaMetaConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/SignVersionSchemaMetaConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/SignVersionSchemaMetaConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SignVersionSchemaMetaConfigDto.schema.json",
@@ -4310,17 +3779,13 @@
           "description": "ID of the key chain to use for signing. Defaults to the tenant's default key chain."
         }
       },
-      "required": [
-        "config"
-      ],
+      "required": ["config"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/VocabularyEntryDto.schema.json",
-    "fileMatch": [
-      "a://b/VocabularyEntryDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/VocabularyEntryDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/VocabularyEntryDto.schema.json",
@@ -4336,10 +3801,7 @@
           "description": "Display label for UI rendering."
         },
         "status": {
-          "enum": [
-            "active",
-            "deprecated"
-          ],
+          "enum": ["active", "deprecated"],
           "type": "string",
           "description": "Vocabulary lifecycle status."
         },
@@ -4348,19 +3810,13 @@
           "description": "Replacement code when status is deprecated."
         }
       },
-      "required": [
-        "code",
-        "label",
-        "status"
-      ],
+      "required": ["code", "label", "status"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetadataVocabulariesDto.schema.json",
-    "fileMatch": [
-      "a://b/SchemaMetadataVocabulariesDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/SchemaMetadataVocabulariesDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetadataVocabulariesDto.schema.json",
@@ -4386,19 +3842,13 @@
           }
         }
       },
-      "required": [
-        "version",
-        "categories",
-        "tags"
-      ],
+      "required": ["version", "categories", "tags"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/MetadataSchemaDto.schema.json",
-    "fileMatch": [
-      "a://b/MetadataSchemaDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/MetadataSchemaDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/MetadataSchemaDto.schema.json",
@@ -4410,10 +3860,7 @@
           "description": "Unique identifier for this schema entry"
         },
         "formatIdentifier": {
-          "enum": [
-            "dc+sd-jwt",
-            "mso_mdoc"
-          ],
+          "enum": ["dc+sd-jwt", "mso_mdoc"],
           "type": "string",
           "description": "The credential format identifier"
         },
@@ -4431,18 +3878,13 @@
           "description": "Subresource Integrity hash for the schema"
         }
       },
-      "required": [
-        "id",
-        "formatIdentifier"
-      ],
+      "required": ["id", "formatIdentifier"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustAuthorityDto.schema.json",
-    "fileMatch": [
-      "a://b/TrustAuthorityDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/TrustAuthorityDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustAuthorityDto.schema.json",
@@ -4456,9 +3898,7 @@
         "frameworkType": {
           "type": "string",
           "description": "Type of trust framework",
-          "enum": [
-            "etsi_tl"
-          ]
+          "enum": ["etsi_tl"]
         },
         "value": {
           "type": "string",
@@ -4470,19 +3910,13 @@
           "description": "Verification method for the trust list signature (e.g., JWK)"
         }
       },
-      "required": [
-        "id",
-        "frameworkType",
-        "value"
-      ],
+      "required": ["id", "frameworkType", "value"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AccessCertificateRefDto.schema.json",
-    "fileMatch": [
-      "a://b/AccessCertificateRefDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/AccessCertificateRefDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AccessCertificateRefDto.schema.json",
@@ -4505,21 +3939,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "id",
-        "relyingPartyId",
-        "certificate",
-        "revoked",
-        "createdAt"
-      ],
+      "required": ["id", "relyingPartyId", "certificate", "revoked", "createdAt"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetadataResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/SchemaMetadataResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/SchemaMetadataResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/SchemaMetadataResponseDto.schema.json",
@@ -4553,12 +3979,7 @@
           "description": "Level of security (LoS) of this attestation"
         },
         "bindingType": {
-          "enum": [
-            "claim",
-            "key",
-            "biometric",
-            "none"
-          ],
+          "enum": ["claim", "key", "biometric", "none"],
           "type": "string",
           "description": "Required binding type between attestation and holder"
         },
@@ -4566,10 +3987,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "enum": [
-              "dc+sd-jwt",
-              "mso_mdoc"
-            ]
+            "enum": ["dc+sd-jwt", "mso_mdoc"]
           },
           "description": "Credential formats in which this attestation is available"
         },
@@ -4588,15 +4006,7 @@
           }
         },
         "category": {
-          "enum": [
-            "identity",
-            "health",
-            "finance",
-            "education",
-            "mobility",
-            "employment",
-            "other"
-          ],
+          "enum": ["identity", "health", "finance", "education", "mobility", "employment", "other"],
           "type": "string",
           "description": "Domain category for filtering"
         },
@@ -4672,9 +4082,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateSchemaMetadataDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateSchemaMetadataDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateSchemaMetadataDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateSchemaMetadataDto.schema.json",
@@ -4682,15 +4090,7 @@
       "type": "object",
       "properties": {
         "category": {
-          "enum": [
-            "identity",
-            "health",
-            "finance",
-            "education",
-            "mobility",
-            "employment",
-            "other"
-          ],
+          "enum": ["identity", "health", "finance", "education", "mobility", "employment", "other"],
           "type": "string",
           "description": "Domain category for filtering"
         },
@@ -4719,9 +4119,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeprecateSchemaMetadataDto.schema.json",
-    "fileMatch": [
-      "a://b/DeprecateSchemaMetadataDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/DeprecateSchemaMetadataDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeprecateSchemaMetadataDto.schema.json",
@@ -4741,17 +4139,13 @@
           "description": "The version that supersedes this one"
         }
       },
-      "required": [
-        "deprecated"
-      ],
+      "required": ["deprecated"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateAttributeProviderDto.schema.json",
-    "fileMatch": [
-      "a://b/CreateAttributeProviderDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CreateAttributeProviderDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateAttributeProviderDto.schema.json",
@@ -4782,20 +4176,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "auth",
-        "id",
-        "name",
-        "url"
-      ],
+      "required": ["auth", "id", "name", "url"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateAttributeProviderDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateAttributeProviderDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateAttributeProviderDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateAttributeProviderDto.schema.json",
@@ -4831,9 +4218,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateWebhookEndpointDto.schema.json",
-    "fileMatch": [
-      "a://b/CreateWebhookEndpointDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CreateWebhookEndpointDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateWebhookEndpointDto.schema.json",
@@ -4865,20 +4250,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "id",
-        "auth",
-        "name",
-        "url"
-      ],
+      "required": ["id", "auth", "name", "url"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateWebhookEndpointDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateWebhookEndpointDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateWebhookEndpointDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateWebhookEndpointDto.schema.json",
@@ -4915,9 +4293,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListEntityInfo.schema.json",
-    "fileMatch": [
-      "a://b/TrustListEntityInfo*.schema.json"
-    ],
+    "fileMatch": ["a://b/TrustListEntityInfo*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListEntityInfo.schema.json",
@@ -4949,17 +4325,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "name"
-      ],
+      "required": ["name"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InternalTrustListEntity.schema.json",
-    "fileMatch": [
-      "a://b/InternalTrustListEntity*.schema.json"
-    ],
+    "fileMatch": ["a://b/InternalTrustListEntity*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InternalTrustListEntity.schema.json",
@@ -4968,9 +4340,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": [
-            "internal"
-          ]
+          "enum": ["internal"]
         },
         "issuerKeyChainId": {
           "type": "string"
@@ -4982,20 +4352,13 @@
           "$ref": "./TrustListEntityInfo.schema.json"
         }
       },
-      "required": [
-        "type",
-        "issuerKeyChainId",
-        "revocationKeyChainId",
-        "info"
-      ],
+      "required": ["type", "issuerKeyChainId", "revocationKeyChainId", "info"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExternalTrustListEntity.schema.json",
-    "fileMatch": [
-      "a://b/ExternalTrustListEntity*.schema.json"
-    ],
+    "fileMatch": ["a://b/ExternalTrustListEntity*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExternalTrustListEntity.schema.json",
@@ -5004,9 +4367,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": [
-            "external"
-          ]
+          "enum": ["external"]
         },
         "issuerCertPem": {
           "type": "string"
@@ -5018,20 +4379,13 @@
           "$ref": "./TrustListEntityInfo.schema.json"
         }
       },
-      "required": [
-        "type",
-        "issuerCertPem",
-        "revocationCertPem",
-        "info"
-      ],
+      "required": ["type", "issuerCertPem", "revocationCertPem", "info"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListCreateDto.schema.json",
-    "fileMatch": [
-      "a://b/TrustListCreateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/TrustListCreateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListCreateDto.schema.json",
@@ -5072,17 +4426,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "entities"
-      ],
+      "required": ["entities"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustList.schema.json",
-    "fileMatch": [
-      "a://b/TrustList*.schema.json"
-    ],
+    "fileMatch": ["a://b/TrustList*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustList.schema.json",
@@ -5158,9 +4508,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListVersion.schema.json",
-    "fileMatch": [
-      "a://b/TrustListVersion*.schema.json"
-    ],
+    "fileMatch": ["a://b/TrustListVersion*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/TrustListVersion.schema.json",
@@ -5215,9 +4563,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DCQL.schema.json",
-    "fileMatch": [
-      "a://b/DCQL*.schema.json"
-    ],
+    "fileMatch": ["a://b/DCQL*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DCQL.schema.json",
@@ -5237,17 +4583,13 @@
           }
         }
       },
-      "required": [
-        "credentials"
-      ],
+      "required": ["credentials"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificatePurpose.schema.json",
-    "fileMatch": [
-      "a://b/RegistrationCertificatePurpose*.schema.json"
-    ],
+    "fileMatch": ["a://b/RegistrationCertificatePurpose*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificatePurpose.schema.json",
@@ -5261,18 +4603,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "lang",
-        "content"
-      ],
+      "required": ["lang", "content"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateBody.schema.json",
-    "fileMatch": [
-      "a://b/RegistrationCertificateBody*.schema.json"
-    ],
+    "fileMatch": ["a://b/RegistrationCertificateBody*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateBody.schema.json",
@@ -5312,9 +4649,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateRequest.schema.json",
-    "fileMatch": [
-      "a://b/RegistrationCertificateRequest*.schema.json"
-    ],
+    "fileMatch": ["a://b/RegistrationCertificateRequest*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateRequest.schema.json",
@@ -5343,9 +4678,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationAttachment.schema.json",
-    "fileMatch": [
-      "a://b/PresentationAttachment*.schema.json"
-    ],
+    "fileMatch": ["a://b/PresentationAttachment*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationAttachment.schema.json",
@@ -5365,18 +4698,13 @@
           }
         }
       },
-      "required": [
-        "format",
-        "data"
-      ],
+      "required": ["format", "data"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfig.schema.json",
-    "fileMatch": [
-      "a://b/PresentationConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/PresentationConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfig.schema.json",
@@ -5485,21 +4813,13 @@
           "description": "Optional ID of the access certificate to use for signing the presentation request.\nIf not provided, the default access certificate for the tenant will be used.\n\nNote: This is intentionally NOT a TypeORM relationship because CertEntity uses\na composite primary key (id + tenantId), and SQLite cannot create foreign keys\nthat reference only part of a composite primary key. The relationship is handled\nat the application level in the service layer."
         }
       },
-      "required": [
-        "id",
-        "tenant",
-        "dcql_query",
-        "createdAt",
-        "updatedAt"
-      ],
+      "required": ["id", "tenant", "dcql_query", "createdAt", "updatedAt"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ResolveIssuerMetadataDto.schema.json",
-    "fileMatch": [
-      "a://b/ResolveIssuerMetadataDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ResolveIssuerMetadataDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ResolveIssuerMetadataDto.schema.json",
@@ -5513,17 +4833,13 @@
           "example": "https://issuer.example.com/issuers/tenant-a"
         }
       },
-      "required": [
-        "issuerUrl"
-      ],
+      "required": ["issuerUrl"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ResolveSchemaMetadataDto.schema.json",
-    "fileMatch": [
-      "a://b/ResolveSchemaMetadataDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ResolveSchemaMetadataDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ResolveSchemaMetadataDto.schema.json",
@@ -5537,17 +4853,13 @@
           "example": "https://registrar.example.com/schema-metadata/5c0d7dbb-ef2e-448b-b84f-b8103575947b"
         }
       },
-      "required": [
-        "schemaMetadataUrl"
-      ],
+      "required": ["schemaMetadataUrl"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfigCreateDto.schema.json",
-    "fileMatch": [
-      "a://b/PresentationConfigCreateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/PresentationConfigCreateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfigCreateDto.schema.json",
@@ -5630,18 +4942,13 @@
           "description": "Optional ID of the access certificate to use for signing the presentation request.\nIf not provided, the default access certificate for the tenant will be used.\n\nNote: This is intentionally NOT a TypeORM relationship because CertEntity uses\na composite primary key (id + tenantId), and SQLite cannot create foreign keys\nthat reference only part of a composite primary key. The relationship is handled\nat the application level in the service layer."
         }
       },
-      "required": [
-        "id",
-        "dcql_query"
-      ],
+      "required": ["id", "dcql_query"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfigUpdateDto.schema.json",
-    "fileMatch": [
-      "a://b/PresentationConfigUpdateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/PresentationConfigUpdateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationConfigUpdateDto.schema.json",
@@ -5729,9 +5036,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateDefaults.schema.json",
-    "fileMatch": [
-      "a://b/RegistrationCertificateDefaults*.schema.json"
-    ],
+    "fileMatch": ["a://b/RegistrationCertificateDefaults*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrationCertificateDefaults.schema.json",
@@ -5754,9 +5059,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrarConfigResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/RegistrarConfigResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/RegistrarConfigResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RegistrarConfigResponseDto.schema.json",
@@ -5804,21 +5107,13 @@
           "example": true
         }
       },
-      "required": [
-        "registrarUrl",
-        "oidcUrl",
-        "clientId",
-        "username",
-        "hasPassword"
-      ],
+      "required": ["registrarUrl", "oidcUrl", "clientId", "username", "hasPassword"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateRegistrarConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/CreateRegistrarConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CreateRegistrarConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateRegistrarConfigDto.schema.json",
@@ -5865,21 +5160,13 @@
           ]
         }
       },
-      "required": [
-        "registrarUrl",
-        "oidcUrl",
-        "clientId",
-        "username",
-        "password"
-      ],
+      "required": ["registrarUrl", "oidcUrl", "clientId", "username", "password"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateRegistrarConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateRegistrarConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateRegistrarConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/UpdateRegistrarConfigDto.schema.json",
@@ -5931,9 +5218,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateAccessCertificateDto.schema.json",
-    "fileMatch": [
-      "a://b/CreateAccessCertificateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CreateAccessCertificateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CreateAccessCertificateDto.schema.json",
@@ -5946,17 +5231,13 @@
           "example": "my-signing-key"
         }
       },
-      "required": [
-        "keyId"
-      ],
+      "required": ["keyId"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeferredCredentialRequestDto.schema.json",
-    "fileMatch": [
-      "a://b/DeferredCredentialRequestDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/DeferredCredentialRequestDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeferredCredentialRequestDto.schema.json",
@@ -5969,17 +5250,13 @@
           "example": "8xLOxBtZp8"
         }
       },
-      "required": [
-        "transaction_id"
-      ],
+      "required": ["transaction_id"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/NotificationRequestDto.schema.json",
-    "fileMatch": [
-      "a://b/NotificationRequestDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/NotificationRequestDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/NotificationRequestDto.schema.json",
@@ -5991,25 +5268,16 @@
         },
         "event": {
           "type": "string",
-          "enum": [
-            "credential_accepted",
-            "credential_failure",
-            "credential_deleted"
-          ]
+          "enum": ["credential_accepted", "credential_failure", "credential_deleted"]
         }
       },
-      "required": [
-        "notification_id",
-        "event"
-      ],
+      "required": ["notification_id", "event"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/OfferResponse.schema.json",
-    "fileMatch": [
-      "a://b/OfferResponse*.schema.json"
-    ],
+    "fileMatch": ["a://b/OfferResponse*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/OfferResponse.schema.json",
@@ -6027,18 +5295,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "uri",
-        "session"
-      ],
+      "required": ["uri", "session"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CompleteDeferredDto.schema.json",
-    "fileMatch": [
-      "a://b/CompleteDeferredDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CompleteDeferredDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CompleteDeferredDto.schema.json",
@@ -6056,17 +5319,13 @@
           }
         }
       },
-      "required": [
-        "claims"
-      ],
+      "required": ["claims"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeferredOperationResponse.schema.json",
-    "fileMatch": [
-      "a://b/DeferredOperationResponse*.schema.json"
-    ],
+    "fileMatch": ["a://b/DeferredOperationResponse*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DeferredOperationResponse.schema.json",
@@ -6079,13 +5338,7 @@
         },
         "status": {
           "description": "The new status of the transaction",
-          "enum": [
-            "pending",
-            "ready",
-            "retrieved",
-            "expired",
-            "failed"
-          ],
+          "enum": ["pending", "ready", "retrieved", "expired", "failed"],
           "type": "string"
         },
         "message": {
@@ -6093,18 +5346,13 @@
           "description": "Optional message"
         }
       },
-      "required": [
-        "transactionId",
-        "status"
-      ],
+      "required": ["transactionId", "status"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FailDeferredDto.schema.json",
-    "fileMatch": [
-      "a://b/FailDeferredDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/FailDeferredDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FailDeferredDto.schema.json",
@@ -6122,9 +5370,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EC_Public.schema.json",
-    "fileMatch": [
-      "a://b/EC_Public*.schema.json"
-    ],
+    "fileMatch": ["a://b/EC_Public*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EC_Public.schema.json",
@@ -6148,20 +5394,13 @@
           "description": "The y coordinate of the EC public key."
         }
       },
-      "required": [
-        "kty",
-        "crv",
-        "x",
-        "y"
-      ],
+      "required": ["kty", "crv", "x", "y"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/JwksResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/JwksResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/JwksResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/JwksResponseDto.schema.json",
@@ -6176,17 +5415,13 @@
           }
         }
       },
-      "required": [
-        "keys"
-      ],
+      "required": ["keys"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthorizationResponse.schema.json",
-    "fileMatch": [
-      "a://b/AuthorizationResponse*.schema.json"
-    ],
+    "fileMatch": ["a://b/AuthorizationResponse*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AuthorizationResponse.schema.json",
@@ -6222,9 +5457,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Object.schema.json",
-    "fileMatch": [
-      "a://b/Object*.schema.json"
-    ],
+    "fileMatch": ["a://b/Object*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Object.schema.json",
@@ -6236,9 +5469,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ParResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/ParResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ParResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ParResponseDto.schema.json",
@@ -6254,18 +5485,13 @@
           "description": "The expiration time for the request URI in seconds."
         }
       },
-      "required": [
-        "request_uri",
-        "expires_in"
-      ],
+      "required": ["request_uri", "expires_in"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationRequestDto.schema.json",
-    "fileMatch": [
-      "a://b/InteractiveAuthorizationRequestDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/InteractiveAuthorizationRequestDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationRequestDto.schema.json",
@@ -6338,9 +5564,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationCodeResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/InteractiveAuthorizationCodeResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/InteractiveAuthorizationCodeResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationCodeResponseDto.schema.json",
@@ -6358,18 +5582,13 @@
           "example": "auth-code-123"
         }
       },
-      "required": [
-        "status",
-        "code"
-      ],
+      "required": ["status", "code"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationErrorResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/InteractiveAuthorizationErrorResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/InteractiveAuthorizationErrorResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/InteractiveAuthorizationErrorResponseDto.schema.json",
@@ -6387,17 +5606,13 @@
           "example": "Missing required parameter: interaction_types_supported"
         }
       },
-      "required": [
-        "error"
-      ],
+      "required": ["error"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsParResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/ChainedAsParResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ChainedAsParResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsParResponseDto.schema.json",
@@ -6415,18 +5630,13 @@
           "example": 600
         }
       },
-      "required": [
-        "request_uri",
-        "expires_in"
-      ],
+      "required": ["request_uri", "expires_in"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsErrorResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/ChainedAsErrorResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ChainedAsErrorResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsErrorResponseDto.schema.json",
@@ -6443,17 +5653,13 @@
           "description": "Human-readable error description"
         }
       },
-      "required": [
-        "error"
-      ],
+      "required": ["error"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenRequestDto.schema.json",
-    "fileMatch": [
-      "a://b/ChainedAsTokenRequestDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ChainedAsTokenRequestDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenRequestDto.schema.json",
@@ -6486,17 +5692,13 @@
           "description": "PKCE code verifier"
         }
       },
-      "required": [
-        "grant_type"
-      ],
+      "required": ["grant_type"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/ChainedAsTokenResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ChainedAsTokenResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAsTokenResponseDto.schema.json",
@@ -6541,19 +5743,13 @@
           "description": "Refresh token (issued when refresh tokens are enabled)"
         }
       },
-      "required": [
-        "access_token",
-        "token_type",
-        "expires_in"
-      ],
+      "required": ["access_token", "token_type", "expires_in"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProviderCapabilitiesDto.schema.json",
-    "fileMatch": [
-      "a://b/KmsProviderCapabilitiesDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KmsProviderCapabilitiesDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProviderCapabilitiesDto.schema.json",
@@ -6577,9 +5773,7 @@
         },
         "supportedAlgs": {
           "description": "Signing algorithms supported by the provider.",
-          "example": [
-            "ES256"
-          ],
+          "example": ["ES256"],
           "type": "array",
           "items": {
             "type": "string"
@@ -6591,21 +5785,13 @@
           "example": "ES256"
         }
       },
-      "required": [
-        "canImport",
-        "canCreate",
-        "canDelete",
-        "supportedAlgs",
-        "defaultAlg"
-      ],
+      "required": ["canImport", "canCreate", "canDelete", "supportedAlgs", "defaultAlg"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProviderInfoDto.schema.json",
-    "fileMatch": [
-      "a://b/KmsProviderInfoDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KmsProviderInfoDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProviderInfoDto.schema.json",
@@ -6636,19 +5822,13 @@
           ]
         }
       },
-      "required": [
-        "name",
-        "type",
-        "capabilities"
-      ],
+      "required": ["name", "type", "capabilities"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProvidersResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/KmsProvidersResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KmsProvidersResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsProvidersResponseDto.schema.json",
@@ -6668,18 +5848,13 @@
           "example": "db"
         }
       },
-      "required": [
-        "providers",
-        "default"
-      ],
+      "required": ["providers", "default"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DbKmsConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/DbKmsConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/DbKmsConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/DbKmsConfigDto.schema.json",
@@ -6692,9 +5867,7 @@
           "example": "main-vault"
         },
         "type": {
-          "enum": [
-            "db"
-          ],
+          "enum": ["db"],
           "type": "string",
           "description": "Type of the KMS provider.",
           "example": "db"
@@ -6705,18 +5878,13 @@
           "example": "Production HashiCorp Vault for signing keys"
         }
       },
-      "required": [
-        "id",
-        "type"
-      ],
+      "required": ["id", "type"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/VaultKmsConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/VaultKmsConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/VaultKmsConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/VaultKmsConfigDto.schema.json",
@@ -6729,9 +5897,7 @@
           "example": "main-vault"
         },
         "type": {
-          "enum": [
-            "vault"
-          ],
+          "enum": ["vault"],
           "type": "string",
           "description": "Type of the KMS provider.",
           "example": "vault"
@@ -6752,20 +5918,13 @@
           "example": "${VAULT_TOKEN}"
         }
       },
-      "required": [
-        "id",
-        "type",
-        "vaultUrl",
-        "vaultToken"
-      ],
+      "required": ["id", "type", "vaultUrl", "vaultToken"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AwsKmsConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/AwsKmsConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/AwsKmsConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/AwsKmsConfigDto.schema.json",
@@ -6778,9 +5937,7 @@
           "example": "main-vault"
         },
         "type": {
-          "enum": [
-            "aws-kms"
-          ],
+          "enum": ["aws-kms"],
           "type": "string",
           "description": "Type of the KMS provider.",
           "example": "aws-kms"
@@ -6806,19 +5963,13 @@
           "example": "${AWS_SECRET_ACCESS_KEY}"
         }
       },
-      "required": [
-        "id",
-        "type",
-        "region"
-      ],
+      "required": ["id", "type", "region"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Pkcs11KmsConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/Pkcs11KmsConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/Pkcs11KmsConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Pkcs11KmsConfigDto.schema.json",
@@ -6831,9 +5982,7 @@
           "example": "main-vault"
         },
         "type": {
-          "enum": [
-            "pkcs11"
-          ],
+          "enum": ["pkcs11"],
           "type": "string",
           "description": "Type of the KMS provider.",
           "example": "pkcs11"
@@ -6864,21 +6013,13 @@
           "example": false
         }
       },
-      "required": [
-        "id",
-        "type",
-        "library",
-        "slot",
-        "pin"
-      ],
+      "required": ["id", "type", "library", "slot", "pin"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/HttpAuthBaseConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/HttpAuthBaseConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/HttpAuthBaseConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/HttpAuthBaseConfigDto.schema.json",
@@ -6886,27 +6027,18 @@
       "type": "object",
       "properties": {
         "type": {
-          "enum": [
-            "none",
-            "bearer",
-            "oauth2-client-credentials",
-            "mtls"
-          ],
+          "enum": ["none", "bearer", "oauth2-client-credentials", "mtls"],
           "type": "string",
           "description": "Authentication method for the remote KMS service."
         }
       },
-      "required": [
-        "type"
-      ],
+      "required": ["type"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/HttpKmsConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/HttpKmsConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/HttpKmsConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/HttpKmsConfigDto.schema.json",
@@ -6919,9 +6051,7 @@
           "example": "main-vault"
         },
         "type": {
-          "enum": [
-            "http"
-          ],
+          "enum": ["http"],
           "type": "string",
           "description": "Type of the KMS provider.",
           "example": "http"
@@ -6960,19 +6090,13 @@
           "example": false
         }
       },
-      "required": [
-        "id",
-        "type",
-        "baseUrl"
-      ],
+      "required": ["id", "type", "baseUrl"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CscAuthorizeAuthDataDto.schema.json",
-    "fileMatch": [
-      "a://b/CscAuthorizeAuthDataDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CscAuthorizeAuthDataDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CscAuthorizeAuthDataDto.schema.json",
@@ -6990,18 +6114,13 @@
           "example": "123456"
         }
       },
-      "required": [
-        "id",
-        "value"
-      ],
+      "required": ["id", "value"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CscKmsConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/CscKmsConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CscKmsConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CscKmsConfigDto.schema.json",
@@ -7014,9 +6133,7 @@
           "example": "main-vault"
         },
         "type": {
-          "enum": [
-            "csc"
-          ],
+          "enum": ["csc"],
           "type": "string",
           "description": "Type of the KMS provider.",
           "example": "csc"
@@ -7094,22 +6211,13 @@
           }
         }
       },
-      "required": [
-        "id",
-        "type",
-        "baseUrl",
-        "tokenUrl",
-        "clientId",
-        "clientSecret"
-      ],
+      "required": ["id", "type", "baseUrl", "tokenUrl", "clientId", "clientSecret"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/KmsConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KmsConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsConfigDto.schema.json",
@@ -7179,17 +6287,13 @@
           ]
         }
       },
-      "required": [
-        "providers"
-      ],
+      "required": ["providers"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsTenantConfigResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/KmsTenantConfigResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KmsTenantConfigResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KmsTenantConfigResponseDto.schema.json",
@@ -7215,17 +6319,13 @@
           ]
         }
       },
-      "required": [
-        "effectiveConfig"
-      ],
+      "required": ["effectiveConfig"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CertificateInfoDto.schema.json",
-    "fileMatch": [
-      "a://b/CertificateInfoDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CertificateInfoDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/CertificateInfoDto.schema.json",
@@ -7259,17 +6359,13 @@
           "description": "Serial number."
         }
       },
-      "required": [
-        "pem"
-      ],
+      "required": ["pem"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PublicKeyInfoDto.schema.json",
-    "fileMatch": [
-      "a://b/PublicKeyInfoDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/PublicKeyInfoDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PublicKeyInfoDto.schema.json",
@@ -7296,17 +6392,13 @@
           "example": "P-256"
         }
       },
-      "required": [
-        "kty"
-      ],
+      "required": ["kty"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/RotationPolicyResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/RotationPolicyResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyResponseDto.schema.json",
@@ -7331,17 +6423,13 @@
           "description": "Next scheduled rotation date."
         }
       },
-      "required": [
-        "enabled"
-      ],
+      "required": ["enabled"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/KeyChainResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KeyChainResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainResponseDto.schema.json",
@@ -7353,21 +6441,12 @@
           "description": "Unique identifier for the key chain."
         },
         "usageType": {
-          "enum": [
-            "access",
-            "attestation",
-            "trustList",
-            "statusList",
-            "encrypt"
-          ],
+          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"],
           "type": "string",
           "description": "Usage type of the key chain."
         },
         "type": {
-          "enum": [
-            "standalone",
-            "internalChain"
-          ],
+          "enum": ["standalone", "internalChain"],
           "type": "string",
           "description": "Type of key chain (standalone or internalChain)."
         },
@@ -7458,9 +6537,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExportEcJwk.schema.json",
-    "fileMatch": [
-      "a://b/ExportEcJwk*.schema.json"
-    ],
+    "fileMatch": ["a://b/ExportEcJwk*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExportEcJwk.schema.json",
@@ -7499,21 +6576,13 @@
           "description": "Key ID"
         }
       },
-      "required": [
-        "kty",
-        "crv",
-        "x",
-        "y",
-        "d"
-      ],
+      "required": ["kty", "crv", "x", "y", "d"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExportRotationPolicyDto.schema.json",
-    "fileMatch": [
-      "a://b/ExportRotationPolicyDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ExportRotationPolicyDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExportRotationPolicyDto.schema.json",
@@ -7533,17 +6602,13 @@
           "description": "Certificate validity in days."
         }
       },
-      "required": [
-        "enabled"
-      ],
+      "required": ["enabled"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainExportDto.schema.json",
-    "fileMatch": [
-      "a://b/KeyChainExportDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KeyChainExportDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainExportDto.schema.json",
@@ -7559,13 +6624,7 @@
           "description": "Human-readable description."
         },
         "usageType": {
-          "enum": [
-            "access",
-            "attestation",
-            "trustList",
-            "statusList",
-            "encrypt"
-          ],
+          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"],
           "type": "string",
           "description": "Usage type for this key chain."
         },
@@ -7597,19 +6656,13 @@
           ]
         }
       },
-      "required": [
-        "id",
-        "usageType",
-        "key"
-      ],
+      "required": ["id", "usageType", "key"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyCreateDto.schema.json",
-    "fileMatch": [
-      "a://b/RotationPolicyCreateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/RotationPolicyCreateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyCreateDto.schema.json",
@@ -7636,17 +6689,13 @@
           "example": 365
         }
       },
-      "required": [
-        "enabled"
-      ],
+      "required": ["enabled"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainCreateDto.schema.json",
-    "fileMatch": [
-      "a://b/KeyChainCreateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KeyChainCreateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainCreateDto.schema.json",
@@ -7654,22 +6703,13 @@
       "type": "object",
       "properties": {
         "usageType": {
-          "enum": [
-            "access",
-            "attestation",
-            "trustList",
-            "statusList",
-            "encrypt"
-          ],
+          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"],
           "type": "string",
           "description": "Usage type determines the purpose of this key chain (access, attestation, etc.).",
           "example": "attestation"
         },
         "type": {
-          "enum": [
-            "standalone",
-            "internalChain"
-          ],
+          "enum": ["standalone", "internalChain"],
           "type": "string",
           "description": "Type of key chain to create.",
           "example": "internalChain"
@@ -7693,18 +6733,13 @@
           ]
         }
       },
-      "required": [
-        "usageType",
-        "type"
-      ],
+      "required": ["usageType", "type"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EcJwk.schema.json",
-    "fileMatch": [
-      "a://b/EcJwk*.schema.json"
-    ],
+    "fileMatch": ["a://b/EcJwk*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/EcJwk.schema.json",
@@ -7733,21 +6768,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "kty",
-        "x",
-        "y",
-        "crv",
-        "d"
-      ],
+      "required": ["kty", "x", "y", "crv", "d"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyImportDto.schema.json",
-    "fileMatch": [
-      "a://b/RotationPolicyImportDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/RotationPolicyImportDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyImportDto.schema.json",
@@ -7774,17 +6801,13 @@
           "example": 365
         }
       },
-      "required": [
-        "enabled"
-      ],
+      "required": ["enabled"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainImportDto.schema.json",
-    "fileMatch": [
-      "a://b/KeyChainImportDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KeyChainImportDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainImportDto.schema.json",
@@ -7808,13 +6831,7 @@
           "description": "Human-readable description."
         },
         "usageType": {
-          "enum": [
-            "access",
-            "attestation",
-            "trustList",
-            "statusList",
-            "encrypt"
-          ],
+          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"],
           "type": "string",
           "description": "Usage type for this key chain."
         },
@@ -7838,18 +6855,13 @@
           ]
         }
       },
-      "required": [
-        "key",
-        "usageType"
-      ],
+      "required": ["key", "usageType"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyUpdateDto.schema.json",
-    "fileMatch": [
-      "a://b/RotationPolicyUpdateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/RotationPolicyUpdateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/RotationPolicyUpdateDto.schema.json",
@@ -7878,9 +6890,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainUpdateDto.schema.json",
-    "fileMatch": [
-      "a://b/KeyChainUpdateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KeyChainUpdateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/KeyChainUpdateDto.schema.json",
@@ -7909,9 +6919,7 @@
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationRequest.schema.json",
-    "fileMatch": [
-      "a://b/PresentationRequest*.schema.json"
-    ],
+    "fileMatch": ["a://b/PresentationRequest*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/PresentationRequest.schema.json",
@@ -7921,10 +6929,7 @@
         "response_type": {
           "type": "string",
           "description": "The type of response expected from the presentation request.",
-          "enum": [
-            "uri",
-            "dc-api"
-          ]
+          "enum": ["uri", "dc-api"]
         },
         "requestId": {
           "type": "string",
@@ -7955,18 +6960,13 @@
           }
         }
       },
-      "required": [
-        "response_type",
-        "requestId"
-      ],
+      "required": ["response_type", "requestId"],
       "additionalProperties": false
     }
   },
   {
     "uri": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FileUploadDto.schema.json",
-    "fileMatch": [
-      "a://b/FileUploadDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/FileUploadDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/FileUploadDto.schema.json",
@@ -7978,9 +6978,7 @@
           "format": "binary"
         }
       },
-      "required": [
-        "file"
-      ],
+      "required": ["file"],
       "additionalProperties": false
     }
   }

--- a/docs/getting-started/issuance/issuance-configuration.md
+++ b/docs/getting-started/issuance/issuance-configuration.md
@@ -19,7 +19,7 @@ authorization, token behavior, and trust-related requirements.
 
 ## Configuration Fields
 
-- `authorizationServers` (array, optional): Managed authorization server definitions. Supports `external`, `oid4vp`, and `chained` types.
+- `authorizationServers` (array, required): Managed authorization server definitions. Must contain at least one entry and supports `external`, `oid4vp`, `chained`, and `built-in` types.
 - `batchSize` (number, optional): Value to determine the amount of credentials that are issued in a batch. Default is 1.
 - `dPopRequired` (boolean, optional): Indicates whether DPoP is required for the issuance process. Default value is true.
 - `signingKeyId` (string, optional): Key ID used for signing access tokens. If omitted, the default signing key for the tenant is used.
@@ -44,6 +44,7 @@ authorization, token behavior, and trust-related requirements.
 ## Authorization Servers (`authorizationServers`)
 
 Use `authorizationServers` to define wallet-facing AS behavior for OID4VCI auth-code flows.
+The array must contain at least one entry.
 
 ### Example
 
@@ -98,14 +99,14 @@ Use `authorizationServers` to define wallet-facing AS behavior for OID4VCI auth-
 
 ### Common Fields
 
-| Field                   | Type    | Required                | Description                                        |
-| ----------------------- | ------- | ----------------------- | -------------------------------------------------- |
-| `type`                  | string  | Yes                     | One of `external`, `oid4vp`, `chained`.            |
-| `label`                 | string  | No                      | Optional UI label.                                 |
-| `enabled`               | boolean | No                      | Enables/disables this entry. Default `true`.       |
-| `requireDPoP`           | boolean | No (`oid4vp`/`chained`) | Require DPoP proofs on token requests for this AS. |
-| `token.lifetimeSeconds` | number  | No (`oid4vp`/`chained`) | Access token lifetime for this AS.                 |
-| `token.signingKeyId`    | string  | No (`oid4vp`/`chained`) | Key used to sign AS-issued tokens.                 |
+| Field                   | Type    | Required                | Description                                         |
+| ----------------------- | ------- | ----------------------- | --------------------------------------------------- |
+| `type`                  | string  | Yes                     | One of `external`, `oid4vp`, `chained`, `built-in`. |
+| `label`                 | string  | No                      | Optional UI label.                                  |
+| `enabled`               | boolean | No                      | Enables/disables this entry. Default `true`.        |
+| `requireDPoP`           | boolean | No (`oid4vp`/`chained`) | Require DPoP proofs on token requests for this AS.  |
+| `token.lifetimeSeconds` | number  | No (`oid4vp`/`chained`) | Access token lifetime for this AS.                  |
+| `token.signingKeyId`    | string  | No (`oid4vp`/`chained`) | Key used to sign AS-issued tokens.                  |
 
 ### Type-Specific Fields
 

--- a/docs/migration/5.x-to-6.0.md
+++ b/docs/migration/5.x-to-6.0.md
@@ -34,6 +34,9 @@ with type set to one of:
 - external
 - oid4vp
 - chained
+- built-in
+
+The `authorizationServers` array must contain at least one entry.
 
 ### Before (5.x)
 

--- a/packages/eudiplo-sdk-core/src/config/derive.ts
+++ b/packages/eudiplo-sdk-core/src/config/derive.ts
@@ -8,13 +8,37 @@ const JSON_SCHEMA_DRAFT_2020_12 = "https://json-schema.org/draft/2020-12/schema"
 
 type Segment = string | number | null;
 
-function resolveChildPath(parentPath: Segment[], childPath: Segment[]): Segment[] {
+function resolveChildPath(
+  parentPath: Segment[],
+  parentType: ClaimFieldDefinition["type"],
+  childPath: Segment[],
+): Segment[] {
   if (childPath.length >= parentPath.length) {
     const startsWithParent = parentPath.every((seg, i) => seg === childPath[i]);
     if (startsWithParent) {
       return childPath;
     }
   }
+
+  // For array parents, support relative child paths without an explicit
+  // array marker (null/number) by inserting the item step automatically.
+  // Breaking change: relative child paths using a leading null marker are rejected.
+  if (
+    parentType === "array" &&
+    childPath.length > 0
+  ) {
+    if (childPath[0] === null) {
+      throw new Error(
+        "Relative child paths under array parents must not start with null. " +
+          "Use ['field'] instead of [null, 'field']."
+      );
+    }
+
+    if (typeof childPath[0] !== "number") {
+      return [...parentPath, null, ...childPath];
+    }
+  }
+
   return [...parentPath, ...childPath];
 }
 
@@ -28,7 +52,7 @@ export function flattenFields(fields: ClaimFieldDefinition[]): ClaimFieldDefinit
     if (children && children.length > 0) {
       const resolvedChildren: ClaimFieldDefinition[] = children.map((child) => ({
         ...child,
-        path: resolveChildPath(field.path, child.path),
+        path: resolveChildPath(field.path, field.type, child.path),
       }));
       result.push(...flattenFields(resolvedChildren));
     }

--- a/packages/eudiplo-sdk-core/test/derive.spec.ts
+++ b/packages/eudiplo-sdk-core/test/derive.spec.ts
@@ -143,4 +143,96 @@ describe("config derive helpers", () => {
       required: ["nationalities"],
     });
   });
+
+  it("infers array item step for children when parent type is array", () => {
+    const fields: ClaimFieldDefinition[] = [
+      {
+        path: ["driving_privileges"],
+        type: "array",
+        defaultValue: [
+          {
+            vehicle_category_code: "B",
+            codes: [{ code: "B96" }],
+          },
+        ],
+        children: [
+          {
+            path: ["vehicle_category_code"],
+            type: "string",
+            mandatory: true,
+          },
+          {
+            path: ["codes"],
+            type: "array",
+            children: [
+              {
+                path: ["code"],
+                type: "string",
+                mandatory: true,
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    expect(buildClaims(fields)).toEqual({
+      driving_privileges: [
+        {
+          vehicle_category_code: "B",
+          codes: [{ code: "B96" }],
+        },
+      ],
+    });
+
+    expect(buildJsonSchema(fields)).toEqual({
+      $schema: "https://json-schema.org/draft/2020-12/schema",
+      type: "object",
+      properties: {
+        driving_privileges: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              vehicle_category_code: {
+                type: "string",
+              },
+              codes: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    code: {
+                      type: "string",
+                    },
+                  },
+                  required: ["code"],
+                },
+              },
+            },
+            required: ["vehicle_category_code"],
+          },
+        },
+      },
+    });
+  });
+
+  it("rejects relative array child paths that start with null", () => {
+    const fields: ClaimFieldDefinition[] = [
+      {
+        path: ["driving_privileges"],
+        type: "array",
+        children: [
+          {
+            path: [null, "vehicle_category_code"],
+            type: "string",
+          },
+        ],
+      },
+    ];
+
+    expect(() => buildJsonSchema(fields)).toThrow(
+      "Relative child paths under array parents must not start with null"
+    );
+  });
 });

--- a/schemas/BuiltInAuthorizationServerConfig.schema.json
+++ b/schemas/BuiltInAuthorizationServerConfig.schema.json
@@ -1,19 +1,16 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ManagedAuthorizationServerConfig.schema.json",
-  "title": "ManagedAuthorizationServerConfig",
+  "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/BuiltInAuthorizationServerConfig.schema.json",
+  "title": "BuiltInAuthorizationServerConfig",
   "type": "object",
   "properties": {
     "type": {
       "enum": [
-        "external",
-        "oid4vp",
-        "chained",
         "built-in"
       ],
       "type": "string",
       "description": "Authorization server implementation type",
-      "example": "external"
+      "example": "built-in"
     },
     "label": {
       "type": "string",
@@ -24,6 +21,19 @@
       "type": "boolean",
       "description": "Whether this managed authorization server is enabled",
       "default": true
+    },
+    "token": {
+      "description": "Token configuration for this authorization server",
+      "allOf": [
+        {
+          "$ref": "./ChainedAsTokenConfig.schema.json"
+        }
+      ]
+    },
+    "requireDPoP": {
+      "type": "boolean",
+      "description": "Require DPoP for token requests issued by this authorization server",
+      "default": false
     }
   },
   "required": [

--- a/schemas/ChainedAsTokenConfig.schema.json
+++ b/schemas/ChainedAsTokenConfig.schema.json
@@ -13,6 +13,17 @@
     "signingKeyId": {
       "type": "string",
       "description": "Key ID for token signing"
+    },
+    "refreshTokenEnabled": {
+      "type": "boolean",
+      "description": "Whether refresh tokens should be issued",
+      "default": true
+    },
+    "refreshTokenExpiresInSeconds": {
+      "type": "number",
+      "description": "Refresh token lifetime in seconds",
+      "minimum": 60,
+      "default": 2592000
     }
   },
   "additionalProperties": false

--- a/schemas/ChainedAuthorizationServerConfig.schema.json
+++ b/schemas/ChainedAuthorizationServerConfig.schema.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ChainedAuthorizationServerConfig.schema.json",
+  "title": "ChainedAuthorizationServerConfig",
+  "type": "object",
+  "properties": {
+    "type": {
+      "enum": [
+        "chained"
+      ],
+      "type": "string",
+      "description": "Authorization server implementation type",
+      "example": "chained"
+    },
+    "label": {
+      "type": "string",
+      "description": "Human-friendly label for the UI",
+      "example": "PID Authorization Server"
+    },
+    "enabled": {
+      "type": "boolean",
+      "description": "Whether this managed authorization server is enabled",
+      "default": true
+    },
+    "upstream": {
+      "description": "Upstream OIDC provider configuration for chained mode",
+      "allOf": [
+        {
+          "$ref": "./UpstreamOidcConfig.schema.json"
+        }
+      ]
+    },
+    "token": {
+      "description": "Token configuration for this authorization server",
+      "allOf": [
+        {
+          "$ref": "./ChainedAsTokenConfig.schema.json"
+        }
+      ]
+    },
+    "requireDPoP": {
+      "type": "boolean",
+      "description": "Require DPoP for token requests issued by this authorization server",
+      "default": false
+    }
+  },
+  "required": [
+    "type",
+    "upstream"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/CredentialQuery.schema.json
+++ b/schemas/CredentialQuery.schema.json
@@ -4,6 +4,16 @@
   "title": "CredentialQuery",
   "type": "object",
   "properties": {
+    "claim_sets": {
+      "type": "array",
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "description": "Ordered alternative claim combinations for this credential query."
+    },
     "id": {
       "type": "string",
       "pattern": "^[A-Za-z0-9_-]+$"
@@ -18,15 +28,6 @@
       "type": "array",
       "items": {
         "$ref": "./ClaimsQuery.schema.json"
-      }
-    },
-    "claim_sets": {
-      "type": "array",
-      "items": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        }
       }
     },
     "meta": {

--- a/schemas/ExternalAuthorizationServerConfig.schema.json
+++ b/schemas/ExternalAuthorizationServerConfig.schema.json
@@ -1,15 +1,12 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ManagedAuthorizationServerConfig.schema.json",
-  "title": "ManagedAuthorizationServerConfig",
+  "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/ExternalAuthorizationServerConfig.schema.json",
+  "title": "ExternalAuthorizationServerConfig",
   "type": "object",
   "properties": {
     "type": {
       "enum": [
-        "external",
-        "oid4vp",
-        "chained",
-        "built-in"
+        "external"
       ],
       "type": "string",
       "description": "Authorization server implementation type",
@@ -24,10 +21,17 @@
       "type": "boolean",
       "description": "Whether this managed authorization server is enabled",
       "default": true
+    },
+    "issuer": {
+      "type": "string",
+      "format": "uri",
+      "description": "Issuer URL for external authorization servers",
+      "example": "https://auth.example.com"
     }
   },
   "required": [
-    "type"
+    "type",
+    "issuer"
   ],
   "additionalProperties": false
 }

--- a/schemas/IssuanceConfig.schema.json
+++ b/schemas/IssuanceConfig.schema.json
@@ -47,11 +47,6 @@
         }
       ]
     },
-    "refreshTokenEnabled": {
-      "type": "boolean",
-      "description": "Whether refresh tokens should be issued for OID4VCI token responses.",
-      "default": true
-    },
     "credentialResponseEncryption": {
       "type": "boolean",
       "description": "Whether `credential_response_encryption` should be advertised in the credential issuer metadata.",
@@ -61,12 +56,6 @@
       "type": "boolean",
       "description": "Whether `credential_request_encryption` should be advertised in the credential issuer metadata.",
       "default": false
-    },
-    "refreshTokenExpiresInSeconds": {
-      "type": "number",
-      "description": "Refresh token lifetime in seconds. Defaults to 2592000 (30 days).",
-      "default": 2592000,
-      "nullable": true
     },
     "txCodeMaxAttempts": {
       "type": "number",
@@ -100,10 +89,6 @@
       "items": {
         "type": "string"
       }
-    },
-    "preferredAuthServer": {
-      "type": "string",
-      "description": "The URL of the preferred authorization server for wallet-initiated flows.\nWhen set, this AS is placed first in the `authorization_servers` array\nof the credential issuer metadata, signaling wallets to use it by default.\nMust match one of the configured auth servers, the chained AS URL, or \"built-in\"."
     },
     "display": {
       "type": "array",

--- a/schemas/IssuanceConfig.schema.json
+++ b/schemas/IssuanceConfig.schema.json
@@ -9,11 +9,33 @@
       "description": "Key ID for signing access tokens. If unset, the default signing key is used."
     },
     "authorizationServers": {
-      "nullable": true,
-      "description": "Dedicated managed authorization servers hosted by this issuer.\nEach entry creates a distinct AS endpoint and can be bound to a different\npresentation configuration.",
       "type": "array",
+      "description": "Dedicated managed authorization servers hosted by this issuer. At least one entry is required.",
+      "minItems": 1,
       "items": {
-        "$ref": "./ManagedAuthorizationServerConfig.schema.json"
+        "oneOf": [
+          {
+            "$ref": "./ExternalAuthorizationServerConfig.schema.json"
+          },
+          {
+            "$ref": "./Oid4VpAuthorizationServerConfig.schema.json"
+          },
+          {
+            "$ref": "./ChainedAuthorizationServerConfig.schema.json"
+          },
+          {
+            "$ref": "./BuiltInAuthorizationServerConfig.schema.json"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "external": "#/components/schemas/ExternalAuthorizationServerConfig",
+            "oid4vp": "#/components/schemas/Oid4VpAuthorizationServerConfig",
+            "chained": "#/components/schemas/ChainedAuthorizationServerConfig",
+            "built-in": "#/components/schemas/BuiltInAuthorizationServerConfig"
+          }
+        }
       }
     },
     "federation": {
@@ -108,6 +130,7 @@
     }
   },
   "required": [
+    "authorizationServers",
     "tenant",
     "display",
     "createdAt",

--- a/schemas/IssuanceDto.schema.json
+++ b/schemas/IssuanceDto.schema.json
@@ -9,11 +9,33 @@
       "description": "Key ID for signing access tokens. If unset, the default signing key is used."
     },
     "authorizationServers": {
-      "nullable": true,
-      "description": "Dedicated managed authorization servers hosted by this issuer.\nEach entry creates a distinct AS endpoint and can be bound to a different\npresentation configuration.",
       "type": "array",
+      "description": "Dedicated managed authorization servers hosted by this issuer. At least one entry is required.",
+      "minItems": 1,
       "items": {
-        "$ref": "./ManagedAuthorizationServerConfig.schema.json"
+        "oneOf": [
+          {
+            "$ref": "./ExternalAuthorizationServerConfig.schema.json"
+          },
+          {
+            "$ref": "./Oid4VpAuthorizationServerConfig.schema.json"
+          },
+          {
+            "$ref": "./ChainedAuthorizationServerConfig.schema.json"
+          },
+          {
+            "$ref": "./BuiltInAuthorizationServerConfig.schema.json"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "external": "#/components/schemas/ExternalAuthorizationServerConfig",
+            "oid4vp": "#/components/schemas/Oid4VpAuthorizationServerConfig",
+            "chained": "#/components/schemas/ChainedAuthorizationServerConfig",
+            "built-in": "#/components/schemas/BuiltInAuthorizationServerConfig"
+          }
+        }
       }
     },
     "federation": {
@@ -90,6 +112,7 @@
     }
   },
   "required": [
+    "authorizationServers",
     "display"
   ],
   "additionalProperties": false

--- a/schemas/IssuanceDto.schema.json
+++ b/schemas/IssuanceDto.schema.json
@@ -47,11 +47,6 @@
         }
       ]
     },
-    "refreshTokenEnabled": {
-      "type": "boolean",
-      "description": "Whether refresh tokens should be issued for OID4VCI token responses.",
-      "default": true
-    },
     "credentialResponseEncryption": {
       "type": "boolean",
       "description": "Whether `credential_response_encryption` should be advertised in the credential issuer metadata.",
@@ -61,12 +56,6 @@
       "type": "boolean",
       "description": "Whether `credential_request_encryption` should be advertised in the credential issuer metadata.",
       "default": false
-    },
-    "refreshTokenExpiresInSeconds": {
-      "type": "number",
-      "description": "Refresh token lifetime in seconds. Defaults to 2592000 (30 days).",
-      "default": 2592000,
-      "nullable": true
     },
     "txCodeMaxAttempts": {
       "type": "number",
@@ -92,10 +81,6 @@
       "items": {
         "type": "string"
       }
-    },
-    "preferredAuthServer": {
-      "type": "string",
-      "description": "The URL of the preferred authorization server for wallet-initiated flows.\nWhen set, this AS is placed first in the `authorization_servers` array\nof the credential issuer metadata, signaling wallets to use it by default.\nMust match one of the configured auth servers, the chained AS URL, or \"built-in\"."
     },
     "display": {
       "type": "array",

--- a/schemas/ManagedAuthorizationServerConfig.schema.json
+++ b/schemas/ManagedAuthorizationServerConfig.schema.json
@@ -18,7 +18,8 @@
       "enum": [
         "external",
         "oid4vp",
-        "chained"
+        "chained",
+        "built-in"
       ],
       "type": "string",
       "description": "Authorization server implementation type",

--- a/schemas/Oid4VpAuthorizationServerConfig.schema.json
+++ b/schemas/Oid4VpAuthorizationServerConfig.schema.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/openwallet-foundation/eudiplo/refs/heads/main/schemas/Oid4VpAuthorizationServerConfig.schema.json",
+  "title": "Oid4VpAuthorizationServerConfig",
+  "type": "object",
+  "properties": {
+    "type": {
+      "enum": [
+        "oid4vp"
+      ],
+      "type": "string",
+      "description": "Authorization server implementation type",
+      "example": "oid4vp"
+    },
+    "label": {
+      "type": "string",
+      "description": "Human-friendly label for the UI",
+      "example": "PID Authorization Server"
+    },
+    "enabled": {
+      "type": "boolean",
+      "description": "Whether this managed authorization server is enabled",
+      "default": true
+    },
+    "id": {
+      "type": "string",
+      "description": "Stable identifier used in the AS URL path",
+      "example": "pid-auth"
+    },
+    "presentationConfigId": {
+      "type": "string",
+      "description": "Presentation configuration ID to use for OID4VP",
+      "example": "playground-pid"
+    },
+    "immediateWalletRedirect": {
+      "type": "boolean",
+      "description": "Immediately redirect the browser into the wallet OID4VP request",
+      "default": true
+    },
+    "token": {
+      "description": "Token configuration for this authorization server",
+      "allOf": [
+        {
+          "$ref": "./ChainedAsTokenConfig.schema.json"
+        }
+      ]
+    },
+    "requireDPoP": {
+      "type": "boolean",
+      "description": "Require DPoP for token requests issued by this authorization server",
+      "default": false
+    }
+  },
+  "required": [
+    "type",
+    "id",
+    "presentationConfigId"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/Session.schema.json
+++ b/schemas/Session.schema.json
@@ -75,6 +75,7 @@
       ]
     },
     "offer": {
+      "nullable": true,
       "description": "Credential offer object containing details about the credential offer or presentation request.\nEncrypted at rest.",
       "type": "object"
     },
@@ -181,7 +182,7 @@
     "consumedAt": {
       "format": "date-time",
       "type": "string",
-      "description": "Timestamp when the session offer was consumed.\nNull if the offer has not yet been consumed."
+      "description": "Timestamp of the first consumption event for the session offer.\nFor OID4VCI this can be URI resolution or later flow completion.\nNull if no consumption event has happened yet."
     }
   },
   "required": [


### PR DESCRIPTION
## 📝 Description

Moves refresh-token behavior from issuance config into authorization server configuration, unifies authorization server handling in the issuance UI, and refactors credential field editing to support a consistent flat↔nested model for both SD-JWT and mDOC.

Also updates SDK derive logic for array-child path handling and adds regression tests.

Fixes #N/A

## 🔄 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [x] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test improvements
- [ ] 🏗️ Build/CI changes

## 💥 Breaking Changes (if applicable)

If this is a breaking change, list what is affected:

- **API changes**: Refresh-token policy is no longer sourced from issuance config; chained authorization behavior now reads token-related settings from authorization server config.
- **Environment variables**: None.
- **Config import format**: Nested child field paths under array parents now expect relative paths without leading `null`; SDK rejects relative array child paths starting with `null`.
- **Database**: Migration included to remove refresh-token settings from issuance configuration storage.

## 🧪 Testing

Describe the tests that you ran to verify your changes:

- [x] Unit tests pass
- [ ] Integration tests pass
- [ ] E2E tests pass
- [x] Manual testing performed

**Test Configuration**:

- Node.js version: local dev environment
- OS: macOS
- Test environment: local workspace

Executed:
- `pnpm --filter @eudiplo/sdk-core test`
- `pnpm --filter @eudiplo/client build`

## 📸 Screenshots (if applicable)

N/A

## ✔️ Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## 📋 Additional Notes

- Issuance config create/show pages were refactored to use a unified authorization server model and improved table/accordion behavior.
- Credential field editor now supports a shared path parsing workflow with nested reconstruction on save.
- Sonar MCP `analyze_file_list` calls failed tool-side during local workflow, but builds/tests above passed.