### PR TITLE
feat: add CWT status list negotiation, verifier support, tests, and docs

### DIFF
--- a/apps/backend/src/crypto/key/key-chain-signing.service.ts
+++ b/apps/backend/src/crypto/key/key-chain-signing.service.ts
@@ -87,6 +87,26 @@ export class KeyChainSigningService {
         return `${signingInput}.${sigB64}`;
     }
 
+    @Span("keychain.signBytes")
+    async signBytes(
+        data: Uint8Array,
+        tenantId: string,
+        keyId?: string,
+        alg?: KmsSigningAlg,
+    ): Promise<Uint8Array> {
+        const keyChain = keyId
+            ? await this.getKeyChain(tenantId, keyId)
+            : await this.getFirstKeyChain(tenantId);
+
+        const adapter = this.kmsRegistry.resolve(
+            keyChain.kmsProvider,
+            keyChain.tenantId,
+        );
+        const ref = this.refFromEntity(keyChain);
+
+        return adapter.sign(ref, data, alg);
+    }
+
     getPublicKey(type: "jwk", tenantId: string, keyId?: string): Promise<JWK>;
     getPublicKey(
         type: "pem",

--- a/apps/backend/src/crypto/key/key-chain.service.ts
+++ b/apps/backend/src/crypto/key/key-chain.service.ts
@@ -517,6 +517,14 @@ export class KeyChainService {
         return this.signingService.signJWT(payload, header, tenantId, keyId);
     }
 
+    async signBytes(
+        data: Uint8Array,
+        tenantId: string,
+        keyId?: string,
+    ): Promise<Uint8Array> {
+        return this.signingService.signBytes(data, tenantId, keyId);
+    }
+
     getPublicKey(type: "jwk", tenantId: string, keyId?: string): Promise<JWK>;
     getPublicKey(
         type: "pem",

--- a/apps/backend/src/issuer/lifecycle/status/status-list.controller.ts
+++ b/apps/backend/src/issuer/lifecycle/status/status-list.controller.ts
@@ -1,10 +1,12 @@
-import { Controller, Get, Header, Param } from "@nestjs/common";
+import { Controller, Get, Header, Headers, Param, Res } from "@nestjs/common";
 import {
     ApiExtraModels,
     ApiOkResponse,
     ApiOperation,
+    ApiProduces,
     ApiTags,
 } from "@nestjs/swagger";
+import { Response } from "express";
 import { StatusListAggregationDto } from "./dto/status-list-aggregation.dto";
 import { StatusListImportDto } from "./dto/status-list-import.dto";
 import { StatusListService } from "./status-list.service";
@@ -19,15 +21,38 @@ export class StatusListController {
      * Get the JWT for a specific status list.
      * @param tenantId The tenant ID.
      * @param listId The status list ID.
-     * @returns The status list JWT.
+     * @returns The status list token (JWT or CWT).
      */
     @Get("status-list/:listId")
-    @Header("Content-Type", "application/statuslist+jwt")
-    getList(
+    @ApiProduces("application/statuslist+jwt", "application/statuslist+cwt")
+    async getList(
+        @Res({ passthrough: true }) res: Response,
         @Param("tenantId") tenantId: string,
         @Param("listId") listId: string,
+        @Headers("accept") acceptHeader?: string,
+        @Headers("content-type") contentTypeHeader?: string,
     ) {
+        const wantsCwt = this.prefersCwt(acceptHeader, contentTypeHeader);
+
+        if (wantsCwt) {
+            res.setHeader("Content-Type", "application/statuslist+cwt");
+            const cwt = await this.statusListService.getListCwt(
+                tenantId,
+                listId,
+            );
+            res.send(Buffer.from(cwt));
+            return;
+        }
+
+        res.setHeader("Content-Type", "application/statuslist+jwt");
         return this.statusListService.getListJwt(tenantId, listId);
+    }
+
+    private prefersCwt(acceptHeader?: string, contentTypeHeader?: string) {
+        const headers = `${acceptHeader ?? ""},${contentTypeHeader ?? ""}`
+            .toLowerCase()
+            .replace(/\s+/g, "");
+        return headers.includes("application/statuslist+cwt");
     }
 
     /**

--- a/apps/backend/src/issuer/lifecycle/status/status-list.service.ts
+++ b/apps/backend/src/issuer/lifecycle/status/status-list.service.ts
@@ -13,10 +13,15 @@ import {
     BitsPerStatus,
     createHeaderAndPayload,
     JWTwithStatusListPayload,
+    getListFromStatusListJWT,
     StatusList,
+    StatusListCwt,
     StatusListJWTHeaderParameters,
 } from "@owf/token-status-list";
 import { JwtPayload } from "@sd-jwt/core";
+import { SignatureAlgorithm } from "@owf/cose";
+import { X509Certificate } from "@peculiar/x509";
+import { decodeJwt } from "jose";
 import { IsNull, Repository } from "typeorm";
 import { v4 } from "uuid";
 import { TenantEntity } from "../../../auth/tenant/entitites/tenant.entity";
@@ -59,6 +64,31 @@ export class StatusListService {
             ImportPhase.FINAL,
             (tenantId) => this.importForTenant(tenantId),
         );
+    }
+
+    private async getSigningCert(entry: StatusListEntity) {
+        // Use the pinned key chain if specified, otherwise use the tenant's default status list key chain.
+        // Falls back to attestation key chains when no dedicated status list key exists.
+        const cert = entry.keyChainId
+            ? await this.certService.find({
+                  tenantId: entry.tenantId,
+                  type: KeyUsageType.StatusList,
+                  fallbackType: KeyUsageType.Attestation,
+                  keyId: entry.keyChainId,
+              })
+            : await this.certService.find({
+                  tenantId: entry.tenantId,
+                  type: KeyUsageType.StatusList,
+                  fallbackType: KeyUsageType.Attestation,
+              });
+
+        if (!cert) {
+            throw new NotFoundException(
+                `Key chain ${entry.keyChainId} not found for tenant ${entry.tenantId}`,
+            );
+        }
+
+        return cert;
     }
 
     /**
@@ -200,26 +230,7 @@ export class StatusListService {
             ttl, // Maximum cache time in seconds for verifiers
         };
 
-        // Use the pinned key chain if specified, otherwise use the tenant's default status list key chain.
-        // Falls back to attestation key chains when no dedicated status list key exists.
-        const cert = entry.keyChainId
-            ? await this.certService.find({
-                  tenantId: entry.tenantId,
-                  type: KeyUsageType.StatusList,
-                  fallbackType: KeyUsageType.Attestation,
-                  keyId: entry.keyChainId,
-              })
-            : await this.certService.find({
-                  tenantId: entry.tenantId,
-                  type: KeyUsageType.StatusList,
-                  fallbackType: KeyUsageType.Attestation,
-              });
-
-        if (!cert) {
-            throw new NotFoundException(
-                `Key chain ${entry.keyChainId} not found for tenant ${entry.tenantId}`,
-            );
-        }
+        const cert = await this.getSigningCert(entry);
 
         const preHeader: StatusListJWTHeaderParameters = {
             alg: "ES256",
@@ -317,6 +328,76 @@ export class StatusListService {
         }
 
         return list.jwt!;
+    }
+
+    /**
+     * Get the CWT for a specific status list.
+     * The CWT content follows the same freshness policy as JWT status list tokens.
+     */
+    async getListCwt(tenantId: string, listId: string): Promise<Uint8Array> {
+        let list = await this.getListById(tenantId, listId);
+
+        const needsRegeneration =
+            !list.jwt || !list.expiresAt || list.expiresAt <= new Date();
+
+        if (needsRegeneration) {
+            await this.createListJWT(list);
+            list = await this.getListById(tenantId, listId);
+        }
+
+        const jwt = list.jwt!;
+        const jwtPayload = decodeJwt(jwt);
+        const statusList = getListFromStatusListJWT(jwt);
+        const cert = await this.getSigningCert(list);
+
+        const subject =
+            typeof jwtPayload.sub === "string"
+                ? jwtPayload.sub
+                : this.buildStatusListUri(tenantId, listId);
+        const issuedAt =
+            typeof jwtPayload.iat === "number"
+                ? new Date(jwtPayload.iat * 1000)
+                : new Date();
+        const expirationTime =
+            typeof jwtPayload.exp === "number"
+                ? new Date(jwtPayload.exp * 1000)
+                : undefined;
+        const ttl =
+            typeof jwtPayload.ttl === "number" ? jwtPayload.ttl : undefined;
+
+        const x5chain = cert.crt.map(
+            (pem) => new Uint8Array(new X509Certificate(pem).rawData),
+        );
+
+        const cwt = new StatusListCwt({
+            payload: {
+                subject,
+                issuedAt,
+                expirationTime,
+                timeToLive: ttl,
+                statusList,
+            },
+            protectedHeaders: new Map<number, unknown>([
+                [1, SignatureAlgorithm.ES256],
+                [4, new TextEncoder().encode(cert.keyId)],
+            ]),
+            unprotectedHeaders: new Map<number, unknown>([[33, x5chain]]),
+        });
+
+        return cwt.signAndEncode(
+            {
+                signingKey: { algorithm: SignatureAlgorithm.ES256 } as never,
+                algorithm: SignatureAlgorithm.ES256,
+            },
+            {
+                sign: async ({ toBeSigned }) =>
+                    this.keyChainService.signBytes(
+                        toBeSigned,
+                        tenantId,
+                        cert.keyId,
+                    ),
+            },
+        );
     }
 
     /**

--- a/apps/backend/src/shared/trust/status-list-verifier.service.ts
+++ b/apps/backend/src/shared/trust/status-list-verifier.service.ts
@@ -165,7 +165,9 @@ export class StatusListVerifierService {
             statusList = statusListCwt.payload.statusList;
             ttl = statusListCwt.payload.timeToLive;
             exp = statusListCwt.payload.expirationTime
-                ? Math.floor(statusListCwt.payload.expirationTime.getTime() / 1000)
+                ? Math.floor(
+                      statusListCwt.payload.expirationTime.getTime() / 1000,
+                  )
                 : undefined;
         }
 

--- a/apps/backend/src/shared/trust/status-list-verifier.service.ts
+++ b/apps/backend/src/shared/trust/status-list-verifier.service.ts
@@ -4,6 +4,7 @@ import {
     getListFromStatusListJWT,
     getStatusListFromJWT,
     StatusList,
+    StatusListCwt,
     StatusListEntry,
     StatusType,
 } from "@owf/token-status-list";
@@ -148,13 +149,25 @@ export class StatusListVerifierService {
 
         // Fetch and cache
         this.logger.debug(`Fetching status list from ${uri}`);
-        const statusListJwt = await this.fetchStatusListJwt(uri);
-        const statusList = getListFromStatusListJWT(statusListJwt);
+        const statusListToken = await this.fetchStatusListToken(uri);
 
-        // Extract TTL and exp from the JWT payload
-        const payload = decodeJwt(statusListJwt);
-        const ttl = typeof payload.ttl === "number" ? payload.ttl : undefined;
-        const exp = typeof payload.exp === "number" ? payload.exp : undefined;
+        let statusList: StatusList;
+        let ttl: number | undefined;
+        let exp: number | undefined;
+
+        if (typeof statusListToken === "string") {
+            statusList = getListFromStatusListJWT(statusListToken);
+            const payload = decodeJwt(statusListToken);
+            ttl = typeof payload.ttl === "number" ? payload.ttl : undefined;
+            exp = typeof payload.exp === "number" ? payload.exp : undefined;
+        } else {
+            const statusListCwt = StatusListCwt.fromToken(statusListToken);
+            statusList = statusListCwt.payload.statusList;
+            ttl = statusListCwt.payload.timeToLive;
+            exp = statusListCwt.payload.expirationTime
+                ? Math.floor(statusListCwt.payload.expirationTime.getTime() / 1000)
+                : undefined;
+        }
 
         this.cache.set(uri, {
             statusList,
@@ -173,10 +186,10 @@ export class StatusListVerifierService {
      * @param timeoutMs Timeout in milliseconds
      * @returns The raw JWT string
      */
-    private async fetchStatusListJwt(
+    private async fetchStatusListToken(
         uri: string,
         timeoutMs = 10000,
-    ): Promise<string> {
+    ): Promise<string | Uint8Array> {
         const ctrl = new AbortController();
         const timeout = setTimeout(() => ctrl.abort(), timeoutMs);
 
@@ -184,13 +197,22 @@ export class StatusListVerifierService {
             const response = await firstValueFrom(
                 this.httpService.get(uri, {
                     signal: ctrl.signal,
-                    responseType: "text",
+                    responseType: "arraybuffer",
                     headers: {
-                        Accept: "application/statuslist+jwt, application/jwt",
+                        Accept: "application/statuslist+jwt, application/statuslist+cwt, application/jwt",
                     },
                 }),
             );
-            return response.data;
+
+            const contentType = String(
+                response.headers?.["content-type"] || "",
+            ).toLowerCase();
+
+            if (contentType.includes("application/statuslist+cwt")) {
+                return new Uint8Array(response.data);
+            }
+
+            return Buffer.from(response.data).toString("utf8").trim();
         } catch (error: any) {
             if (
                 error?.name === "CanceledError" ||
@@ -212,6 +234,17 @@ export class StatusListVerifierService {
      * Check if a cache entry is expired.
      */
     private isCacheExpired(cached: CachedStatusList): boolean {
+        return this.isTimedCacheExpired(cached);
+    }
+
+    /**
+     * Shared expiration logic for parsed-list and raw-token caches.
+     */
+    private isTimedCacheExpired(cached: {
+        fetchedAt: number;
+        ttl?: number;
+        exp?: number;
+    }): boolean {
         const now = Date.now();
 
         // Check if JWT has expired (exp claim)
@@ -291,7 +324,13 @@ export class StatusListVerifierService {
 
         // Fetch and cache
         this.logger.debug(`Fetching status list JWT from ${uri}`);
-        const jwt = await this.fetchStatusListJwt(uri);
+        const token = await this.fetchStatusListToken(uri);
+        if (typeof token !== "string") {
+            throw new TypeError(
+                `Status list at ${uri} returned CWT while JWT was requested`,
+            );
+        }
+        const jwt = token;
 
         // Extract TTL and exp from the JWT payload
         const payload = decodeJwt(jwt);
@@ -312,20 +351,6 @@ export class StatusListVerifierService {
      * Check if a JWT cache entry is expired.
      */
     private isJwtCacheExpired(cached: CachedJwt): boolean {
-        const now = Date.now();
-
-        // Check if JWT has expired (exp claim)
-        if (cached.exp && now >= cached.exp * 1000) {
-            return true;
-        }
-
-        // Check TTL from JWT payload
-        if (cached.ttl) {
-            const expiresAt = cached.fetchedAt + cached.ttl * 1000;
-            return now >= expiresAt;
-        }
-
-        // Fall back to default cache TTL
-        return now >= cached.fetchedAt + this.defaultCacheTtlMs;
+        return this.isTimedCacheExpired(cached);
     }
 }

--- a/apps/backend/test/issuance/status-list-format-negotiation.e2e-spec.ts
+++ b/apps/backend/test/issuance/status-list-format-negotiation.e2e-spec.ts
@@ -1,0 +1,96 @@
+import { INestApplication } from "@nestjs/common";
+import { decodeProtectedHeader } from "jose";
+import request from "supertest";
+import { App } from "supertest/types";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { IssuanceTestContext, setupIssuanceTestApp } from "../utils";
+
+function parseBinary(
+    res: NodeJS.ReadableStream,
+    callback: (err: Error | null, body: Buffer) => void,
+) {
+    const chunks: Buffer[] = [];
+    res.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+    res.on("end", () => callback(null, Buffer.concat(chunks)));
+    res.on("error", (err) => callback(err, Buffer.alloc(0)));
+}
+
+describe("Status List - Token Format Negotiation", () => {
+    let app: INestApplication<App>;
+    let authToken: string;
+    let listId: string;
+
+    beforeAll(async () => {
+        const ctx: IssuanceTestContext = await setupIssuanceTestApp();
+        app = ctx.app;
+        authToken = ctx.authToken;
+
+        const createdList = await request(app.getHttpServer())
+            .post("/status-lists")
+            .set("Authorization", `Bearer ${authToken}`)
+            .send({})
+            .expect(201);
+
+        listId = createdList.body.id;
+        expect(listId).toBeDefined();
+    });
+
+    afterAll(async () => {
+        if (app) {
+            await app.close();
+        }
+    });
+
+    test("returns JWT by default", () => {
+        return request(app.getHttpServer())
+            .get(`/issuers/root/status-management/status-list/${listId}`)
+            .expect((response) => {
+                expect(response.headers["content-type"]).toContain(
+                    "application/statuslist+jwt",
+                );
+                expect(typeof response.text).toBe("string");
+
+                const header = decodeProtectedHeader(response.text);
+                expect(header.typ).toBe("statuslist+jwt");
+            })
+            .expect(200);
+    });
+
+    test("returns CWT when Accept requests application/statuslist+cwt", () => {
+        return request(app.getHttpServer())
+            .get(`/issuers/root/status-management/status-list/${listId}`)
+            .set("Accept", "application/statuslist+cwt")
+            .buffer(true)
+            .parse(parseBinary)
+            .expect((response) => {
+                expect(response.headers["content-type"]).toContain(
+                    "application/statuslist+cwt",
+                );
+
+                expect(Buffer.isBuffer(response.body)).toBe(true);
+                expect(response.body.length).toBeGreaterThan(32);
+                // COSE_Sign1 with CBOR tag 18 starts with 0xd2
+                expect(response.body[0]).toBe(0xd2);
+            })
+            .expect(200);
+    });
+
+    test("returns CWT when Content-Type requests application/statuslist+cwt", () => {
+        return request(app.getHttpServer())
+            .get(`/issuers/root/status-management/status-list/${listId}`)
+            .set("Content-Type", "application/statuslist+cwt")
+            .buffer(true)
+            .parse(parseBinary)
+            .expect((response) => {
+                expect(response.headers["content-type"]).toContain(
+                    "application/statuslist+cwt",
+                );
+
+                expect(Buffer.isBuffer(response.body)).toBe(true);
+                expect(response.body.length).toBeGreaterThan(32);
+                // COSE_Sign1 with CBOR tag 18 starts with 0xd2
+                expect(response.body[0]).toBe(0xd2);
+            })
+            .expect(200);
+    });
+});

--- a/docs/architecture/status-management.md
+++ b/docs/architecture/status-management.md
@@ -31,7 +31,7 @@ sequenceDiagram
 
     Wallet->>Verifier: Present credential
     Verifier->>StatusList: GET /status-list/{id}
-    StatusList-->>Verifier: JWT with status bits
+    StatusList-->>Verifier: Status List Token (JWT or CWT)
     Note over Verifier: Check bit at index 42
 
     Issuer->>StatusList: Revoke credential (set bit)
@@ -93,9 +93,12 @@ The capacity determines how many credentials can use a single status list:
 
 Larger capacities mean larger JWT payloads but fewer status lists to manage.
 
-## JWT Caching and TTL
+## Status List Token Caching and TTL
 
-Per RFC 9528, status list JWTs include time-based claims for caching:
+Per RFC 9528, status list tokens include time-based claims for caching.
+EUDIPLO can serve JWT or CWT representations from the same endpoint.
+
+Example JWT payload:
 
 ```json
 {
@@ -114,36 +117,43 @@ Per RFC 9528, status list JWTs include time-based claims for caching:
 | `exp` | Expiration timestamp (RECOMMENDED)         |
 | `ttl` | Time-to-live hint in seconds (RECOMMENDED) |
 
+For CWT responses, the same semantics are exposed as CWT claims:
+
+- Subject (`sub`) maps to CWT claim key `2`
+- Issued At (`iat`) maps to CWT claim key `6`
+- Expiration (`exp`) maps to CWT claim key `4`
+- Time-To-Live (`ttl`) maps to CWT claim key `65534`
+
 ### Regeneration Modes
 
-EUDIPLO supports two JWT regeneration strategies:
+EUDIPLO supports two token regeneration strategies:
 
 #### Lazy Mode (Default)
 
-The JWT is regenerated only when:
+The token is regenerated only when:
 
 1. A verifier requests the status list AND
-2. The current JWT has expired (`exp` < now)
+2. The current token has expired (`exp` < now)
 
 This minimizes computation but means status changes may not be immediately
 visible to verifiers until the TTL expires.
 
 ```
 TTL = 1 hour
-├─ 10:00 - Credential revoked (JWT not regenerated)
-├─ 10:30 - Verifier checks (gets cached JWT, sees valid)
-├─ 11:00 - JWT expires
-└─ 11:05 - Verifier checks (new JWT generated, sees revoked)
+├─ 10:00 - Credential revoked (token not regenerated)
+├─ 10:30 - Verifier checks (gets cached token, sees valid)
+├─ 11:00 - Token expires
+└─ 11:05 - Verifier checks (new token generated, sees revoked)
 ```
 
 #### Immediate Mode
 
-When `immediateUpdate` is enabled, the JWT is regenerated immediately whenever
+When `immediateUpdate` is enabled, the token is regenerated immediately whenever
 a status entry changes. This ensures verifiers always see the latest status but
 increases computational overhead.
 
 ```
-├─ 10:00 - Credential revoked (JWT regenerated immediately)
+├─ 10:00 - Credential revoked (token regenerated immediately)
 └─ 10:01 - Verifier checks (sees revoked)
 ```
 
@@ -205,7 +215,7 @@ Binding is useful when:
 
 ### Certificate Pinning
 
-By default, status list JWTs are signed with the tenant's default signing
+By default, status list tokens are signed with the tenant's default signing
 certificate. You can pin a specific certificate to a status list for:
 
 - Key rotation scenarios
@@ -214,7 +224,7 @@ certificate. You can pin a specific certificate to a status list for:
 
 ### Signing Key Resolution
 
-When signing a status list JWT, EUDIPLO looks for a key chain with usage type
+When signing a status list token, EUDIPLO looks for a key chain with usage type
 `statusList`. If no dedicated status list key chain exists for the tenant, it
 automatically falls back to the `attestation` key chain. This ensures that
 status lists share the same trust anchor as the issued credentials, which is
@@ -249,14 +259,23 @@ Key operations include:
 
 ### Public Status List Endpoint
 
-The status list JWT is served at a public endpoint for verifiers:
+The status list token is served at a public endpoint for verifiers:
 
 ```
 GET /{tenant}/status-management/status-list/{listId}
 ```
 
-This endpoint requires no authentication and returns the cached status list JWT.
-Verifiers should respect the `exp` and `ttl` claims for caching.
+This endpoint requires no authentication.
+
+Response format negotiation:
+
+| Request Header            | Value                        | Response Content-Type        |
+| ------------------------- | ---------------------------- | ---------------------------- |
+| `Accept`                  | `application/statuslist+cwt` | `application/statuslist+cwt` |
+| `Content-Type` (fallback) | `application/statuslist+cwt` | `application/statuslist+cwt` |
+| Otherwise                 | Any/none                     | `application/statuslist+jwt` |
+
+Verifiers should respect `exp` and `ttl` for caching regardless of JWT/CWT format.
 
 ## Web Client
 


### PR DESCRIPTION
## 📝 Description

Implements status list token format negotiation and CWT support for status management.

This PR adds:

- Public status list endpoint negotiation based on request headers:
  - Default response: `application/statuslist+jwt`
  - CWT response when requested: `application/statuslist+cwt`
- CWT status list token generation in the status list service
- Byte-signing support via key chain services for COSE/CWT signing flow
- Verifier support for fetching and parsing both JWT and CWT status list tokens
- New e2e coverage for status list format negotiation
- Updated architecture documentation for status token handling and negotiation

## 🔄 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test improvements
- [ ] 🏗️ Build/CI changes

## 💥 Breaking Changes (if applicable)

- None.

## 🧪 Testing

- [ ] Unit tests pass
- [ ] Integration tests pass
- [x] E2E tests pass
- [x] Manual testing performed

**Test Configuration**:

- Node.js version: local dev environment
- OS: macOS
- Test environment: local

Commands run:

- `pnpm --filter @eudiplo/backend build`
- `pnpm --filter @eudiplo/backend exec vitest run --config ./test/vitest.config.ts test/issuance/status-list-format-negotiation.e2e-spec.ts`

## 📸 Screenshots (if applicable)

- N/A

## ✔️ Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## 📋 Additional Notes

- CWT responses are returned as raw bytes from the controller (`res.send(Buffer.from(cwt))`) to avoid JSON serialization of binary payloads.
- Verifier fetch logic now supports both JWT and CWT status list content types.
