### PR TITLE
fix: wire mdoc status issuance and verification

### DIFF
--- a/apps/backend/src/issuer/configuration/credentials/issuer/mdoc-issuer/mdoc-issuer.service.ts
+++ b/apps/backend/src/issuer/configuration/credentials/issuer/mdoc-issuer/mdoc-issuer.service.ts
@@ -1,6 +1,12 @@
 import { Injectable, Logger } from "@nestjs/common";
 import type { Jwk } from "@openid4vc/oauth2";
-import { CoseKey, DeviceKey, Issuer, SignatureAlgorithm, StatusOptions } from "@owf/mdoc";
+import {
+    CoseKey,
+    DeviceKey,
+    Issuer,
+    SignatureAlgorithm,
+    StatusOptions,
+} from "@owf/mdoc";
 import { X509Certificate } from "@peculiar/x509";
 import { exportJWK, importX509 } from "jose";
 import { CertService } from "../../../../../crypto/key/cert/cert.service";

--- a/apps/backend/src/issuer/configuration/credentials/issuer/mdoc-issuer/mdoc-issuer.service.ts
+++ b/apps/backend/src/issuer/configuration/credentials/issuer/mdoc-issuer/mdoc-issuer.service.ts
@@ -1,11 +1,12 @@
 import { Injectable, Logger } from "@nestjs/common";
 import type { Jwk } from "@openid4vc/oauth2";
-import { CoseKey, DeviceKey, Issuer, SignatureAlgorithm } from "@owf/mdoc";
+import { CoseKey, DeviceKey, Issuer, SignatureAlgorithm, StatusOptions } from "@owf/mdoc";
 import { X509Certificate } from "@peculiar/x509";
 import { exportJWK, importX509 } from "jose";
 import { CertService } from "../../../../../crypto/key/cert/cert.service";
 import { KeyUsageType } from "../../../../../crypto/key/entities/key-chain.entity";
 import { KeyChainService } from "../../../../../crypto/key/key-chain.service";
+import { StatusListService } from "../../../../lifecycle/status/status-list.service";
 import { Session } from "../../../../../session/entities/session.entity";
 import { mdocContext } from "../../../../../verifier/presentations/mdoc-context";
 import { CredentialConfig } from "../../entities/credential.entity";
@@ -28,6 +29,7 @@ export class MdocIssuerService {
     constructor(
         private readonly certService: CertService,
         private readonly keyChainService: KeyChainService,
+        private readonly statusListService: StatusListService,
     ) {}
 
     /**
@@ -139,6 +141,24 @@ export class MdocIssuerService {
             validUntil.setFullYear(validUntil.getFullYear() + 1);
         }
 
+        // If status management is enabled, create an entry and map it to mDOC status format.
+        let status: StatusOptions | undefined;
+        if (credentialConfiguration.statusManagement) {
+            const statusPayload = await this.statusListService.createEntry(
+                session,
+                credentialConfiguration.id,
+            );
+            const statusList = statusPayload.status?.status_list;
+            if (statusList) {
+                status = {
+                    statusList: {
+                        idx: statusList.idx,
+                        uri: statusList.uri,
+                    },
+                };
+            }
+        }
+
         // Sign the mDOC
         const issuerSigned = await issuer.sign({
             signingKey: CoseKey.fromJwk(privateKey as Jwk),
@@ -147,6 +167,7 @@ export class MdocIssuerService {
             digestAlgorithm: "SHA-256",
             deviceKeyInfo: { deviceKey: DeviceKey.fromJwk(deviceKey) },
             validityInfo: { signed, validFrom, validUntil },
+            status,
         });
 
         this.logger.debug(

--- a/apps/backend/src/issuer/lifecycle/status/status-list.service.ts
+++ b/apps/backend/src/issuer/lifecycle/status/status-list.service.ts
@@ -380,8 +380,9 @@ export class StatusListService {
             protectedHeaders: new Map<number, unknown>([
                 [1, SignatureAlgorithm.ES256],
                 [4, new TextEncoder().encode(cert.keyId)],
+                // mDOC status verification expects x5chain in protected headers.
+                [33, x5chain],
             ]),
-            unprotectedHeaders: new Map<number, unknown>([[33, x5chain]]),
         });
 
         return cwt.signAndEncode(

--- a/apps/backend/src/verifier/presentations/credential/credential-chain-validation.service.ts
+++ b/apps/backend/src/verifier/presentations/credential/credential-chain-validation.service.ts
@@ -397,6 +397,44 @@ export class CredentialChainValidationService {
     }
 
     /**
+     * Get trusted revocation certificate buffers for mDOC status validation.
+     * Returns certificates as Uint8Array[] for the mdoc library.
+     */
+    async getTrustedStatusCertificateBuffers(
+        trustListSource?: TrustListSource,
+    ): Promise<Uint8Array[]> {
+        const store = await this.getTrustStoreIfConfigured(trustListSource);
+        if (!store) {
+            return [];
+        }
+
+        const trustedCertificates: Uint8Array[] = [];
+
+        for (const entity of store.entities) {
+            const revocationServices = entity.services.filter((s) =>
+                s.serviceTypeIdentifier.endsWith("/Revocation"),
+            );
+
+            for (const svc of revocationServices) {
+                try {
+                    const cert = new x509.X509Certificate(svc.certValue as any);
+                    trustedCertificates.push(new Uint8Array(cert.rawData));
+                } catch (e: any) {
+                    this.logger.warn(
+                        `Failed to parse revocation certificate from entity ${entity.entityId}: ${e?.message ?? e}`,
+                    );
+                }
+            }
+        }
+
+        this.logger.debug(
+            `Loaded ${trustedCertificates.length} trusted status certificate(s) for verification`,
+        );
+
+        return trustedCertificates;
+    }
+
+    /**
      * Get the trust store if configured.
      */
     private async getTrustStoreIfConfigured(

--- a/apps/backend/src/verifier/presentations/credential/mdocverifier/mdocverifier.service.ts
+++ b/apps/backend/src/verifier/presentations/credential/mdocverifier/mdocverifier.service.ts
@@ -176,7 +176,14 @@ export class MdocverifierService {
                 await this.chainValidation.getTrustedCertificateBuffers(
                     options.trustListSource,
                 );
+            const trustedStatusCertBuffers =
+                await this.chainValidation.getTrustedStatusCertificateBuffers(
+                    options.trustListSource,
+                );
             const trustedAnchors = trustedCertBuffers.map(
+                (buffer) => new Uint8Array(buffer),
+            );
+            const trustedStatusAnchors = trustedStatusCertBuffers.map(
                 (buffer) => new Uint8Array(buffer),
             );
             const trustedCertificates =
@@ -184,6 +191,9 @@ export class MdocverifierService {
                     ? [
                           {
                               issuance: [...issuerX5Chain, ...trustedAnchors],
+                              ...(trustedStatusAnchors.length > 0
+                                  ? { status: trustedStatusAnchors }
+                                  : {}),
                           },
                       ]
                     : [];

--- a/apps/backend/test/presentation/presentation-mdoc.e2e-spec.ts
+++ b/apps/backend/test/presentation/presentation-mdoc.e2e-spec.ts
@@ -187,7 +187,11 @@ describe("Presentation - mDOC Credential", () => {
             requestId: "pid-de",
         };
 
-        const res = await createPresentationRequest(app, authToken, requestBody);
+        const res = await createPresentationRequest(
+            app,
+            authToken,
+            requestBody,
+        );
 
         const authRequest = client.parseOpenid4vpAuthorizationRequest({
             authorizationRequest: res.body.uri,

--- a/apps/backend/test/presentation/presentation-mdoc.e2e-spec.ts
+++ b/apps/backend/test/presentation/presentation-mdoc.e2e-spec.ts
@@ -24,6 +24,7 @@ import {
     prepareMdocPresentation,
     setupPresentationTestApp,
 } from "../utils";
+import { StatusListService } from "../../src/issuer/lifecycle/status/status-list.service";
 
 describe("Presentation - mDOC Credential", () => {
     let app: INestApplication<App>;
@@ -33,6 +34,7 @@ describe("Presentation - mDOC Credential", () => {
     let issuerCert: string;
     let ctx: PresentationTestContext;
     let client: Openid4vpClient;
+    let statusListService: StatusListService;
 
     function computeJwkThumbprint(jwks?: {
         keys?: Array<Record<string, any>>;
@@ -153,6 +155,7 @@ describe("Presentation - mDOC Credential", () => {
         host = ctx.host;
         privateIssuerKey = ctx.privateIssuerKey;
         issuerCert = ctx.issuerCert;
+        statusListService = ctx.statusListService;
 
         client = new Openid4vpClient({
             callbacks: {
@@ -175,6 +178,70 @@ describe("Presentation - mDOC Credential", () => {
         });
 
         expect(submitRes).toBeDefined();
+        expect(submitRes.response.status).toBe(200);
+    });
+
+    test("present mso mdoc credential with status list", async () => {
+        const requestBody: PresentationRequest = {
+            response_type: ResponseType.URI,
+            requestId: "pid-de",
+        };
+
+        const res = await createPresentationRequest(app, authToken, requestBody);
+
+        const authRequest = client.parseOpenid4vpAuthorizationRequest({
+            authorizationRequest: res.body.uri,
+        });
+
+        const resolved = await client.resolveOpenId4vpAuthorizationRequest({
+            authorizationRequestPayload: authRequest.params,
+            responseMode: { type: "direct_post" },
+        });
+
+        const statusPayload = await statusListService.createEntry(
+            { tenantId: "root", id: "mdoc-status-e2e" } as any,
+            "pid-mso-mdoc",
+        );
+        const statusList = statusPayload.status?.status_list;
+        expect(statusList).toBeDefined();
+
+        const vp_token = await prepareMdocPresentation(
+            resolved.authorizationRequestPayload.nonce,
+            privateIssuerKey,
+            issuerCert,
+            resolved.authorizationRequestPayload.client_id!,
+            resolved.authorizationRequestPayload.response_uri as string,
+            resolved.authorizationRequestPayload.response_mode ??
+                "direct_post.jwt",
+            computeJwkThumbprint(
+                resolved.authorizationRequestPayload.client_metadata?.jwks,
+            ),
+            {
+                statusList: {
+                    idx: statusList!.idx,
+                    uri: statusList!.uri,
+                },
+            },
+        );
+
+        const jwt = await encryptVpToken(vp_token, "pid-mso-mdoc", resolved);
+
+        const authorizationResponse =
+            await client.createOpenid4vpAuthorizationResponse({
+                authorizationRequestPayload: authRequest.params,
+                authorizationResponsePayload: {
+                    response: jwt,
+                },
+                ...callbacks,
+            });
+
+        const submitRes = await client.submitOpenid4vpAuthorizationResponse({
+            authorizationResponsePayload:
+                authorizationResponse.authorizationResponsePayload,
+            authorizationRequestPayload:
+                resolved.authorizationRequestPayload as Openid4vpAuthorizationRequest,
+        });
+
         expect(submitRes.response.status).toBe(200);
     });
 

--- a/apps/backend/test/utils.ts
+++ b/apps/backend/test/utils.ts
@@ -63,6 +63,12 @@ export async function prepareMdocPresentation(
     responseUri: string,
     responseMode: string = "direct_post.jwt",
     jwkThumbprint?: Uint8Array,
+    mdocStatus?: {
+        statusList: {
+            idx: number;
+            uri: string;
+        };
+    },
 ) {
     // Use the EU PID docType and namespace to match the pid-de fixture
     const docType = "eu.europa.ec.eudi.pid.1";
@@ -93,6 +99,7 @@ export async function prepareMdocPresentation(
         digestAlgorithm: "SHA-256",
         deviceKeyInfo: { deviceKey: DeviceKey.fromJwk(DEVICE_JWK) },
         validityInfo: { signed, validFrom, validUntil },
+        status: mdocStatus,
     });
 
     const encodedIssuerSigned = issuerSigned.encodedForOid4Vci;


### PR DESCRIPTION
## 📝 Description

Wire status support end-to-end for mDOC credentials.

This PR:
- adds mDOC issuance status embedding based on the existing status list service
- adds verifier-side status trust anchors for mDOC verification
- fixes status-list CWT header placement so mdoc-ts can validate embedded status references
- adds an e2e presentation test covering an mDOC with status information

Fixes #

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test improvements
- [ ] 🏗️ Build/CI changes

## 💥 Breaking Changes (if applicable)

- **API changes**: None
- **Environment variables**: None
- **Config import format**: None
- **Database**: None

## 🧪 Testing

Describe the tests that you ran to verify your changes:

- [x] Unit tests pass
- [ ] Integration tests pass
- [x] E2E tests pass
- [ ] Manual testing performed

**Test Configuration**:

- Node.js version: local project environment
- OS: macOS
- Test environment: backend Vitest e2e/unit test setup

## 📸 Screenshots (if applicable)

N/A

## ✔️ Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## 📋 Additional Notes

The new e2e initially exposed a compatibility issue in status-list CWT generation: mdoc-ts expects `x5chain` in protected headers for status verification. This PR includes that server-side fix so the end-to-end mDOC status flow succeeds.