### PR TITLE
fix: CWT generation for status lists

### DIFF
--- a/apps/backend/src/database/migrations/1771000000000-AddCwtCacheToStatusList.ts
+++ b/apps/backend/src/database/migrations/1771000000000-AddCwtCacheToStatusList.ts
@@ -1,0 +1,66 @@
+import { MigrationInterface, QueryRunner, TableColumn } from "typeorm";
+
+/**
+ * Adds a CWT cache column to status list rows.
+ * CWT is stored as base64url text and regenerated together with JWT on refresh.
+ */
+export class AddCwtCacheToStatusList1771000000000
+    implements MigrationInterface
+{
+    name = "AddCwtCacheToStatusList1771000000000";
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const tableName = await this.resolveStatusListTableName(queryRunner);
+        if (!tableName) {
+            console.log(
+                "[Migration] status list table not found - skipping AddCwtCacheToStatusList.",
+            );
+            return;
+        }
+
+        const table = await queryRunner.getTable(tableName);
+        if (!table) {
+            return;
+        }
+
+        if (!table.columns.some((col) => col.name === "cwt")) {
+            await queryRunner.addColumn(
+                tableName,
+                new TableColumn({
+                    name: "cwt",
+                    type: "text",
+                    isNullable: true,
+                }),
+            );
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const tableName = await this.resolveStatusListTableName(queryRunner);
+        if (!tableName) {
+            return;
+        }
+
+        const table = await queryRunner.getTable(tableName);
+        if (!table) {
+            return;
+        }
+
+        if (table.columns.some((col) => col.name === "cwt")) {
+            await queryRunner.dropColumn(tableName, "cwt");
+        }
+    }
+
+    private async resolveStatusListTableName(
+        queryRunner: QueryRunner,
+    ): Promise<string | null> {
+        const candidates = ["status_list_entity", "status_list"];
+        for (const candidate of candidates) {
+            const table = await queryRunner.getTable(candidate);
+            if (table) {
+                return candidate;
+            }
+        }
+        return null;
+    }
+}

--- a/apps/backend/src/database/migrations/index.ts
+++ b/apps/backend/src/database/migrations/index.ts
@@ -35,3 +35,4 @@ export { AddIssuerRegistrationCertificateToIssuanceConfig1767000000000 } from ".
 export { RemoveRefreshTokenFromIssuanceConfig1768000000000 } from "./1768000000000-RemoveRefreshTokenFromIssuanceConfig";
 export { RemovePreferredAuthServerFromIssuanceConfig1769000000000 } from "./1769000000000-RemovePreferredAuthServerFromIssuanceConfig";
 export { AddDcApiProtocolToSession1770000000000 } from "./1770000000000-AddDcApiProtocolToSession";
+export { AddCwtCacheToStatusList1771000000000 } from "./1771000000000-AddCwtCacheToStatusList";

--- a/apps/backend/src/issuer/lifecycle/status/entities/status-list.entity.ts
+++ b/apps/backend/src/issuer/lifecycle/status/entities/status-list.entity.ts
@@ -71,6 +71,13 @@ export class StatusListEntity {
     jwt?: string;
 
     /**
+     * Base64url-encoded CBOR Web Token (CWT) for the status list.
+     * Cached alongside JWT to avoid re-signing on each CWT request.
+     */
+    @Column("text", { nullable: true })
+    cwt?: string;
+
+    /**
      * When the current JWT expires (based on TTL).
      * Used for lazy regeneration - JWT is regenerated on request when expired.
      */

--- a/apps/backend/src/issuer/lifecycle/status/status-list.service.ts
+++ b/apps/backend/src/issuer/lifecycle/status/status-list.service.ts
@@ -200,7 +200,7 @@ export class StatusListService {
     }
 
     /**
-     * Create the JWT for a status list and update the entity.
+     * Create status list tokens (JWT and CWT) and update the entity.
      * The JWT includes:
      * - `iat`: When the token was issued (REQUIRED)
      * - `exp`: When the token expires (RECOMMENDED)
@@ -208,16 +208,17 @@ export class StatusListService {
      * - `aggregation_uri`: URI to fetch all status list URIs (OPTIONAL, per RFC Section 9)
      */
     async createListJWT(entry: StatusListEntity): Promise<void> {
-        const list = new StatusList(entry.elements, entry.bits);
-        const iss = `${this.configService.getOrThrow<string>("PUBLIC_URL")}`;
-
-        const sub = this.buildStatusListUri(entry.tenantId, entry.id);
-
         // Get TTL from tenant config or global default
         const effectiveConfig =
             await this.statusListConfigService.getEffectiveConfig(
                 entry.tenantId,
             );
+        const aggregationUri = effectiveConfig.enableAggregation
+            ? this.buildAggregationUri(entry.tenantId)
+            : undefined;
+        const list = new StatusList(entry.elements, entry.bits, aggregationUri);
+        const iss = `${this.configService.getOrThrow<string>("PUBLIC_URL")}`;
+        const sub = this.buildStatusListUri(entry.tenantId, entry.id);
         const ttl = effectiveConfig.ttl!;
         const now = Math.floor(Date.now() / 1000);
         const exp = now + ttl;
@@ -247,7 +248,7 @@ export class StatusListService {
         // This allows relying parties to pre-fetch all status lists for offline validation
         if (effectiveConfig.enableAggregation && payload.status_list) {
             (payload.status_list as Record<string, unknown>).aggregation_uri =
-                this.buildAggregationUri(entry.tenantId);
+                aggregationUri;
         }
 
         const jwt = await this.keyChainService.signJWT(
@@ -257,11 +258,70 @@ export class StatusListService {
             cert.keyId,
         );
 
-        // Store JWT and expiration time
+        const issuedAt = new Date(now * 1000);
+        const expirationTime = new Date(exp * 1000);
+        const cwt = await this.signStatusListCwt(
+            entry.tenantId,
+            cert.keyId,
+            cert.crt,
+            {
+                subject: sub,
+                issuedAt,
+                expirationTime,
+                ttl,
+                statusList: list,
+            },
+        );
+
+        // Store JWT/CWT and expiration time
         const expiresAt = new Date(exp * 1000);
         await this.statusListRepository.update(
             { id: entry.id, tenantId: entry.tenantId },
-            { jwt, expiresAt },
+            { jwt, cwt: Buffer.from(cwt).toString("base64url"), expiresAt },
+        );
+    }
+
+    private async signStatusListCwt(
+        tenantId: string,
+        keyId: string,
+        certChainPem: string[],
+        payload: {
+            subject: string;
+            issuedAt: Date;
+            expirationTime?: Date;
+            ttl?: number;
+            statusList: StatusList;
+        },
+    ): Promise<Uint8Array> {
+        const x5chain = certChainPem.map(
+            (pem) => new Uint8Array(new X509Certificate(pem).rawData),
+        );
+
+        const cwt = new StatusListCwt({
+            payload: {
+                subject: payload.subject,
+                issuedAt: payload.issuedAt,
+                expirationTime: payload.expirationTime,
+                timeToLive: payload.ttl,
+                statusList: payload.statusList,
+            },
+            protectedHeaders: new Map<number, unknown>([
+                [1, SignatureAlgorithm.ES256],
+                [4, new TextEncoder().encode(keyId)],
+                // mDOC status verification expects x5chain in protected headers.
+                [33, x5chain],
+            ]),
+        });
+
+        return cwt.signAndEncode(
+            {
+                signingKey: { algorithm: SignatureAlgorithm.ES256 } as never,
+                algorithm: SignatureAlgorithm.ES256,
+            },
+            {
+                sign: async ({ toBeSigned }) =>
+                    this.keyChainService.signBytes(toBeSigned, tenantId, keyId),
+            },
         );
     }
 
@@ -332,7 +392,7 @@ export class StatusListService {
 
     /**
      * Get the CWT for a specific status list.
-     * The CWT content follows the same freshness policy as JWT status list tokens.
+     * The CWT follows the same caching/freshness policy as JWT status list tokens.
      */
     async getListCwt(tenantId: string, listId: string): Promise<Uint8Array> {
         let list = await this.getListById(tenantId, listId);
@@ -345,60 +405,50 @@ export class StatusListService {
             list = await this.getListById(tenantId, listId);
         }
 
-        const jwt = list.jwt!;
-        const jwtPayload = decodeJwt(jwt);
-        const statusList = getListFromStatusListJWT(jwt);
-        const cert = await this.getSigningCert(list);
+        if (!list.cwt) {
+            const jwt = list.jwt!;
+            const jwtPayload = decodeJwt(jwt);
+            const statusList = getListFromStatusListJWT(jwt);
+            const cert = await this.getSigningCert(list);
 
-        const subject =
-            typeof jwtPayload.sub === "string"
-                ? jwtPayload.sub
-                : this.buildStatusListUri(tenantId, listId);
-        const issuedAt =
-            typeof jwtPayload.iat === "number"
-                ? new Date(jwtPayload.iat * 1000)
-                : new Date();
-        const expirationTime =
-            typeof jwtPayload.exp === "number"
-                ? new Date(jwtPayload.exp * 1000)
-                : undefined;
-        const ttl =
-            typeof jwtPayload.ttl === "number" ? jwtPayload.ttl : undefined;
+            const subject =
+                typeof jwtPayload.sub === "string"
+                    ? jwtPayload.sub
+                    : this.buildStatusListUri(tenantId, listId);
+            const issuedAt =
+                typeof jwtPayload.iat === "number"
+                    ? new Date(jwtPayload.iat * 1000)
+                    : new Date();
+            const expirationTime =
+                typeof jwtPayload.exp === "number"
+                    ? new Date(jwtPayload.exp * 1000)
+                    : undefined;
+            const ttl =
+                typeof jwtPayload.ttl === "number"
+                    ? jwtPayload.ttl
+                    : undefined;
 
-        const x5chain = cert.crt.map(
-            (pem) => new Uint8Array(new X509Certificate(pem).rawData),
-        );
+            const cwt = await this.signStatusListCwt(
+                tenantId,
+                cert.keyId,
+                cert.crt,
+                {
+                    subject,
+                    issuedAt,
+                    expirationTime,
+                    ttl,
+                    statusList,
+                },
+            );
 
-        const cwt = new StatusListCwt({
-            payload: {
-                subject,
-                issuedAt,
-                expirationTime,
-                timeToLive: ttl,
-                statusList,
-            },
-            protectedHeaders: new Map<number, unknown>([
-                [1, SignatureAlgorithm.ES256],
-                [4, new TextEncoder().encode(cert.keyId)],
-                // mDOC status verification expects x5chain in protected headers.
-                [33, x5chain],
-            ]),
-        });
+            await this.statusListRepository.update(
+                { id: list.id, tenantId: list.tenantId },
+                { cwt: Buffer.from(cwt).toString("base64url") },
+            );
+            list = await this.getListById(tenantId, listId);
+        }
 
-        return cwt.signAndEncode(
-            {
-                signingKey: { algorithm: SignatureAlgorithm.ES256 } as never,
-                algorithm: SignatureAlgorithm.ES256,
-            },
-            {
-                sign: async ({ toBeSigned }) =>
-                    this.keyChainService.signBytes(
-                        toBeSigned,
-                        tenantId,
-                        cert.keyId,
-                    ),
-            },
-        );
+        return Uint8Array.from(Buffer.from(list.cwt!, "base64url"));
     }
 
     /**

--- a/apps/backend/test/issuance/status-list-format-negotiation.e2e-spec.ts
+++ b/apps/backend/test/issuance/status-list-format-negotiation.e2e-spec.ts
@@ -93,4 +93,28 @@ describe("Status List - Token Format Negotiation", () => {
             })
             .expect(200);
     });
+
+    test("returns the same cached CWT across repeated requests", async () => {
+        const firstResponse = await request(app.getHttpServer())
+            .get(`/issuers/root/status-management/status-list/${listId}`)
+            .set("Accept", "application/statuslist+cwt")
+            .buffer(true)
+            .parse(parseBinary)
+            .expect(200);
+
+        const secondResponse = await request(app.getHttpServer())
+            .get(`/issuers/root/status-management/status-list/${listId}`)
+            .set("Accept", "application/statuslist+cwt")
+            .buffer(true)
+            .parse(parseBinary)
+            .expect(200);
+
+        expect(firstResponse.headers["content-type"]).toContain(
+            "application/statuslist+cwt",
+        );
+        expect(secondResponse.headers["content-type"]).toContain(
+            "application/statuslist+cwt",
+        );
+        expect(Buffer.compare(firstResponse.body, secondResponse.body)).toBe(0);
+    });
 });


### PR DESCRIPTION
## 📝 Description

Fixes CWT (CBOR Web Token) generation for status lists. Previously, CWT tokens were not being generated and stored alongside JWT tokens. This PR ensures both JWT and CWT are produced during status list token creation and persisted in the database.

Key changes:
- `aggregation_uri` is now correctly passed to `StatusList` constructor before building the JWT payload
- CWT is generated via `signStatusListCwt` and stored as a base64url-encoded value in the new `cwt` column on `StatusListEntity`
- Added DB migration `1771000000000-AddCwtCacheToStatusList` to add the `cwt` column
- Added E2E test coverage in `status-list-format-negotiation.e2e-spec.ts` to verify CWT negotiation

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🧪 Test improvements

## 🧪 Testing

- [x] E2E tests pass (`status-list-format-negotiation.e2e-spec.ts`)
- [x] Manual testing performed

## ✔️ Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective