### PR TITLE
feat: add verifier skew seconds configuration

### DIFF
--- a/apps/backend/src/database/migrations/1772000000000-AddVerifierSkewSeconds.ts
+++ b/apps/backend/src/database/migrations/1772000000000-AddVerifierSkewSeconds.ts
@@ -1,0 +1,76 @@
+import { MigrationInterface, QueryRunner, TableColumn } from "typeorm";
+
+export class AddVerifierSkewSeconds1772000000000 implements MigrationInterface {
+    name = "AddVerifierSkewSeconds1772000000000";
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const presentationConfigTable = await queryRunner.getTable(
+            "presentation_config",
+        );
+        if (presentationConfigTable) {
+            const hasSkewSeconds = presentationConfigTable.columns.some(
+                (column) => column.name === "skewSeconds",
+            );
+            if (!hasSkewSeconds) {
+                await queryRunner.addColumn(
+                    "presentation_config",
+                    new TableColumn({
+                        name: "skewSeconds",
+                        type: "int",
+                        isNullable: false,
+                        default: 60,
+                    }),
+                );
+                console.log(
+                    "[Migration] Added skewSeconds column to presentation_config.",
+                );
+            }
+        } else {
+            console.log(
+                "[Migration] presentation_config table not found — skipping.",
+            );
+        }
+
+        const sessionTable = await queryRunner.getTable("session");
+        if (sessionTable) {
+            const hasSkewSeconds = sessionTable.columns.some(
+                (column) => column.name === "skewSeconds",
+            );
+            if (!hasSkewSeconds) {
+                await queryRunner.addColumn(
+                    "session",
+                    new TableColumn({
+                        name: "skewSeconds",
+                        type: "int",
+                        isNullable: true,
+                    }),
+                );
+                console.log("[Migration] Added skewSeconds column to session.");
+            }
+        } else {
+            console.log("[Migration] session table not found — skipping.");
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const sessionTable = await queryRunner.getTable("session");
+        if (
+            sessionTable?.columns.some(
+                (column) => column.name === "skewSeconds",
+            )
+        ) {
+            await queryRunner.dropColumn("session", "skewSeconds");
+        }
+
+        const presentationConfigTable = await queryRunner.getTable(
+            "presentation_config",
+        );
+        if (
+            presentationConfigTable?.columns.some(
+                (column) => column.name === "skewSeconds",
+            )
+        ) {
+            await queryRunner.dropColumn("presentation_config", "skewSeconds");
+        }
+    }
+}

--- a/apps/backend/src/database/migrations/index.ts
+++ b/apps/backend/src/database/migrations/index.ts
@@ -36,3 +36,4 @@ export { RemoveRefreshTokenFromIssuanceConfig1768000000000 } from "./17680000000
 export { RemovePreferredAuthServerFromIssuanceConfig1769000000000 } from "./1769000000000-RemovePreferredAuthServerFromIssuanceConfig";
 export { AddDcApiProtocolToSession1770000000000 } from "./1770000000000-AddDcApiProtocolToSession";
 export { AddCwtCacheToStatusList1771000000000 } from "./1771000000000-AddCwtCacheToStatusList";
+export { AddVerifierSkewSeconds1772000000000 } from "./1772000000000-AddVerifierSkewSeconds";

--- a/apps/backend/src/session/entities/session.entity.ts
+++ b/apps/backend/src/session/entities/session.entity.ts
@@ -259,6 +259,12 @@ export class Session {
     @Column("json", { nullable: true })
     transaction_data?: TransactionData[];
 
+    /**
+     * Per-session clock skew tolerance for presentation credential JWT time validation.
+     */
+    @Column("int", { nullable: true })
+    skewSeconds?: number;
+
     // External authorization server fields (for wallet-initiated flows with external AS like Keycloak)
 
     /**

--- a/apps/backend/src/shared/trust/types.ts
+++ b/apps/backend/src/shared/trust/types.ts
@@ -80,6 +80,8 @@ export type FederationTrustSource = {
     enforceSigningPolicy?: boolean;
 };
 
+export const DEFAULT_VERIFIER_SKEW_SECONDS = 60;
+
 export type VerifierOptions = {
     trustListSource?: TrustListSource;
     federationTrustSource?: FederationTrustSource;
@@ -104,6 +106,11 @@ export type VerifierOptions = {
      * SD-JWT key binding nonce.
      */
     keyBindingNonce?: string;
+    /**
+     * Allow for clock skew when validating JWTs and SD-JWTs.
+     * Default is 60 seconds.
+     */
+    skewSeconds?: number;
 };
 
 export type TrustListSource = {

--- a/apps/backend/src/verifier/iso18013/iso18013.service.ts
+++ b/apps/backend/src/verifier/iso18013/iso18013.service.ts
@@ -17,7 +17,10 @@ import { EncryptionService } from "../../crypto/encryption/encryption.service";
 import { ServiceTypeIdentifier } from "../../issuer/trust-list/trustlist.service";
 import { SessionStatus } from "../../session/entities/session.entity";
 import { SessionService } from "../../session/session.service";
-import { VerifierOptions } from "../../shared/trust/types";
+import {
+    DEFAULT_VERIFIER_SKEW_SECONDS,
+    VerifierOptions,
+} from "../../shared/trust/types";
 import { AuditLogService } from "../../shared/utils/logger/audit-log.service";
 import { WebhookService } from "../../shared/utils/webhook/webhook.service";
 import { MdocverifierService } from "../presentations/credential/mdocverifier/mdocverifier.service";
@@ -63,6 +66,7 @@ export class Iso18013Service {
         requestId: string,
         tenantId: string,
         origin: string,
+        skewSeconds?: number,
     ): Promise<Iso18013Offer> {
         const config = await this.presentationsService.getPresentationConfig(
             requestId,
@@ -126,6 +130,10 @@ export class Iso18013Service {
             vp_nonce: nonce.toString("hex"),
             parsedWebhook: config.webhook ?? undefined,
             redirectUri: config.redirectUri ?? undefined,
+            skewSeconds:
+                skewSeconds ??
+                config.skewSeconds ??
+                DEFAULT_VERIFIER_SKEW_SECONDS,
             expiresAt,
             status: SessionStatus.Active,
         });
@@ -282,6 +290,10 @@ export class Iso18013Service {
             policy: {
                 requireX5c: true,
             },
+            skewSeconds:
+                session.skewSeconds ??
+                config.skewSeconds ??
+                DEFAULT_VERIFIER_SKEW_SECONDS,
         };
 
         const deviceResponseB64 = deviceResponseCbor.toString("base64url");

--- a/apps/backend/src/verifier/oid4vp/dto/presentation-request.dto.ts
+++ b/apps/backend/src/verifier/oid4vp/dto/presentation-request.dto.ts
@@ -2,9 +2,11 @@ import { Type } from "class-transformer";
 import {
     IsArray,
     IsEnum,
+    IsNumber,
     IsObject,
     IsOptional,
     IsString,
+    Min,
 } from "class-validator";
 import { WebhookConfig } from "../../../shared/utils/webhook/webhook.dto";
 import { TransactionData } from "../../presentations/entities/presentation-config.entity";
@@ -79,11 +81,24 @@ export class PresentationRequest {
     @IsTransactionData()
     @Type(() => TransactionData)
     transaction_data?: TransactionData[];
+
+    /**
+     * Optional clock skew tolerance for this presentation offer, in seconds.
+     * If provided, this overrides the presentation configuration for the created session.
+     */
+    @IsOptional()
+    @IsNumber()
+    @Min(0)
+    skewSeconds?: number;
 }
 
 export type PresentationRequestOptions = Pick<
     PresentationRequest,
-    "webhook" | "redirectUri" | "expected_origin" | "transaction_data"
+    | "webhook"
+    | "redirectUri"
+    | "expected_origin"
+    | "transaction_data"
+    | "skewSeconds"
 > & {
     session?: string;
 };

--- a/apps/backend/src/verifier/oid4vp/oid4vp.service.ts
+++ b/apps/backend/src/verifier/oid4vp/oid4vp.service.ts
@@ -17,6 +17,7 @@ import { OfferResponse } from "../../issuer/issuance/oid4vci/dto/offer-request.d
 import { RegistrarService } from "../../registrar/registrar.service";
 import { SessionStatus } from "../../session/entities/session.entity";
 import { SessionService } from "../../session/session.service";
+import { DEFAULT_VERIFIER_SKEW_SECONDS } from "../../shared/trust/types";
 import { AuditLogContext } from "../../shared/utils/logger/audit-log.service";
 import { SessionLoggerService } from "../../shared/utils/logger/session-logger.service";
 import { WebhookService } from "../../shared/utils/webhook/webhook.service";
@@ -426,6 +427,10 @@ export class Oid4vpService {
                 clientId,
                 responseUri,
                 transaction_data,
+                skewSeconds:
+                    values.skewSeconds ??
+                    presentationConfig.skewSeconds ??
+                    DEFAULT_VERIFIER_SKEW_SECONDS,
             });
 
             if (request_uri_method === "get") {

--- a/apps/backend/src/verifier/presentations/entities/presentation-config.entity.ts
+++ b/apps/backend/src/verifier/presentations/entities/presentation-config.entity.ts
@@ -14,6 +14,7 @@ import {
     IsObject,
     IsOptional,
     IsString,
+    Min,
     Validate,
     ValidateNested,
     ValidationArguments,
@@ -258,6 +259,20 @@ export class PresentationConfig {
     @IsOptional()
     @Column("int", { default: 300 })
     lifeTime?: number;
+
+    /**
+     * Clock skew tolerance for credential JWT time validation, in seconds.
+     */
+    @ApiPropertyOptional({
+        description:
+            "Clock skew tolerance for credential JWT time validation, in seconds.",
+        default: 60,
+    })
+    @IsNumber()
+    @Min(0)
+    @IsOptional()
+    @Column("int", { default: 60 })
+    skewSeconds?: number;
 
     /**
      * The DCQL query to be used for the VP request.

--- a/apps/backend/src/verifier/presentations/presentations.service.ts
+++ b/apps/backend/src/verifier/presentations/presentations.service.ts
@@ -21,7 +21,10 @@ import { TokenPayload } from "../../auth/token.decorator";
 import { ServiceTypeIdentifier } from "../../issuer/trust-list/trustlist.service";
 import { RegistrarService } from "../../registrar/registrar.service";
 import { Session } from "../../session/entities/session.entity";
-import { VerifierOptions } from "../../shared/trust/types";
+import {
+    DEFAULT_VERIFIER_SKEW_SECONDS,
+    VerifierOptions,
+} from "../../shared/trust/types";
 import {
     extractRequestMeta,
     getChangedFields,
@@ -680,6 +683,7 @@ export class PresentationsService {
             lifeTime: config.lifeTime,
             dcql_query: config.dcql_query,
             transaction_data: config.transaction_data,
+            skewSeconds: config.skewSeconds,
             registration_cert: config.registration_cert,
             registrationCertCache: config.registrationCertCache,
             webhook: config.webhook,
@@ -1514,6 +1518,10 @@ export class PresentationsService {
                     policy: {
                         requireX5c: true,
                     },
+                    skewSeconds:
+                        session.skewSeconds ??
+                        presentationConfig.skewSeconds ??
+                        DEFAULT_VERIFIER_SKEW_SECONDS,
                     // Pass transaction data for hash validation (only for credentials that have it)
                     transactionData: relevantTransactionData,
                 };

--- a/apps/backend/src/verifier/verifier-offer/verifier-offer.controller.ts
+++ b/apps/backend/src/verifier/verifier-offer/verifier-offer.controller.ts
@@ -93,6 +93,7 @@ export class VerifierOfferController {
                 body.requestId,
                 user.entity!.id,
                 origin,
+                body.skewSeconds,
             );
             return res.status(201).json(offer);
         }
@@ -103,6 +104,7 @@ export class VerifierOfferController {
                 webhook: body.webhook,
                 redirectUri: body.redirectUri,
                 transaction_data: body.transaction_data,
+                skewSeconds: body.skewSeconds,
             },
             user.entity!.id,
             body.response_type === ResponseType.DC_API,

--- a/docs/getting-started/presentation/presentation-configuration.md
+++ b/docs/getting-started/presentation/presentation-configuration.md
@@ -28,6 +28,7 @@ For creating request payloads and runtime overrides, see
 - `webhook`: **OPTIONAL** - Webhook configuration for receiving verified presentations asynchronously. See [Webhook Integration](../../architecture/webhooks.md#presentation-webhook) for details.
 - `redirectUri`: **OPTIONAL** - URI to redirect the user to after completing the presentation. This is useful for web applications that need to return the user to a specific page after verification. You can use the `{sessionId}` placeholder in the URI, which will be replaced with the actual session ID (e.g., `https://example.com/callback?session={sessionId}`).
 - `transaction_data`: **OPTIONAL** - Array of transaction data objects to include in the OID4VP authorization request. See [Transaction Data](transaction-data.md) for details.
+- `skewSeconds`: **OPTIONAL** - Clock skew tolerance in seconds for credential JWT time validation. Defaults to `60` seconds.
 
 !!! Info
 
@@ -40,6 +41,7 @@ For creating request payloads and runtime overrides, see
     - `webhook` in the request overrides `webhook` from the presentation configuration
     - `redirectUri` in the request overrides `redirectUri` from the presentation configuration
     - `transaction_data` in the request overrides `transaction_data` from the presentation configuration
+    - `skewSeconds` in the request overrides `skewSeconds` from the presentation configuration for that session
 
 ### registrationCert Structure
 

--- a/docs/getting-started/presentation/presentation-requests.md
+++ b/docs/getting-started/presentation/presentation-requests.md
@@ -25,6 +25,7 @@ to request (DCQL, webhook defaults, registration certificate), see
 | `webhook`          | No       | Inline webhook override for this request.                             |
 | `redirectUri`      | No       | Redirect target after completion. Supports `{sessionId}` placeholder. |
 | `transaction_data` | No       | Transaction data override for this request.                           |
+| `skewSeconds`      | No       | Clock skew override in seconds for credential JWT time validation.    |
 | `expected_origin`  | No       | Browser origin for DC API flows. Falls back to the `Origin` header.   |
 
 ---
@@ -57,7 +58,8 @@ to request (DCQL, webhook defaults, registration certificate), see
             "credential_ids": ["pid"],
             "resource": "Building A"
         }
-    ]
+    ],
+    "skewSeconds": 60
 }
 ```
 
@@ -71,6 +73,7 @@ from the presentation configuration for that session:
 - `webhook` overrides configuration `webhook`
 - `redirectUri` overrides configuration `redirectUri`
 - `transaction_data` overrides configuration `transaction_data`
+- `skewSeconds` overrides configuration `skewSeconds`
 
 These values are not merged.
 

--- a/packages/eudiplo-sdk-core/README.md
+++ b/packages/eudiplo-sdk-core/README.md
@@ -159,6 +159,7 @@ const { uri, sessionId } = await client.createPresentationRequest({
   configId: 'age-over-18', // Presentation config ID
   responseType: 'uri', // 'uri' | 'qrcode' | 'dc-api'
   redirectUri: 'https://...', // Optional redirect after completion
+  skewSeconds: 60, // Optional JWT clock skew override for this request
 });
 ```
 

--- a/packages/eudiplo-sdk-core/src/api/schemas.gen.ts
+++ b/packages/eudiplo-sdk-core/src/api/schemas.gen.ts
@@ -4695,6 +4695,11 @@ export const PresentationConfigSchema = {
             type: 'number',
             description: 'Lifetime how long the presentation request is valid after creation, in seconds.'
         },
+        skewSeconds: {
+            type: 'number',
+            description: 'Clock skew tolerance for credential JWT time validation, in seconds.',
+            default: 60
+        },
         dcql_query: {
             description: 'The DCQL query to be used for the VP request.',
             allOf: [
@@ -4837,6 +4842,11 @@ export const PresentationConfigCreateDtoSchema = {
             type: 'number',
             description: 'Lifetime how long the presentation request is valid after creation, in seconds.'
         },
+        skewSeconds: {
+            type: 'number',
+            description: 'Clock skew tolerance for credential JWT time validation, in seconds.',
+            default: 60
+        },
         dcql_query: {
             description: 'The DCQL query to be used for the VP request.',
             allOf: [
@@ -4921,6 +4931,11 @@ export const PresentationConfigUpdateDtoSchema = {
         lifeTime: {
             type: 'number',
             description: 'Lifetime how long the presentation request is valid after creation, in seconds.'
+        },
+        skewSeconds: {
+            type: 'number',
+            description: 'Clock skew tolerance for credential JWT time validation, in seconds.',
+            default: 60
         },
         dcql_query: {
             description: 'The DCQL query to be used for the VP request.',
@@ -6755,6 +6770,10 @@ export const PresentationRequestSchema = {
             items: {
                 $ref: '#/components/schemas/TransactionData'
             }
+        },
+        skewSeconds: {
+            type: 'number',
+            description: 'Optional clock skew tolerance for this presentation offer, in seconds.\nIf provided, this overrides the presentation configuration for the created session.'
         }
     },
     required: [

--- a/packages/eudiplo-sdk-core/src/api/types.gen.ts
+++ b/packages/eudiplo-sdk-core/src/api/types.gen.ts
@@ -2292,6 +2292,10 @@ export type PresentationConfig = {
      */
     lifeTime?: number;
     /**
+     * Clock skew tolerance for credential JWT time validation, in seconds.
+     */
+    skewSeconds?: number;
+    /**
      * The DCQL query to be used for the VP request.
      */
     dcql_query: Dcql;
@@ -2376,6 +2380,10 @@ export type PresentationConfigCreateDto = {
      */
     lifeTime?: number;
     /**
+     * Clock skew tolerance for credential JWT time validation, in seconds.
+     */
+    skewSeconds?: number;
+    /**
      * The DCQL query to be used for the VP request.
      */
     dcql_query: Dcql;
@@ -2430,6 +2438,10 @@ export type PresentationConfigUpdateDto = {
      * Lifetime how long the presentation request is valid after creation, in seconds.
      */
     lifeTime?: number;
+    /**
+     * Clock skew tolerance for credential JWT time validation, in seconds.
+     */
+    skewSeconds?: number;
     /**
      * The DCQL query to be used for the VP request.
      */
@@ -3521,6 +3533,11 @@ export type PresentationRequest = {
      * If provided, this will override the transaction_data from the presentation configuration.
      */
     transaction_data?: Array<TransactionData>;
+    /**
+     * Optional clock skew tolerance for this presentation offer, in seconds.
+     * If provided, this overrides the presentation configuration for the created session.
+     */
+    skewSeconds?: number;
 };
 
 export type FileUploadDto = {

--- a/packages/eudiplo-sdk-core/src/client.ts
+++ b/packages/eudiplo-sdk-core/src/client.ts
@@ -191,6 +191,8 @@ export interface PresentationRequestOptions {
   responseType?: 'uri' | 'dc-api';
   /** Optional redirect URI after presentation completes */
   redirectUri?: string;
+  /** Optional clock skew tolerance for this presentation request, in seconds */
+  skewSeconds?: number;
   /**
    * Optional browser origin used for DC API audience binding.
    * For server-side flows, pass the caller origin explicitly.
@@ -421,6 +423,7 @@ export class EudiploClient {
       response_type: options.responseType ?? 'uri',
       requestId: options.configId,
       redirectUri: options.redirectUri,
+      skewSeconds: options.skewSeconds,
       expected_origin:
         options.responseType === 'dc-api' ? inferredOrigin : undefined,
     };

--- a/schemas/PresentationConfig.schema.json
+++ b/schemas/PresentationConfig.schema.json
@@ -33,6 +33,11 @@
       "type": "number",
       "description": "Lifetime how long the presentation request is valid after creation, in seconds."
     },
+    "skewSeconds": {
+      "type": "number",
+      "description": "Clock skew tolerance for credential JWT time validation, in seconds.",
+      "default": 60
+    },
     "dcql_query": {
       "description": "The DCQL query to be used for the VP request.",
       "allOf": [

--- a/schemas/PresentationConfigCreateDto.schema.json
+++ b/schemas/PresentationConfigCreateDto.schema.json
@@ -17,6 +17,11 @@
       "type": "number",
       "description": "Lifetime how long the presentation request is valid after creation, in seconds."
     },
+    "skewSeconds": {
+      "type": "number",
+      "description": "Clock skew tolerance for credential JWT time validation, in seconds.",
+      "default": 60
+    },
     "dcql_query": {
       "description": "The DCQL query to be used for the VP request.",
       "allOf": [

--- a/schemas/PresentationConfigUpdateDto.schema.json
+++ b/schemas/PresentationConfigUpdateDto.schema.json
@@ -17,6 +17,11 @@
       "type": "number",
       "description": "Lifetime how long the presentation request is valid after creation, in seconds."
     },
+    "skewSeconds": {
+      "type": "number",
+      "description": "Clock skew tolerance for credential JWT time validation, in seconds.",
+      "default": 60
+    },
     "dcql_query": {
       "description": "The DCQL query to be used for the VP request.",
       "allOf": [

--- a/schemas/PresentationRequest.schema.json
+++ b/schemas/PresentationRequest.schema.json
@@ -40,6 +40,10 @@
       "items": {
         "$ref": "./TransactionData.schema.json"
       }
+    },
+    "skewSeconds": {
+      "type": "number",
+      "description": "Optional clock skew tolerance for this presentation offer, in seconds.\nIf provided, this overrides the presentation configuration for the created session."
     }
   },
   "required": [


### PR DESCRIPTION
## Summary
- Add configurable `skewSeconds` for verifier credential time validation with a 60-second default.
- Allow `skewSeconds` on presentation configs and per `/verifier/offer` request, storing request-time overrides on the session.
- Wire the resolved skew into OID4VP, ISO 18013-7, generated schemas, SDK API types, SDK helper options, and documentation.

## Validation
- `pnpm --filter @eudiplo/backend build`
- `pnpm --filter @eudiplo/backend lint`
- `pnpm --filter @eudiplo/sdk-core build`

## Breaking Changes
None.