### PR TITLE
ci: upload coverage to GitHub Code Quality

### DIFF
--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -419,13 +419,14 @@ jobs:
   test-coverage-report:
     permissions:
       contents: read
-    name: Test Coverage & SonarQube Report
+    name: Test Coverage Report
     runs-on: ubuntu-latest
     needs: [lint]
     steps:
       - uses: actions/checkout@v7
         with:
-          fetch-depth: 0 # Full history for SonarQube analysis
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Add entry to /etc/hosts
         run: echo "127.0.0.1       host.testcontainers.internal" | sudo tee -a /etc/hosts
@@ -449,55 +450,55 @@ jobs:
           nohup pnpm --filter test-rp dev &
 
       - name: Run backend unit tests with coverage
-        run: pnpm run --filter @eudiplo/backend test -- --coverage
-        continue-on-error: true
+        run: pnpm --filter @eudiplo/backend exec vitest run --coverage --config ./vitest.config.ts
 
       - name: Run backend E2E tests with coverage
         run: pnpm run --filter @eudiplo/backend test:e2e
         env:
           TESTCONTAINERS_HOST_OVERRIDE: host.testcontainers.internal
-        continue-on-error: true
 
-      - name: Merge coverage reports and fix paths for SonarQube
-        run: |
-          # Install lcov for merging
-          sudo apt-get update && sudo apt-get install -y lcov
-
-          # Create output directory
-          mkdir -p apps/backend/coverage/merged
-
-          # Merge unit and e2e coverage reports
-          if [ -f "apps/backend/coverage/unit/lcov.info" ] && [ -f "apps/backend/coverage/e2e/lcov.info" ]; then
-            lcov -a apps/backend/coverage/unit/lcov.info -a apps/backend/coverage/e2e/lcov.info -o apps/backend/coverage/merged/lcov.info
-            echo "✓ Merged unit and e2e coverage reports"
-          elif [ -f "apps/backend/coverage/unit/lcov.info" ]; then
-            cp apps/backend/coverage/unit/lcov.info apps/backend/coverage/merged/lcov.info
-            echo "✓ Using unit coverage report only"
-          elif [ -f "apps/backend/coverage/e2e/lcov.info" ]; then
-            cp apps/backend/coverage/e2e/lcov.info apps/backend/coverage/merged/lcov.info
-            echo "✓ Using e2e coverage report only"
-          else
-            echo "⚠ No coverage reports found"
-            ls -la apps/backend/coverage/ || echo "Coverage directory not found"
-            exit 1
-          fi
-
-          # Fix absolute paths to relative paths for SonarQube
-          sed -i 's|SF:.*/eudiplo/apps/backend/|SF:apps/backend/|g' apps/backend/coverage/merged/lcov.info
-          echo "✓ Fixed coverage report paths"
-
-      - name: SonarQube Scan
-        uses: SonarSource/sonarqube-scan-action@v3
+      - name: Upload Cobertura coverage artifacts
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v7
         with:
-          args: >
-            -Dsonar.projectKey=eudiplo
-            -Dsonar.sources=apps/backend/src,apps/client/src,packages/eudiplo-sdk-core/src
-            -Dsonar.javascript.lcov.reportPaths=apps/backend/coverage/merged/lcov.info
-            -Dsonar.typescript.lcov.reportPaths=apps/backend/coverage/merged/lcov.info
-        env:
-          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        continue-on-error: true
+          name: backend-cobertura-coverage
+          path: |
+            apps/backend/coverage/unit/cobertura-coverage.xml
+            apps/backend/coverage/e2e/cobertura-coverage.xml
+          if-no-files-found: error
+
+  upload-code-coverage:
+    permissions:
+      contents: read
+      pull-requests: read
+      code-quality: write
+    name: Upload Coverage to GitHub Code Quality
+    runs-on: ubuntu-latest
+    needs: [test-coverage-report]
+    if: >-
+      needs.test-coverage-report.result == 'success' &&
+      (
+        github.event_name != 'pull_request' ||
+        github.event.pull_request.head.repo.full_name == github.repository
+      )
+    steps:
+      - name: Download Cobertura coverage artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: backend-cobertura-coverage
+          path: apps/backend/coverage
+
+      - uses: actions/upload-code-coverage@v1
+        with:
+          file: apps/backend/coverage/unit/cobertura-coverage.xml
+          language: TypeScript
+          label: backend-unit
+
+      - uses: actions/upload-code-coverage@v1
+        with:
+          file: apps/backend/coverage/e2e/cobertura-coverage.xml
+          language: TypeScript
+          label: backend-e2e
 
   # =============================================================================
   # Docker Backend: Build, Test & Push (multi-platform with native runners)

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -37,9 +37,6 @@ sonar.cpd.exclusions=\
   **/*.e2e-spec.ts,\
   **/fixtures/**
 
-# Coverage report location (Vitest E2E — requires test-e2e job to run first)
-sonar.javascript.lcov.reportPaths=apps/backend/coverage/e2e/lcov.info
-
 # TypeScript configuration
 sonar.typescript.tsconfigPaths=apps/backend/tsconfig.json
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 ![License](https://img.shields.io/github/license/openwallet-foundation/eudiplo)
 [![Website](https://img.shields.io/badge/website-eudiplo-blue)](https://openwallet-foundation.github.io/eudiplo/docs/latest/)
 [![Documentation Coverage](https://openwallet-foundation.github.io/eudiplo/main/compodoc/images/coverage-badge-documentation.svg)](https://openwallet-foundation.github.io/eudiplo/main/compodoc/coverage.html)
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=openwallet-foundation_eudiplo&metric=coverage)](https://sonarcloud.io/project/overview?id=openwallet-foundation_eudiplo)
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=openwallet-foundation_eudiplo&metric=security_rating)](https://sonarcloud.io/project/overview?id=openwallet-foundation_eudiplo)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=openwallet-foundation_eudiplo&metric=alert_status)](https://sonarcloud.io/project/overview?id=openwallet-foundation_eudiplo)
 [![Join our Discord](https://img.shields.io/discord/1022962884864643214?label=Join%20our%20Discord&logo=discord&color=7289DA&labelColor=2C2F33)](https://discord.gg/58ys8XfXDu)

--- a/apps/backend/test/vitest.config.ts
+++ b/apps/backend/test/vitest.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
         coverage: {
             provider: "v8",
             reportsDirectory: "./coverage/e2e",
-            reporter: ["text", "lcov"],
+            reporter: ["text", "lcov", "cobertura"],
             cleanOnRerun: false,
         },
         reporters: ["default", "junit"],

--- a/apps/backend/vitest.config.ts
+++ b/apps/backend/vitest.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
         coverage: {
             provider: "v8",
             reportsDirectory: "./coverage/unit",
-            reporter: ["text", "lcov"],
+            reporter: ["text", "lcov", "cobertura"],
             cleanOnRerun: false,
         },
     },


### PR DESCRIPTION
## 📝 Description

Replace the token-based SonarQube coverage scan in CI with GitHub native Code Coverage uploads (Cobertura), while keeping SonarQube Cloud Automatic Analysis as the Sonar source of truth.

Fixes #N/A

## 🔄 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test improvements
- [x] 🏗️ Build/CI changes

## 💥 Breaking Changes (if applicable)

None.

## 🧪 Testing

- [x] Unit tests pass
- [ ] Integration tests pass
- [ ] E2E tests pass
- [x] Manual testing performed

**Test Configuration**:

- Node.js version: local environment default
- OS: macOS
- Test environment: local

Executed:
- `pnpm --filter @eudiplo/backend exec vitest run --coverage --config ./vitest.config.ts` (pass)
- `pnpm --filter @eudiplo/backend lint` (pass)
- `pnpm run --filter @eudiplo/backend test:e2e` (fails locally in multiple existing E2E tests; Docker/Testcontainers are available, but suite currently fails in this environment)
- `actionlint .github/workflows/ci-and-release.yml` (not available locally)

## 📸 Screenshots (if applicable)

N/A

## ✔️ Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## 📋 Additional Notes

What changed:
- Added Cobertura output in both backend Vitest configs:
  - `apps/backend/vitest.config.ts`
  - `apps/backend/test/vitest.config.ts`
- Refactored CI workflow:
  - Added `test-coverage-report` job with `permissions: contents: read` only
  - Coverage job checks out `ref: ${{ github.event.pull_request.head.sha || github.sha }}` for accurate PR mapping
  - Runs unit + non-OIDF E2E coverage tests without `continue-on-error`
  - Uploads both Cobertura files in one artifact via `actions/upload-artifact@v7`
  - Removed SonarQube token-based scan step and any use of `SONAR_TOKEN` / `SONAR_HOST_URL`
- Added separate least-privilege `upload-code-coverage` job:
  - `permissions: contents: read, pull-requests: read, code-quality: write`
  - No checkout and no repository code execution
  - Skips external fork PR uploads via:
    - `needs.test-coverage-report.result == 'success' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)`
  - Uploads both reports via `actions/upload-code-coverage@v1`

Sonar:
- Updated `.sonarcloud.properties` to remove `sonar.javascript.lcov.reportPaths` and its coverage comment.
- SonarQube Cloud Automatic Analysis remains enabled; no Sonar scan runs from GitHub Actions.

Operational note:
- External fork PRs intentionally skip the privileged coverage upload job.
- GitHub Code Quality/coverage upload may require org-level enablement by an administrator and can incur billing.
- No coverage percentage thresholds are introduced in this PR; threshold policy can be configured as a follow-up decision.
