### PR TITLE
fix(#860): fail closed when a configured trust list cannot be loaded

### DIFF
--- a/apps/backend/src/verifier/presentations/credential/credential-chain-validation.service.spec.ts
+++ b/apps/backend/src/verifier/presentations/credential/credential-chain-validation.service.spec.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { TrustListSource } from "../../../shared/trust/types";
+import { CredentialChainValidationService } from "./credential-chain-validation.service";
+
+/**
+ * Regression tests for the trust-list fail-open bug.
+ *
+ * `getTrustStoreIfConfigured` used to swallow every load error (and stale-list
+ * case) and return `null`, which `validateChain` treated identically to "no
+ * trust list configured" — returning `verified: true`. A verifier that had
+ * configured a LoTE trust list would then silently accept ANY credential
+ * whenever the list was unreachable, unparseable, or stale. Verification must
+ * instead fail closed.
+ */
+describe("CredentialChainValidationService — trust list availability", () => {
+    const LOTE_SOURCE: TrustListSource = {
+        lotes: [{ url: "https://trust.example/lote.jwt" }],
+    } as TrustListSource;
+
+    let trustStore: { getTrustStore: ReturnType<typeof vi.fn> };
+    let federationTrustService: Record<string, ReturnType<typeof vi.fn>>;
+    let x509v: Record<string, ReturnType<typeof vi.fn>>;
+    let service: CredentialChainValidationService;
+
+    beforeEach(() => {
+        trustStore = { getTrustStore: vi.fn() };
+        // Plain LoTE mode: no federation, use LoTE, hybrid without enforced
+        // signing policy → enforceFederationPolicy = false (the vulnerable path).
+        federationTrustService = {
+            shouldUseFederation: vi.fn().mockReturnValue(false),
+            shouldUseLote: vi.fn().mockReturnValue(true),
+            getMode: vi.fn().mockReturnValue("hybrid"),
+            evaluateCertificateEntityTrust: vi.fn(),
+        };
+        x509v = {
+            parseX5c: vi.fn().mockReturnValue([{ subject: "leaf" }]),
+        };
+        const logger = {
+            setContext: vi.fn(),
+            error: vi.fn(),
+            warn: vi.fn(),
+            debug: vi.fn(),
+        };
+
+        service = new CredentialChainValidationService(
+            trustStore as any,
+            federationTrustService as any,
+            x509v as any,
+            {} as any, // statusListVerifier — unused on these paths
+            logger as any,
+        );
+    });
+
+    it("fails closed when a configured trust list cannot be loaded", async () => {
+        trustStore.getTrustStore.mockRejectedValue(
+            new Error("getaddrinfo ENOTFOUND trust.example"),
+        );
+
+        const result = await service.validateChain(["<cert>"], LOTE_SOURCE, {});
+
+        expect(result.verified).toBe(false);
+        expect(result.error).toBe("trust_list_unavailable");
+    });
+
+    it("fails closed when the configured trust list is stale (NextUpdate in the past)", async () => {
+        trustStore.getTrustStore.mockResolvedValue({
+            entities: [],
+            nextUpdate: new Date(Date.now() - 86_400_000).toISOString(),
+        });
+
+        const result = await service.validateChain(["<cert>"], LOTE_SOURCE, {});
+
+        expect(result.verified).toBe(false);
+        expect(result.error).toBe("trust_list_unavailable");
+    });
+
+    it("skips trust validation (opt-out) when no trust list is configured", async () => {
+        // No lotes configured → legitimate opt-out, preserve fail-open behavior.
+        const result = await service.validateChain(["<cert>"], undefined, {});
+
+        expect(result.verified).toBe(true);
+        expect(trustStore.getTrustStore).not.toHaveBeenCalled();
+    });
+
+    it("does not throw from best-effort buffer loading when the trust list is unavailable", async () => {
+        trustStore.getTrustStore.mockRejectedValue(new Error("boom"));
+
+        // Non-authoritative anchor augmentation: returns [] rather than throwing.
+        await expect(
+            service.getTrustedCertificateBuffers(LOTE_SOURCE),
+        ).resolves.toEqual([]);
+    });
+});

--- a/apps/backend/src/verifier/presentations/credential/credential-chain-validation.service.ts
+++ b/apps/backend/src/verifier/presentations/credential/credential-chain-validation.service.ts
@@ -18,6 +18,23 @@ import {
 } from "../../../shared/trust/x509-validation.service";
 
 /**
+ * Raised when a trust list WAS configured for a credential but could not be
+ * turned into a usable trust store — the fetch/parse/signature check failed, or
+ * the list is stale (its `NextUpdate` is in the past).
+ *
+ * This is deliberately distinct from "no trust list configured": the latter is a
+ * legitimate opt-out (trust validation is opt-in per credential), whereas this
+ * error means a requested security control is unavailable and verification MUST
+ * fail closed rather than silently accept the credential.
+ */
+class TrustListUnavailableError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "TrustListUnavailableError";
+    }
+}
+
+/**
  * Policy options for certificate chain validation.
  */
 export interface ChainValidationPolicy {
@@ -168,8 +185,37 @@ export class CredentialChainValidationService {
             };
         }
 
-        // 4) Load trust store for LoTE-based validation
-        const store = await this.getTrustStoreIfConfigured(trustListSource);
+        // 4) Load trust store for LoTE-based validation.
+        // A configured-but-unavailable trust list (fetch/parse/signature failure
+        // or stale list) MUST fail closed — never accept a credential when a
+        // requested trust list cannot be evaluated. Under an enforced federation
+        // policy, defer to the federation result (LoTE is supplementary there).
+        let store: BuiltTrustStore | null;
+        try {
+            store = await this.getTrustStoreIfConfigured(trustListSource);
+        } catch (error) {
+            if (error instanceof TrustListUnavailableError) {
+                if (enforceFederationPolicy) {
+                    return {
+                        verified: Boolean(federationTrustResult?.trusted),
+                        matchedEntity: null,
+                        error: federationTrustResult?.trusted
+                            ? undefined
+                            : "trust_list_unavailable",
+                        errorDetails:
+                            federationTrustResult?.reason ?? error.message,
+                    };
+                }
+
+                return {
+                    verified: false,
+                    matchedEntity: null,
+                    error: "trust_list_unavailable",
+                    errorDetails: error.message,
+                };
+            }
+            throw error;
+        }
         if (!store) {
             if (enforceFederationPolicy) {
                 return {
@@ -365,7 +411,7 @@ export class CredentialChainValidationService {
     async getTrustedCertificateBuffers(
         trustListSource?: TrustListSource,
     ): Promise<Uint8Array[]> {
-        const store = await this.getTrustStoreIfConfigured(trustListSource);
+        const store = await this.getTrustStoreForAugmentation(trustListSource);
         if (!store) {
             return [];
         }
@@ -403,7 +449,7 @@ export class CredentialChainValidationService {
     async getTrustedStatusCertificateBuffers(
         trustListSource?: TrustListSource,
     ): Promise<Uint8Array[]> {
-        const store = await this.getTrustStoreIfConfigured(trustListSource);
+        const store = await this.getTrustStoreForAugmentation(trustListSource);
         if (!store) {
             return [];
         }
@@ -435,8 +481,37 @@ export class CredentialChainValidationService {
     }
 
     /**
-     * Get the trust store if configured.
+     * Load the configured trust store.
+     *
+     * Returns `null` ONLY when no trust list is configured for the credential
+     * (legitimate opt-out). When a trust list IS configured but cannot be turned
+     * into a usable store — the fetch/parse/signature check fails, or the list is
+     * stale ({@link BuiltTrustStore.nextUpdate} in the past) — it throws
+     * {@link TrustListUnavailableError} so callers can fail closed instead of
+     * silently accepting the credential.
      */
+    /**
+     * Best-effort trust store load for NON-authoritative anchor augmentation
+     * (supplying extra certificates to the mDOC signature check).
+     *
+     * Unlike {@link getTrustStoreIfConfigured}, an unavailable/stale trust list is
+     * swallowed to `null` here: the authoritative trust decision is made by
+     * {@link validateChain}, which fails closed on {@link TrustListUnavailableError}.
+     * Returning no extra anchors from this path is therefore safe.
+     */
+    private async getTrustStoreForAugmentation(
+        trustListSource?: TrustListSource,
+    ): Promise<BuiltTrustStore | null> {
+        try {
+            return await this.getTrustStoreIfConfigured(trustListSource);
+        } catch (error) {
+            if (error instanceof TrustListUnavailableError) {
+                return null;
+            }
+            throw error;
+        }
+    }
+
     private async getTrustStoreIfConfigured(
         trustListSource?: TrustListSource,
     ): Promise<BuiltTrustStore | null> {
@@ -444,26 +519,25 @@ export class CredentialChainValidationService {
             return null;
         }
 
+        let store: BuiltTrustStore;
         try {
-            const store = await this.trustStore.getTrustStore(trustListSource);
-
-            if (store.nextUpdate) {
-                const nu = new Date(store.nextUpdate);
-                if (!Number.isNaN(nu.getTime()) && nu.getTime() < Date.now()) {
-                    this.logger.warn(
-                        `Trust list NextUpdate is in the past: ${store.nextUpdate}`,
-                    );
-                    return null;
-                }
-            }
-
-            return store;
+            store = await this.trustStore.getTrustStore(trustListSource);
         } catch (error: any) {
-            this.logger.error(
-                `Failed to load trust store: ${error?.message ?? error}`,
-            );
-            return null;
+            const message = `Failed to load configured trust store: ${error?.message ?? error}`;
+            this.logger.error(message);
+            throw new TrustListUnavailableError(message);
         }
+
+        if (store.nextUpdate) {
+            const nu = new Date(store.nextUpdate);
+            if (!Number.isNaN(nu.getTime()) && nu.getTime() < Date.now()) {
+                const message = `Configured trust list is stale (NextUpdate in the past: ${store.nextUpdate})`;
+                this.logger.warn(message);
+                throw new TrustListUnavailableError(message);
+            }
+        }
+
+        return store;
     }
 
     /**

--- a/apps/backend/src/verifier/presentations/credential/mdocverifier/mdocverifier.service.ts
+++ b/apps/backend/src/verifier/presentations/credential/mdocverifier/mdocverifier.service.ts
@@ -389,6 +389,8 @@ export class MdocverifierService {
                 return "no_trust_chain_to_root";
             case "no_trusted_entity_match":
                 return "trust_chain_not_trusted";
+            case "trust_list_unavailable":
+                return "trust_chain_not_trusted";
             default:
                 return "verification_error";
         }

--- a/apps/backend/test/presentation/presentation-transaction-data.e2e-spec.ts
+++ b/apps/backend/test/presentation/presentation-transaction-data.e2e-spec.ts
@@ -18,10 +18,7 @@ import {
     ResponseType,
 } from "../../src/verifier/oid4vp/dto/presentation-request.dto";
 import { PresentationConfigCreateDto } from "../../src/verifier/presentations/dto/presentation-config-create.dto";
-import {
-    TransactionData,
-    TrustedAuthorityType,
-} from "../../src/verifier/presentations/entities/presentation-config.entity";
+import { TransactionData } from "../../src/verifier/presentations/entities/presentation-config.entity";
 import {
     callbacks,
     createPresentationRequest,
@@ -312,14 +309,12 @@ describe("Presentation - Transaction Data", () => {
                                     path: ["address", "locality"],
                                 },
                             ],
-                            trusted_authorities: [
-                                {
-                                    type: TrustedAuthorityType.ETSI_TL,
-                                    values: [
-                                        `${host}/issuers/demo/trust-list/580831bc-ef11-43f4-a3be-a2b6bf1b29a3`,
-                                    ],
-                                },
-                            ],
+                            // No trusted_authorities: these tests exercise
+                            // transaction data, not trust-list validation. The
+                            // previous value referenced a trust list that was
+                            // never created, so it only ever "passed" because
+                            // trust validation used to fail open on load errors
+                            // (fixed in credential-chain-validation.service.ts).
                         },
                     ],
                 },


### PR DESCRIPTION
## 📝 Description

`CredentialChainValidationService.getTrustStoreIfConfigured` collapsed three
distinct outcomes into a single `null` return — (1) no trust list configured,
(2) a stale trust list (`NextUpdate` in the past), and (3) a load/parse/signature
failure — and `validateChain` treated all three the same as "no trust list
configured", returning `{ verified: true }`.

As a result, a verifier that had configured a LoTE trust list (via
`trusted_authorities`) to enforce issuer trust would **silently accept any
credential** — including one from an untrusted or attacker-controlled issuer —
whenever the trust list was unreachable, unparseable, or stale. Because
`validateChain` is the shared, authoritative gate, this fail-open affected both
mDOC and SD-JWT-VC verification.

This PR makes verification **fail closed**: a configured-but-unavailable (or
stale) trust list is distinguished from "not configured" and rejected, so a
requested trust control is never silently bypassed.

Fixes #860

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 💥 Breaking Changes (if applicable)

Not a breaking change in the API sense — **no** API, environment variable,
config-import, or database changes, and no migration.

Intentional **behavioral** change (security): a credential whose configured
trust list cannot be loaded/verified, or which is stale, now **fails**
verification (`trust_list_unavailable`, mapped to `trust_chain_not_trusted` for
mDOC) instead of passing. Configurations with **no** trust list are unaffected
(trust validation remains opt-in per credential).

## 🧪 Testing

Describe the tests that you ran to verify your changes:

- [x] Unit tests pass
- [ ] Integration tests pass
- [x] E2E tests pass
- [ ] Manual testing performed

Details:

- New `credential-chain-validation.service.spec.ts`: fail-closed on load
  failure, fail-closed on a stale list, the no-trust-list opt-out still returns
  `verified: true`, and the best-effort buffer helpers do not throw.
- `presentation-transaction-data.e2e-spec.ts` was passing *because of* this bug —
  it configured a `trusted_authorities` trust list that is never created in the
  setup, so the fetch always failed and two presentations only returned `200` via
  fail-open. With the fix they correctly return `400`, so the non-functional
  `trusted_authorities` block is removed (those tests exercise transaction data,
  not trust-list validation). The adaptation is included and is required for CI
  to pass alongside the fix.

**Test Configuration**:

- Node.js version: <fill in, e.g. 22.x>
- OS: <fill in>
- Test environment: eudiplo backend, SQLite (default)

## 📸 Screenshots (if applicable)

N/A

## ✔️ Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (N/A — no
      user-facing behavior to document beyond the changed failure mode)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules (N/A)

## 📋 Additional Notes

- `validateChain` is the single authoritative trust gate for both mDOC and
  SD-JWT-VC, so this fix covers all presentation verification paths.
- Under an enforced OpenID Federation policy, an unavailable LoTE defers to the
  federation result (LoTE is supplementary there); otherwise it fails closed.
- The non-authoritative anchor-augmentation helpers
  (`getTrustedCertificateBuffers` / `getTrustedStatusCertificateBuffers`) keep
  returning `[]` via a best-effort wrapper — the authoritative decision stays in
  `validateChain`.
- Worth highlighting: the existing test suite was green *because of* this
  fail-open behavior; the included e2e adaptation is what makes it assert the
  correct (fail-closed) result.
