### PR TITLE
fix: normalize mdoc PID field namespace mapping

### DIFF
--- a/apps/backend/src/issuer/configuration/credentials/issuer/mdoc-issuer/mdoc-issuer.service.ts
+++ b/apps/backend/src/issuer/configuration/credentials/issuer/mdoc-issuer/mdoc-issuer.service.ts
@@ -57,29 +57,12 @@ export class MdocIssuerService {
         const issuer = new Issuer(docType, mdocContext);
 
         const defaultNamespace = this.getDefaultNamespace(docType);
-        const claimsByNamespace = buildClaimsByNamespace(
+        this.addClaimsToIssuer(
+            issuer,
             credentialConfiguration.fields as any,
+            defaultNamespace,
+            claims,
         );
-        const namespaceNames = new Set(Object.keys(claimsByNamespace));
-        const defaultNamespaceClaims =
-            claims && typeof claims === "object" && !Array.isArray(claims)
-                ? Object.fromEntries(
-                      Object.entries(claims).filter(
-                          ([key]) => !namespaceNames.has(key),
-                      ),
-                  )
-                : {};
-
-        if (claimsByNamespace && Object.keys(claimsByNamespace).length > 0) {
-            // Multiple namespaces specified
-            for (const [ns, nsClaims] of Object.entries(claimsByNamespace)) {
-                issuer.addIssuerNamespace(ns, nsClaims);
-            }
-        }
-
-        if (Object.keys(defaultNamespaceClaims).length > 0) {
-            issuer.addIssuerNamespace(defaultNamespace, defaultNamespaceClaims);
-        }
 
         // Get signing certificate
         const certificate = await this.certService.find({
@@ -237,5 +220,51 @@ export class MdocIssuerService {
         }
         // For other docTypes, use the docType as namespace
         return docType;
+    }
+
+    private addClaimsToIssuer(
+        issuer: Issuer,
+        fields: any,
+        defaultNamespace: string,
+        claims: Record<string, any>,
+    ): void {
+        const claimsByNamespace = buildClaimsByNamespace(fields);
+        const namespaceNames = new Set(Object.keys(claimsByNamespace));
+        const defaultNamespaceClaims =
+            claims && typeof claims === "object" && !Array.isArray(claims)
+                ? Object.fromEntries(
+                      Object.entries(claims).filter(
+                          ([key]) => !namespaceNames.has(key),
+                      ),
+                  )
+                : {};
+
+        // Merge claims per namespace first, then add each namespace once.
+        // This avoids duplicate issuer-signed items when fallback claims map
+        // to the same default namespace already populated from field defaults.
+        const mergedClaimsByNamespace: Record<string, Record<string, unknown>> =
+            {};
+
+        for (const [ns, nsClaims] of Object.entries(claimsByNamespace)) {
+            mergedClaimsByNamespace[ns] = {
+                ...nsClaims,
+            };
+        }
+
+        if (Object.keys(defaultNamespaceClaims).length > 0) {
+            const existingDefaultNamespaceClaims =
+                mergedClaimsByNamespace[defaultNamespace] ?? {};
+            mergedClaimsByNamespace[defaultNamespace] = {
+                ...existingDefaultNamespaceClaims,
+                ...defaultNamespaceClaims,
+            };
+        }
+
+        for (const [ns, nsClaims] of Object.entries(mergedClaimsByNamespace)) {
+            if (Object.keys(nsClaims).length === 0) {
+                continue;
+            }
+            issuer.addIssuerNamespace(ns, nsClaims);
+        }
     }
 }

--- a/apps/backend/src/issuer/configuration/credentials/issuer/mdoc-issuer/mdoc-issuer.service.ts
+++ b/apps/backend/src/issuer/configuration/credentials/issuer/mdoc-issuer/mdoc-issuer.service.ts
@@ -242,8 +242,10 @@ export class MdocIssuerService {
         // Merge claims per namespace first, then add each namespace once.
         // This avoids duplicate issuer-signed items when fallback claims map
         // to the same default namespace already populated from field defaults.
-        const mergedClaimsByNamespace: Record<string, Record<string, unknown>> =
-            {};
+        const mergedClaimsByNamespace: Record<
+            string,
+            Record<string, unknown>
+        > = {};
 
         for (const [ns, nsClaims] of Object.entries(claimsByNamespace)) {
             mergedClaimsByNamespace[ns] = {

--- a/apps/backend/src/issuer/configuration/credentials/utils/derive.ts
+++ b/apps/backend/src/issuer/configuration/credentials/utils/derive.ts
@@ -388,11 +388,11 @@ export function buildClaimsMetadata(
         .filter((field) => field.path.length > 0)
         .map((field) => {
             const metadata: ClaimMetadata = {
-                path: [
-                    field.namespace!,
-                    ...field.path.map((segment) => segmentToKey(segment)),
-                ],
+                path: field.path.map((segment) => segmentToKey(segment)),                
             };
+            if(field.namespace) {
+                metadata.path = [field.namespace, ...metadata.path];
+            }
 
             if (typeof field.mandatory === "boolean") {
                 metadata.mandatory = field.mandatory;

--- a/apps/backend/src/issuer/configuration/credentials/utils/derive.ts
+++ b/apps/backend/src/issuer/configuration/credentials/utils/derive.ts
@@ -386,9 +386,12 @@ export function buildClaimsMetadata(
 ): ClaimMetadata[] {
     return flattenFields(fields)
         .filter((field) => field.path.length > 0)
-        .map((field) => {            
+        .map((field) => {
             const metadata: ClaimMetadata = {
-                path: [field.namespace!, ...field.path.map((segment) => segmentToKey(segment))],
+                path: [
+                    field.namespace!,
+                    ...field.path.map((segment) => segmentToKey(segment)),
+                ],
             };
 
             if (typeof field.mandatory === "boolean") {

--- a/apps/backend/src/issuer/configuration/credentials/utils/derive.ts
+++ b/apps/backend/src/issuer/configuration/credentials/utils/derive.ts
@@ -388,9 +388,9 @@ export function buildClaimsMetadata(
         .filter((field) => field.path.length > 0)
         .map((field) => {
             const metadata: ClaimMetadata = {
-                path: field.path.map((segment) => segmentToKey(segment)),                
+                path: field.path.map((segment) => segmentToKey(segment)),
             };
-            if(field.namespace) {
+            if (field.namespace) {
                 metadata.path = [field.namespace, ...metadata.path];
             }
 

--- a/apps/backend/src/issuer/configuration/credentials/utils/derive.ts
+++ b/apps/backend/src/issuer/configuration/credentials/utils/derive.ts
@@ -386,9 +386,9 @@ export function buildClaimsMetadata(
 ): ClaimMetadata[] {
     return flattenFields(fields)
         .filter((field) => field.path.length > 0)
-        .map((field) => {
+        .map((field) => {            
             const metadata: ClaimMetadata = {
-                path: field.path.map((segment) => segmentToKey(segment)),
+                path: [field.namespace!, ...field.path.map((segment) => segmentToKey(segment))],
             };
 
             if (typeof field.mandatory === "boolean") {

--- a/apps/backend/test/fixtures/haip/issuance/credentials/pid-mdoc-no-key.json
+++ b/apps/backend/test/fixtures/haip/issuance/credentials/pid-mdoc-no-key.json
@@ -18,72 +18,72 @@
   "lifeTime": 604800,
   "fields": [
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "age_birth_year"
       ],
       "type": "integer",
       "defaultValue": 1964
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "age_in_years"
       ],
       "type": "integer",
       "defaultValue": 61
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "age_over_12"
       ],
       "type": "boolean",
       "defaultValue": true
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "age_over_14"
       ],
       "type": "boolean",
       "defaultValue": true
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "age_over_16"
       ],
       "type": "boolean",
       "defaultValue": true
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "age_over_18"
       ],
       "type": "boolean",
       "defaultValue": true
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "age_over_21"
       ],
       "type": "boolean",
       "defaultValue": true
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "age_over_65"
       ],
       "type": "boolean",
       "defaultValue": false
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "birth_date"
       ],
       "type": "string",
@@ -94,16 +94,16 @@
       }
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "birth_place"
       ],
       "type": "string",
       "defaultValue": "BERLIN"
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "expiry_date"
       ],
       "type": "string",
@@ -114,16 +114,16 @@
       }
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "family_name_birth"
       ],
       "type": "string",
       "defaultValue": "GABLER"
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "family_name"
       ],
       "type": "string",
@@ -131,8 +131,8 @@
       "mandatory": true
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "given_name"
       ],
       "type": "string",
@@ -140,8 +140,8 @@
       "mandatory": true
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "issuance_date"
       ],
       "type": "string",
@@ -152,8 +152,8 @@
       }
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "issuing_authority"
       ],
       "type": "string",
@@ -161,8 +161,8 @@
       "mandatory": true
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "issuing_country"
       ],
       "type": "string",
@@ -170,48 +170,48 @@
       "mandatory": true
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "nationality"
       ],
       "type": "string",
       "defaultValue": "DE"
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "resident_city"
       ],
       "type": "string",
       "defaultValue": "KÖLN"
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "resident_country"
       ],
       "type": "string",
       "defaultValue": "DE"
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "resident_postal_code"
       ],
       "type": "string",
       "defaultValue": "51147"
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "resident_street"
       ],
       "type": "string",
       "defaultValue": "HEIDESTRAẞE 17"
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "source_document_type"
       ],
       "type": "string",

--- a/apps/backend/test/fixtures/haip/issuance/credentials/pid-mdoc.json
+++ b/apps/backend/test/fixtures/haip/issuance/credentials/pid-mdoc.json
@@ -28,72 +28,72 @@
   "lifeTime": 604800,
   "fields": [
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "age_birth_year"
       ],
       "type": "integer",
       "defaultValue": 1964
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "age_in_years"
       ],
       "type": "integer",
       "defaultValue": 61
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "age_over_12"
       ],
       "type": "boolean",
       "defaultValue": true
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "age_over_14"
       ],
       "type": "boolean",
       "defaultValue": true
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "age_over_16"
       ],
       "type": "boolean",
       "defaultValue": true
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "age_over_18"
       ],
       "type": "boolean",
       "defaultValue": true
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "age_over_21"
       ],
       "type": "boolean",
       "defaultValue": true
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "age_over_65"
       ],
       "type": "boolean",
       "defaultValue": false
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "birth_date"
       ],
       "type": "string",
@@ -104,16 +104,16 @@
       }
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "birth_place"
       ],
       "type": "string",
       "defaultValue": "BERLIN"
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "expiry_date"
       ],
       "type": "string",
@@ -124,16 +124,16 @@
       }
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "family_name_birth"
       ],
       "type": "string",
       "defaultValue": "GABLER"
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "family_name"
       ],
       "type": "string",
@@ -141,8 +141,8 @@
       "mandatory": true
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "given_name"
       ],
       "type": "string",
@@ -150,8 +150,8 @@
       "mandatory": true
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "issuance_date"
       ],
       "type": "string",
@@ -162,8 +162,8 @@
       }
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "issuing_authority"
       ],
       "type": "string",
@@ -171,8 +171,8 @@
       "mandatory": true
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "issuing_country"
       ],
       "type": "string",
@@ -180,48 +180,48 @@
       "mandatory": true
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "nationality"
       ],
       "type": "string",
       "defaultValue": "DE"
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "resident_city"
       ],
       "type": "string",
       "defaultValue": "KÖLN"
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "resident_country"
       ],
       "type": "string",
       "defaultValue": "DE"
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "resident_postal_code"
       ],
       "type": "string",
       "defaultValue": "51147"
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "resident_street"
       ],
       "type": "string",
       "defaultValue": "HEIDESTRAẞE 17"
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "source_document_type"
       ],
       "type": "string",

--- a/apps/backend/test/issuance/issuance-claims-metadata.e2e-spec.ts
+++ b/apps/backend/test/issuance/issuance-claims-metadata.e2e-spec.ts
@@ -209,11 +209,11 @@ describe("Issuance - Claims Metadata", () => {
         expect(credConfig.credential_metadata).toBeDefined();
         expect(credConfig.credential_metadata.claims).toBeDefined();
         expect(credConfig.credential_metadata.claims).toHaveLength(2);
-
+        
         // Check mDOC claim path structure [namespace, claim_name]
         const givenNameClaim = credConfig.credential_metadata.claims.find(
             (c: any) =>
-                JSON.stringify(c.path) === JSON.stringify(["given_name"]),
+                JSON.stringify(c.path) === JSON.stringify([ "org.test.claims", "given_name"]),
         );
         expect(givenNameClaim).toBeDefined();
     });

--- a/apps/backend/test/issuance/issuance-claims-metadata.e2e-spec.ts
+++ b/apps/backend/test/issuance/issuance-claims-metadata.e2e-spec.ts
@@ -209,11 +209,12 @@ describe("Issuance - Claims Metadata", () => {
         expect(credConfig.credential_metadata).toBeDefined();
         expect(credConfig.credential_metadata.claims).toBeDefined();
         expect(credConfig.credential_metadata.claims).toHaveLength(2);
-        
+
         // Check mDOC claim path structure [namespace, claim_name]
         const givenNameClaim = credConfig.credential_metadata.claims.find(
             (c: any) =>
-                JSON.stringify(c.path) === JSON.stringify([ "org.test.claims", "given_name"]),
+                JSON.stringify(c.path) ===
+                JSON.stringify(["org.test.claims", "given_name"]),
         );
         expect(givenNameClaim).toBeDefined();
     });

--- a/apps/backend/test/issuance/issuance-mdoc.e2e-spec.ts
+++ b/apps/backend/test/issuance/issuance-mdoc.e2e-spec.ts
@@ -19,12 +19,18 @@ import {
     test,
     vi,
 } from "vitest";
+import { MdocIssuerService } from "../../src/issuer/configuration/credentials/issuer/mdoc-issuer/mdoc-issuer.service";
 import {
     callbacks,
     getSignJwtCallback,
     IssuanceTestContext,
     setupIssuanceTestApp,
 } from "../utils";
+import { mdocContext } from "../utils-mdoc";
+
+function createMdocIssuerService() {
+    return new MdocIssuerService({} as any, {} as any, {} as any);
+}
 
 setGlobalDispatcher(
     new Agent({
@@ -145,8 +151,8 @@ describe("Issuance - mDOC Credentials", () => {
 
         const credential: string = (
             credentialResponse.credentialResponse.credentials?.[0] as any
-        ).credential;
-        expect(credential).toBeDefined();
+        ).credential;        
+        expect(credential).toBeDefined();        
 
         // mDOC credential should be a base64url encoded string
         expect(typeof credential).toBe("string");
@@ -162,5 +168,290 @@ describe("Issuance - mDOC Credentials", () => {
                 birth_date: "1964-08-12",
             }),
         );
+    });
+
+    test("issue mso_mdoc credential with inline claims from credential offer", async () => {
+        const addNamespaceSpy = vi.spyOn(
+            Issuer.prototype as any,
+            "addIssuerNamespace",
+        );
+
+        // Create an offer for mDOC credential with inline claims override
+        const offerResponse = await request(app.getHttpServer())
+            .post("/issuer/offer")
+            .trustLocalhost()
+            .set("Authorization", `Bearer ${authToken}`)
+            .send({
+                response_type: "uri",
+                credentialConfigurationIds: ["pid-mdoc-no-key"],
+                flow: "pre_authorized_code",
+                credentialClaims: {
+                    "pid-mdoc-no-key": {
+                        type: "inline",
+                        claims: {
+                            birth_date: "1999-12-31",
+                            expiry_date: "2035-01-14",
+                            family_name: "OFFER_OVERRIDE",
+                            given_name: "ERIKA",
+                            issuance_date: "2025-01-14",
+                            issuing_authority: "DE",
+                            issuing_country: "DE",
+                        },
+                    },
+                },
+            })
+            .expect(201);
+
+        expect(offerResponse.body.uri).toBeDefined();
+
+        const holderKeyPair = await generateKeyPair("ES256", {
+            extractable: true,
+        });
+        const holderPrivateKeyJwk = await exportJWK(holderKeyPair.privateKey);
+        const holderPublicKeyJwk = await exportJWK(holderKeyPair.publicKey);
+
+        const client = new Openid4vciClient({
+            callbacks: {
+                ...callbacks,
+                clientAuthentication: clientAuthenticationAnonymous(),
+                signJwt: getSignJwtCallback([holderPrivateKeyJwk as Jwk]),
+            },
+        });
+
+        const credentialOffer = await client.resolveCredentialOffer(
+            offerResponse.body.uri,
+        );
+        const issuerMetadata = await client.resolveIssuerMetadata(
+            credentialOffer.credential_issuer,
+        );
+
+        const { accessTokenResponse } =
+            await client.retrievePreAuthorizedCodeAccessTokenFromOffer({
+                credentialOffer,
+                issuerMetadata,
+            });
+
+        const nonceResponse = await client.requestNonce({ issuerMetadata });
+        expect(nonceResponse.c_nonce).toBeDefined();
+
+        const { jwt: proofJwt } = await client.createCredentialRequestJwtProof({
+            issuerMetadata,
+            signer: {
+                method: "jwk",
+                alg: "ES256",
+                publicJwk: holderPublicKeyJwk,
+            } as JwtSignerJwk,
+            clientId,
+            issuedAt: new Date(),
+            credentialConfigurationId:
+                credentialOffer.credential_configuration_ids[0],
+            nonce: nonceResponse.c_nonce,
+        });
+
+        const credentialResponse = await client.retrieveCredentials({
+            accessToken: accessTokenResponse.access_token,
+            credentialConfigurationId:
+                credentialOffer.credential_configuration_ids[0],
+            issuerMetadata,
+            proofs: {
+                jwt: [proofJwt],
+            },
+        });
+
+        const credential: string = (
+            credentialResponse.credentialResponse.credentials?.[0] as any
+        ).credential;
+        expect(credential).toBeDefined();
+        expect(typeof credential).toBe("string");
+        expect(credential).toMatch(/^[A-Za-z0-9_-]+$/);
+
+        expect(addNamespaceSpy).toHaveBeenCalledTimes(1);
+        expect(addNamespaceSpy).toHaveBeenCalledWith(
+            "eu.europa.ec.eudi.pid.1",
+            expect.objectContaining({
+                birth_date: "1999-12-31",
+                family_name: "OFFER_OVERRIDE",
+                age_birth_year: 1964,
+            }),
+        );
+    });
+});
+
+describe("MdocIssuerService namespace merge behavior", () => {
+    const defaultNamespace = "eu.europa.ec.eudi.pid.1";
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    test("adds default namespace once when fields and fallback claims overlap", () => {
+        const addNamespaceSpy = vi.spyOn(
+            Issuer.prototype as any,
+            "addIssuerNamespace",
+        );
+        const service = createMdocIssuerService() as any;
+        const issuer = new Issuer(defaultNamespace, mdocContext);
+
+        service.addClaimsToIssuer(
+            issuer,
+            [
+                {
+                    namespace: defaultNamespace,
+                    path: ["age_birth_year"],
+                    defaultValue: 1964,
+                },
+                {
+                    namespace: defaultNamespace,
+                    path: ["age_over_18"],
+                    defaultValue: true,
+                },
+            ],
+            defaultNamespace,
+            {
+                birth_date: "1964-08-12",
+            },
+        );
+
+        expect(addNamespaceSpy).toHaveBeenCalledTimes(1);
+        expect(addNamespaceSpy).toHaveBeenCalledWith(
+            defaultNamespace,
+            expect.objectContaining({
+                age_birth_year: 1964,
+                age_over_18: true,
+                birth_date: "1964-08-12",
+            }),
+        );
+    });
+
+    test("fallback claims override default values for matching keys", () => {
+        const addNamespaceSpy = vi.spyOn(
+            Issuer.prototype as any,
+            "addIssuerNamespace",
+        );
+        const service = createMdocIssuerService() as any;
+        const issuer = new Issuer(defaultNamespace, mdocContext);
+
+        service.addClaimsToIssuer(
+            issuer,
+            [
+                {
+                    namespace: defaultNamespace,
+                    path: ["birth_date"],
+                    defaultValue: "1964-08-12",
+                },
+            ],
+            defaultNamespace,
+            {
+                birth_date: "1999-12-31",
+            },
+        );
+
+        expect(addNamespaceSpy).toHaveBeenCalledTimes(1);
+        expect(addNamespaceSpy).toHaveBeenCalledWith(
+            defaultNamespace,
+            expect.objectContaining({
+                birth_date: "1999-12-31",
+            }),
+        );
+    });
+
+    test("keeps non-default namespaces and enriches only default namespace from fallback claims", () => {
+        const addNamespaceSpy = vi.spyOn(
+            Issuer.prototype as any,
+            "addIssuerNamespace",
+        );
+        const service = createMdocIssuerService() as any;
+        const issuer = new Issuer(defaultNamespace, mdocContext);
+        const altNamespace = "org.iso.18013.5.1";
+
+        service.addClaimsToIssuer(
+            issuer,
+            [
+                {
+                    namespace: defaultNamespace,
+                    path: ["given_name"],
+                    defaultValue: "ERIKA",
+                },
+                {
+                    namespace: altNamespace,
+                    path: ["document_number"],
+                    defaultValue: "ABCD1234",
+                },
+            ],
+            defaultNamespace,
+            {
+                family_name: "MUSTERMANN",
+            },
+        );
+
+        expect(addNamespaceSpy).toHaveBeenCalledTimes(2);
+        expect(addNamespaceSpy).toHaveBeenCalledWith(
+            defaultNamespace,
+            expect.objectContaining({
+                given_name: "ERIKA",
+                family_name: "MUSTERMANN",
+            }),
+        );
+        expect(addNamespaceSpy).toHaveBeenCalledWith(
+            altNamespace,
+            expect.objectContaining({
+                document_number: "ABCD1234",
+            }),
+        );
+    });
+
+    test("ignores fallback namespace-object key to avoid accidental re-namespacing", () => {
+        const addNamespaceSpy = vi.spyOn(
+            Issuer.prototype as any,
+            "addIssuerNamespace",
+        );
+        const service = createMdocIssuerService() as any;
+        const issuer = new Issuer(defaultNamespace, mdocContext);
+
+        service.addClaimsToIssuer(
+            issuer,
+            [
+                {
+                    namespace: defaultNamespace,
+                    path: ["given_name"],
+                    defaultValue: "ERIKA",
+                },
+            ],
+            defaultNamespace,
+            {
+                [defaultNamespace]: {
+                    should_not_be_nested: true,
+                },
+                family_name: "MUSTERMANN",
+            },
+        );
+
+        expect(addNamespaceSpy).toHaveBeenCalledTimes(1);
+        expect(addNamespaceSpy).toHaveBeenCalledWith(
+            defaultNamespace,
+            expect.objectContaining({
+                given_name: "ERIKA",
+                family_name: "MUSTERMANN",
+            }),
+        );
+
+        const namespacePayload = addNamespaceSpy.mock.calls[0]?.[1] as Record<
+            string,
+            unknown
+        >;
+        expect(namespacePayload[defaultNamespace]).toBeUndefined();
+    });
+
+    test("does not add namespace when both fields and fallback claims are empty", () => {
+        const addNamespaceSpy = vi.spyOn(
+            Issuer.prototype as any,
+            "addIssuerNamespace",
+        );
+        const service = createMdocIssuerService() as any;
+        const issuer = new Issuer(defaultNamespace, mdocContext);
+
+        service.addClaimsToIssuer(issuer, [], defaultNamespace, {});
+
+        expect(addNamespaceSpy).not.toHaveBeenCalled();
     });
 });

--- a/apps/backend/test/issuance/issuance-mdoc.e2e-spec.ts
+++ b/apps/backend/test/issuance/issuance-mdoc.e2e-spec.ts
@@ -151,8 +151,8 @@ describe("Issuance - mDOC Credentials", () => {
 
         const credential: string = (
             credentialResponse.credentialResponse.credentials?.[0] as any
-        ).credential;        
-        expect(credential).toBeDefined();        
+        ).credential;
+        expect(credential).toBeDefined();
 
         // mDOC credential should be a base64url encoded string
         expect(typeof credential).toBe("string");

--- a/assets/config/demo/issuance/credentials/pid-mdoc.json
+++ b/assets/config/demo/issuance/credentials/pid-mdoc.json
@@ -18,8 +18,8 @@
   "lifeTime": 604800,
   "fields": [
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "age_birth_year"
       ],
       "type": "integer",
@@ -36,8 +36,8 @@
       ]
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "age_in_years"
       ],
       "type": "integer",
@@ -54,8 +54,8 @@
       ]
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "age_over_12"
       ],
       "type": "boolean",
@@ -72,8 +72,8 @@
       ]
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "age_over_14"
       ],
       "type": "boolean",
@@ -90,8 +90,8 @@
       ]
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "age_over_16"
       ],
       "type": "boolean",
@@ -108,8 +108,8 @@
       ]
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "age_over_18"
       ],
       "type": "boolean",
@@ -126,8 +126,8 @@
       ]
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "age_over_21"
       ],
       "type": "boolean",
@@ -144,8 +144,8 @@
       ]
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "age_over_65"
       ],
       "type": "boolean",
@@ -162,8 +162,8 @@
       ]
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "birth_date"
       ],
       "type": "string",
@@ -184,8 +184,8 @@
       ]
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "birth_place"
       ],
       "type": "string",
@@ -202,8 +202,8 @@
       ]
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "expiry_date"
       ],
       "type": "string",
@@ -224,8 +224,8 @@
       ]
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "family_name_birth"
       ],
       "type": "string",
@@ -242,8 +242,8 @@
       ]
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "family_name"
       ],
       "type": "string",
@@ -261,8 +261,8 @@
       ]
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "given_name"
       ],
       "type": "string",
@@ -280,8 +280,8 @@
       ]
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "issuance_date"
       ],
       "type": "string",
@@ -302,8 +302,8 @@
       ]
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "issuing_authority"
       ],
       "type": "string",
@@ -321,8 +321,8 @@
       ]
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "issuing_country"
       ],
       "type": "string",
@@ -340,8 +340,8 @@
       ]
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "nationality"
       ],
       "type": "string",
@@ -358,8 +358,8 @@
       ]
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "resident_city"
       ],
       "type": "string",
@@ -376,8 +376,8 @@
       ]
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "resident_country"
       ],
       "type": "string",
@@ -394,8 +394,8 @@
       ]
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "resident_postal_code"
       ],
       "type": "string",
@@ -412,8 +412,8 @@
       ]
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "resident_street"
       ],
       "type": "string",
@@ -430,8 +430,8 @@
       ]
     },
     {
+      "namespace": "eu.europa.ec.eudi.pid.1",
       "path": [
-        "eu.europa.ec.eudi.pid.1",
         "source_document_type"
       ],
       "type": "string",


### PR DESCRIPTION
## 📝 Description

Normalize mDOC PID credential field mapping so `eu.europa.ec.eudi.pid.1` is stored in `namespace` instead of being embedded as the first segment in `path`.

Updated files:
- `assets/config/demo/issuance/credentials/pid-mdoc.json`
- `apps/backend/test/fixtures/haip/issuance/credentials/pid-mdoc.json`
- `apps/backend/test/fixtures/haip/issuance/credentials/pid-mdoc-no-key.json`
- `docs/api/authentication.md` (Keycloak note about refresh tokens with current admin client behavior)

Fixes #N/A

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality
      to not work as expected)
- [x] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test improvements
- [ ] 🏗️ Build/CI changes

## 💥 Breaking Changes (if applicable)

- **API changes**: None
- **Environment variables**: None
- **Config import format**: Field mapping format now consistently uses `namespace` + claim-only `path` for updated PID mDOC configs/fixtures
- **Database**: None

## 🧪 Testing

Describe the tests that you ran to verify your changes:

- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] E2E tests pass
- [x] Manual testing performed

**Test Configuration**:

- Node.js version: N/A
- OS: macOS
- Test environment: Local file-level verification and git diff inspection

## 📸 Screenshots (if applicable)

N/A

## ✔️ Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## 📋 Additional Notes

This change aligns fixture/config structure with namespace-based mDOC field mapping expectations and avoids namespace duplication in `path`.