### PR TITLE
fix: gate CWT status-list requests and fix CLI SEA release invocation

### DIFF
--- a/apps/backend/src/shared/trust/status-list-verifier.service.ts
+++ b/apps/backend/src/shared/trust/status-list-verifier.service.ts
@@ -191,6 +191,7 @@ export class StatusListVerifierService {
     private async fetchStatusListToken(
         uri: string,
         timeoutMs = 10000,
+        type: "jwt" | "cwt" = "jwt",
     ): Promise<string | Uint8Array> {
         const ctrl = new AbortController();
         const timeout = setTimeout(() => ctrl.abort(), timeoutMs);
@@ -201,7 +202,7 @@ export class StatusListVerifierService {
                     signal: ctrl.signal,
                     responseType: "arraybuffer",
                     headers: {
-                        Accept: "application/statuslist+jwt, application/statuslist+cwt, application/jwt",
+                        Accept: type === "cwt" ? "application/statuslist+cwt" : "application/statuslist+jwt",
                     },
                 }),
             );
@@ -327,7 +328,6 @@ export class StatusListVerifierService {
         // Fetch and cache
         this.logger.debug(`Fetching status list JWT from ${uri}`);
         const token = await this.fetchStatusListToken(uri);
-        console.log(token);
         if (typeof token !== "string") {
             throw new TypeError(
                 `Status list at ${uri} returned CWT while JWT was requested`,

--- a/apps/backend/src/shared/trust/status-list-verifier.service.ts
+++ b/apps/backend/src/shared/trust/status-list-verifier.service.ts
@@ -202,7 +202,10 @@ export class StatusListVerifierService {
                     signal: ctrl.signal,
                     responseType: "arraybuffer",
                     headers: {
-                        Accept: type === "cwt" ? "application/statuslist+cwt" : "application/statuslist+jwt",
+                        Accept:
+                            type === "cwt"
+                                ? "application/statuslist+cwt"
+                                : "application/statuslist+jwt",
                     },
                 }),
             );

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint:fix": "pnpm -r lint:fix",
     "test": "pnpm -r test",
     "clean": "pnpm -r clean",
-    "release:dry": "set -a && source .env && set +a && npx semantic-release --dry-run 2>&1 | grep -iE 'next release version|no release'",
+    "release:dry": "set -a && source .env && set +a && npx semantic-release --dry-run 2>&1",
     "release:version": "set -a && source .env && set +a && npx semantic-release --dry-run 2>&1 | sed -n 's/.*next release version is \\([0-9]*\\.[0-9]*\\.[0-9]*\\).*/\\1/p' | head -1 || echo 'No release pending'",
     "gen:api": "ts-node scripts/generate-from-openapi.ts --url http://localhost:3000/api/docs-json --out schemas --no-type",
     "gen:sdk": "pnpm --filter @eudiplo/sdk-core generate",

--- a/scripts/build-cli-sea.mjs
+++ b/scripts/build-cli-sea.mjs
@@ -8,15 +8,18 @@ const packagePath = fileURLToPath(packageDirectory);
 
 rmSync(new URL("dist-sea", packageDirectory), { recursive: true, force: true });
 
-const pnpmExecutable = process.env.npm_execpath;
-if (!pnpmExecutable) {
-    throw new Error("pnpm executable path is not available.");
+const packageManagerExecutable = process.env.npm_execpath;
+if (packageManagerExecutable) {
+    execFileSync(process.execPath, [packageManagerExecutable, "run", "build:sea:bundle"], {
+        cwd: packagePath,
+        stdio: "inherit",
+    });
+} else {
+    execFileSync("pnpm", ["run", "build:sea:bundle"], {
+        cwd: packagePath,
+        stdio: "inherit",
+    });
 }
-
-execFileSync(process.execPath, [pnpmExecutable, "build:sea:bundle"], {
-    cwd: packagePath,
-    stdio: "inherit",
-});
 
 execFileSync(process.execPath, ["--build-sea", "sea-config.json"], {
     cwd: packagePath,


### PR DESCRIPTION
## 📝 Description

This PR includes two fixes:

1. Status-list verification now requests CWT status list only when CWT is explicitly requested (prevents unnecessary/incorrect CWT fetch behavior).
2. Release SEA build invocation is fixed so the package script is executed correctly in CI (`run build:sea:bundle`), resolving release pipeline failures with `Unknown command: "build:sea:bundle"`.

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test improvements
- [x] 🏗️ Build/CI changes

## 💥 Breaking Changes (if applicable)

None.

## 🧪 Testing

- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] E2E tests pass
- [x] Manual testing performed

**Test Configuration**:

- Node.js version: 26.1.0 (local), CI failure context on Node 24.18.0
- OS: macOS (local), Ubuntu GitHub runner
- Test environment: local CLI/SEA script execution

Manual checks performed:
- `node scripts/build-cli-sea.mjs` succeeds locally.
- Simulated CI path with `npm_execpath` set to npm CLI path also succeeds, confirming `run build:sea:bundle` invocation works.

## 📸 Screenshots (if applicable)

N/A.

## ✔️ Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## 📋 Additional Notes

This PR changes the following files:
- `apps/backend/src/shared/trust/status-list-verifier.service.ts`
- `scripts/build-cli-sea.mjs`
- `package.json`
