### PR TITLE
feat(iso18013): opt-in reader authentication (ISO 18013-7 Annex C)

### DIFF
--- a/apps/backend/src/database/migrations/1774000000000-AddReaderAuthToPresentationConfig.ts
+++ b/apps/backend/src/database/migrations/1774000000000-AddReaderAuthToPresentationConfig.ts
@@ -1,0 +1,48 @@
+import { MigrationInterface, QueryRunner, TableColumn } from "typeorm";
+
+/**
+ * Add the `readerAuth` column to `presentation_config`.
+ *
+ * When enabled, the ISO 18013-7 Annex C (DC API) DeviceRequest embeds a detached
+ * `readerAuth` COSE_Sign1 signed with the tenant's Access key chain, allowing the
+ * wallet to cryptographically authenticate the verifier. Nullable — a null value
+ * means disabled.
+ */
+export class AddReaderAuthToPresentationConfig1774000000000
+    implements MigrationInterface
+{
+    name = "AddReaderAuthToPresentationConfig1774000000000";
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const table = await queryRunner.getTable("presentation_config");
+        if (!table) {
+            console.log(
+                "[Migration] presentation_config table not found — skipping.",
+            );
+            return;
+        }
+
+        if (!table.columns.some((c) => c.name === "readerAuth")) {
+            await queryRunner.addColumn(
+                "presentation_config",
+                new TableColumn({
+                    name: "readerAuth",
+                    type: "boolean",
+                    isNullable: true,
+                }),
+            );
+            console.log(
+                "[Migration] Added readerAuth column to presentation_config.",
+            );
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const table = await queryRunner.getTable("presentation_config");
+        if (!table) return;
+
+        if (table.columns.some((c) => c.name === "readerAuth")) {
+            await queryRunner.dropColumn("presentation_config", "readerAuth");
+        }
+    }
+}

--- a/apps/backend/src/database/migrations/index.ts
+++ b/apps/backend/src/database/migrations/index.ts
@@ -38,4 +38,5 @@ export { AddDcApiProtocolToSession1770000000000 } from "./1770000000000-AddDcApi
 export { AddCwtCacheToStatusList1771000000000 } from "./1771000000000-AddCwtCacheToStatusList";
 export { AddVerifierSkewSeconds1772000000000 } from "./1772000000000-AddVerifierSkewSeconds";
 export { AddPresentationStatusCheckMode1773000000000 } from "./1773000000000-AddPresentationStatusCheckMode";
+export { AddReaderAuthToPresentationConfig1774000000000 } from "./1774000000000-AddReaderAuthToPresentationConfig";
 export { AddRootExternalKeyIdToKeyChain1774000000000 } from "./1774000000000-AddRootExternalKeyIdToKeyChain";

--- a/apps/backend/src/verifier/iso18013/cbor-request.ts
+++ b/apps/backend/src/verifier/iso18013/cbor-request.ts
@@ -8,12 +8,22 @@
  *   EncryptedResponse   = ["dcapi", {"enc": bstr, "cipherText": bstr}]
  *   SessionTranscript   = [null, null, ["dcapi", SHA-256(CBOR([encInfoB64u, origin]))]]
  */
-import { cborDecode, cborEncode } from "@owf/cose";
 import {
+    cborDecode,
+    cborEncode,
+    DataItem,
+    ProtectedHeaders,
+    RegisteredCwtHeaderClaimKey,
+    UnprotectedHeaders,
+} from "@owf/cose";
+import {
+    CoseKey,
     DeviceRequest,
     DocRequest,
     ItemsRequest,
+    ReaderAuth,
     SessionTranscript,
+    SignatureAlgorithm,
 } from "@owf/mdoc";
 import { mdocContext } from "../presentations/mdoc-context";
 
@@ -52,23 +62,111 @@ export function buildEncryptionInfo(
 }
 
 /**
- * Build the CBOR DeviceRequest per ISO 18013-5 §8.3.2.1.2.1.
+ * Build the ItemsRequest for a single mDOC docType per ISO 18013-5 §8.3.2.1.2.1.
  *
- * @param docType   mDOC document type (e.g. "org.iso.18013.5.1.mDL")
+ * The same ItemsRequest instance must be embedded in both the DocRequest and the
+ * ReaderAuthentication structure so the wallet can recompute and verify the
+ * reader signature — see {@link buildReaderAuth}.
+ *
+ * @param docType     mDOC document type (e.g. "org.iso.18013.5.1.mDL")
  * @param namespaces  Map of namespace → { claimName: intentToRetain }
  */
-export function buildDeviceRequestCbor(
+export function buildItemsRequest(
     docType: string,
     namespaces: Record<string, Record<string, boolean>>,
+): ItemsRequest {
+    return ItemsRequest.create({ docType, namespaces });
+}
+
+/**
+ * Build the CBOR DeviceRequest per ISO 18013-5 §8.3.2.1.2.1.
+ *
+ * @param itemsRequest  the ItemsRequest from {@link buildItemsRequest}
+ * @param readerAuth    optional detached ReaderAuth (COSE_Sign1) authenticating
+ *                      the verifier — see {@link buildReaderAuth}. When present it
+ *                      is embedded in the DocRequest so the wallet can verify it.
+ */
+export function buildDeviceRequestCbor(
+    itemsRequest: ItemsRequest,
+    readerAuth?: ReaderAuth,
 ): Buffer {
     const dr = DeviceRequest.create({
-        docRequests: [
-            DocRequest.create({
-                itemsRequest: ItemsRequest.create({ docType, namespaces }),
-            }),
-        ],
+        docRequests: [DocRequest.create({ itemsRequest, readerAuth })],
     });
     return Buffer.from(dr.encode());
+}
+
+/**
+ * Sign a detached ReaderAuth (COSE_Sign1) authenticating the verifier inside the
+ * DeviceRequest, per ISO/IEC 18013-5 §9.1.4 / 18013-7 Annex C.
+ *
+ * The signed payload is the CBOR of
+ *
+ *   ReaderAuthentication = ["ReaderAuthentication", SessionTranscript, ItemsRequestBytes]
+ *
+ * carried as the COSE_Sign1 *detached* payload (`ReaderAuthenticationBytes`,
+ * a Tag-24-wrapped bstr). The verifier's certificate chain is placed in the
+ * unprotected `x5chain` header and ES256 in the protected header — the same
+ * shape `@owf/mdoc` produces for IssuerAuth, and the exact bytes its
+ * `ReaderAuth.verify()` recomputes.
+ *
+ * The DCAPIHandover SessionTranscript is available already at offer time (it is
+ * a deterministic function of `encryptionInfo` + browser origin), so the reader
+ * signature can be produced when the DeviceRequest is built.
+ *
+ * @param itemsRequest       the same ItemsRequest embedded in the DocRequest
+ * @param sessionTranscript  DCAPIHandover transcript from {@link buildIsoMdocDcApiTranscript}
+ * @param signingJwk         verifier Access private JWK (must include `d`)
+ * @param certificateChain   leaf-first DER certificate chain for `x5chain`
+ */
+export async function buildReaderAuth(
+    itemsRequest: ItemsRequest,
+    sessionTranscript: SessionTranscript,
+    signingJwk: Record<string, unknown>,
+    certificateChain: Uint8Array[],
+): Promise<ReaderAuth> {
+    // ReaderAuthentication = ["ReaderAuthentication", SessionTranscript, ItemsRequestBytes].
+    // `@owf/mdoc` declares but does not export the ReaderAuthentication model, so
+    // reproduce its encoding exactly (see reader-authentication.ts in the lib):
+    // the itemsRequest is embedded Tag-24 wrapped, and the whole structure is the
+    // detached COSE_Sign1 payload as ReaderAuthenticationBytes = #6.24(bstr .cbor ...).
+    // This is byte-identical to what ReaderAuth.verify() recomputes on the wallet.
+    const readerAuthenticationStructure = [
+        "ReaderAuthentication",
+        sessionTranscript.encodedStructure,
+        DataItem.fromData(itemsRequest.encodedStructure),
+    ];
+    const detachedPayload = cborEncode(
+        DataItem.fromData(readerAuthenticationStructure),
+    );
+
+    const readerAuth = ReaderAuth.create({
+        protectedHeaders: ProtectedHeaders.create({
+            protectedHeaders: new Map([
+                [
+                    RegisteredCwtHeaderClaimKey.Algorithm,
+                    SignatureAlgorithm.ES256,
+                ],
+            ]),
+        }),
+        unprotectedHeaders: UnprotectedHeaders.create({
+            unprotectedHeaders: new Map([
+                [RegisteredCwtHeaderClaimKey.X5Chain, certificateChain],
+            ]),
+        }),
+        payload: null,
+    });
+
+    await readerAuth.sign(
+        {
+            signingKey: CoseKey.fromJwk(signingJwk),
+            algorithm: SignatureAlgorithm.ES256,
+            detachedPayload,
+        },
+        { sign: mdocContext.cose.sign1.sign },
+    );
+
+    return readerAuth;
 }
 
 /**

--- a/apps/backend/src/verifier/iso18013/iso18013.service.ts
+++ b/apps/backend/src/verifier/iso18013/iso18013.service.ts
@@ -12,20 +12,26 @@ import {
     NotFoundException,
 } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
+import type { ItemsRequest, ReaderAuth } from "@owf/mdoc";
+import { X509Certificate } from "@peculiar/x509";
+import { exportJWK } from "jose";
 import { InjectRepository } from "@nestjs/typeorm";
 import { InjectPinoLogger, PinoLogger } from "nestjs-pino";
 import { Repository } from "typeorm";
 import { EncryptionService } from "../../crypto/encryption/encryption.service";
+import { CertService } from "../../crypto/key/cert/cert.service";
+import { KeyUsageType } from "../../crypto/key/entities/key-chain.entity";
+import { KeyChainService } from "../../crypto/key/key-chain.service";
 import { WebhookEndpointEntity } from "../../issuer/configuration/webhook-endpoint/entities/webhook-endpoint.entity";
 import { ServiceTypeIdentifier } from "../../issuer/trust-list/trustlist.service";
 import { SessionStatus } from "../../session/entities/session.entity";
 import { SessionService } from "../../session/session.service";
+import { revocationModeToPolicy } from "../../shared/trust/revocation-policy.util";
 import {
     DEFAULT_VERIFIER_SKEW_SECONDS,
     RevocationCheckMode,
     VerifierOptions,
 } from "../../shared/trust/types";
-import { revocationModeToPolicy } from "../../shared/trust/revocation-policy.util";
 import { AuditLogService } from "../../shared/utils/logger/audit-log.service";
 import { WebhookService } from "../../shared/utils/webhook/webhook.service";
 import { MdocverifierService } from "../presentations/credential/mdocverifier/mdocverifier.service";
@@ -39,6 +45,8 @@ import {
     buildDeviceRequestCbor,
     buildEncryptionInfo,
     buildIsoMdocDcApiTranscript,
+    buildItemsRequest,
+    buildReaderAuth,
     parseEncryptedResponse,
 } from "./cbor-request";
 import { hpkeOpen } from "./hpke";
@@ -64,6 +72,8 @@ export class Iso18013Service {
         private readonly webhookService: WebhookService,
         private readonly auditLogService: AuditLogService,
         private readonly configService: ConfigService,
+        private readonly certService: CertService,
+        private readonly keyChainService: KeyChainService,
         @InjectRepository(WebhookEndpointEntity)
         private readonly webhookEndpointRepo: Repository<WebhookEndpointEntity>,
         @InjectPinoLogger(Iso18013Service.name)
@@ -147,11 +157,30 @@ export class Iso18013Service {
             namespaces[docType] = {};
         }
 
-        const deviceRequestCbor = buildDeviceRequestCbor(docType, namespaces);
         const encryptionInfoCbor = buildEncryptionInfo(
             pubJwk.x!,
             pubJwk.y!,
             nonce,
+        );
+
+        // A single ItemsRequest instance is shared between the DocRequest and,
+        // when reader authentication is enabled, the ReaderAuthentication that is
+        // signed over it — the wallet recomputes the latter from the former.
+        const itemsRequest = buildItemsRequest(docType, namespaces);
+
+        const readerAuth = config.readerAuth
+            ? await this.buildReaderAuthForOffer(
+                  tenantId,
+                  config.accessKeyChainId ?? undefined,
+                  itemsRequest,
+                  encryptionInfoCbor.toString("base64url"),
+                  origin,
+              )
+            : undefined;
+
+        const deviceRequestCbor = buildDeviceRequestCbor(
+            itemsRequest,
+            readerAuth,
         );
 
         const expiresAt = new Date(
@@ -190,6 +219,62 @@ export class Iso18013Service {
                 encryption_info: encryptionInfoCbor.toString("base64url"),
             },
         };
+    }
+
+    /**
+     * Build a detached ReaderAuth (COSE_Sign1) for the offer, signing the
+     * ReaderAuthentication structure with the tenant's Access key chain.
+     *
+     * The DCAPIHandover SessionTranscript is reconstructed deterministically from
+     * the EncryptionInfo (base64url) and browser origin — identical to the one
+     * the wallet derives — so the reader signature binds to this exact request.
+     *
+     * Note: signing extracts the Access private key as a JWK (mirroring mDOC
+     * issuance), so KMS-backed non-extractable keys are not yet supported for
+     * reader authentication.
+     */
+    private async buildReaderAuthForOffer(
+        tenantId: string,
+        accessKeyChainId: string | undefined,
+        itemsRequest: ItemsRequest,
+        encryptionInfoB64u: string,
+        origin: string,
+    ): Promise<ReaderAuth> {
+        const { sessionTranscript } = await buildIsoMdocDcApiTranscript(
+            encryptionInfoB64u,
+            origin,
+        );
+
+        const cert = await this.certService.find({
+            tenantId,
+            type: KeyUsageType.Access,
+            certId: accessKeyChainId,
+        });
+
+        const keyChain = await this.keyChainService.getEntity(
+            tenantId,
+            cert.keyId,
+        );
+        const signingJwk = (await exportJWK(
+            await crypto.subtle.importKey(
+                "jwk",
+                keyChain.activeJwk,
+                { name: "ECDSA", namedCurve: "P-256" },
+                true,
+                ["sign"],
+            ),
+        )) as Record<string, unknown>;
+
+        const certificateChain = cert.crt.map(
+            (pem) => new Uint8Array(new X509Certificate(pem).rawData),
+        );
+
+        return buildReaderAuth(
+            itemsRequest,
+            sessionTranscript,
+            signingJwk,
+            certificateChain,
+        );
     }
 
     /**

--- a/apps/backend/src/verifier/iso18013/reader-auth.spec.ts
+++ b/apps/backend/src/verifier/iso18013/reader-auth.spec.ts
@@ -1,0 +1,150 @@
+import { webcrypto } from "node:crypto";
+import { DeviceRequest } from "@owf/mdoc";
+import * as x509 from "@peculiar/x509";
+import { exportJWK } from "jose";
+import { beforeAll, describe, expect, it } from "vitest";
+import { mdocContext } from "../presentations/mdoc-context";
+import {
+    buildDeviceRequestCbor,
+    buildEncryptionInfo,
+    buildIsoMdocDcApiTranscript,
+    buildItemsRequest,
+    buildReaderAuth,
+} from "./cbor-request";
+
+/**
+ * Reader authentication for the ISO 18013-7 Annex C (DC API) flow.
+ *
+ * The core guarantee is byte-exactness: buildReaderAuth signs the detached
+ * ReaderAuthentication payload, and the wallet-side ReaderAuth.verify() recomputes
+ * that payload from the same SessionTranscript + ItemsRequest. If the two byte
+ * strings diverge, verify() fails — so a passing round-trip proves the manually
+ * built ReaderAuthentication CBOR matches what @owf/mdoc expects.
+ */
+describe("ISO 18013-7 reader authentication", () => {
+    const docType = "eu.europa.ec.av.1";
+    const namespaces = { [docType]: { age_over_18: false } };
+    const origin = "https://verifier.example.com";
+    const x = Buffer.alloc(32, 0x11).toString("base64url");
+    const y = Buffer.alloc(32, 0x22).toString("base64url");
+    const nonce = Buffer.alloc(16, 0x42);
+
+    let signingJwk: Record<string, unknown>;
+    let certificateChain: Uint8Array[];
+
+    beforeAll(async () => {
+        x509.cryptoProvider.set(webcrypto as Crypto);
+
+        const keys = await webcrypto.subtle.generateKey(
+            { name: "ECDSA", namedCurve: "P-256" },
+            true,
+            ["sign", "verify"],
+        );
+
+        const cert = await x509.X509CertificateGenerator.createSelfSigned({
+            serialNumber: "01",
+            name: "C=DE, CN=EUDIPLO Test Reader",
+            notBefore: new Date(Date.now() - 60_000),
+            notAfter: new Date(Date.now() + 3_600_000),
+            signingAlgorithm: { name: "ECDSA", hash: "SHA-256" },
+            keys,
+        });
+
+        signingJwk = (await exportJWK(keys.privateKey)) as Record<
+            string,
+            unknown
+        >;
+        certificateChain = [new Uint8Array(cert.rawData)];
+    });
+
+    async function buildTranscriptAndItems() {
+        const encInfoB64u = buildEncryptionInfo(x, y, nonce).toString(
+            "base64url",
+        );
+        const { sessionTranscript } = await buildIsoMdocDcApiTranscript(
+            encInfoB64u,
+            origin,
+        );
+        const itemsRequest = buildItemsRequest(docType, namespaces);
+        return { sessionTranscript, itemsRequest };
+    }
+
+    it("produces a readerAuth the wallet can verify (byte-exact ReaderAuthentication)", async () => {
+        const { sessionTranscript, itemsRequest } =
+            await buildTranscriptAndItems();
+
+        const readerAuth = await buildReaderAuth(
+            itemsRequest,
+            sessionTranscript,
+            signingJwk,
+            certificateChain,
+        );
+
+        // Recomputes the detached ReaderAuthentication payload internally and
+        // checks the ES256 signature — resolves only on a byte-exact match.
+        await expect(
+            readerAuth.verify(
+                { readerAuthentication: { sessionTranscript, itemsRequest } },
+                mdocContext,
+            ),
+        ).resolves.not.toThrow();
+
+        // ES256 in the protected header, leaf cert in the unprotected x5chain.
+        expect(readerAuth.algorithm).toBeDefined();
+        expect(readerAuth.certificateChain.length).toBe(1);
+    });
+
+    it("fails verification when the transcript differs (binds to the request)", async () => {
+        const { sessionTranscript, itemsRequest } =
+            await buildTranscriptAndItems();
+        const readerAuth = await buildReaderAuth(
+            itemsRequest,
+            sessionTranscript,
+            signingJwk,
+            certificateChain,
+        );
+
+        // A transcript from a different origin must not verify.
+        const otherEncInfo = buildEncryptionInfo(x, y, nonce).toString(
+            "base64url",
+        );
+        const { sessionTranscript: otherTranscript } =
+            await buildIsoMdocDcApiTranscript(
+                otherEncInfo,
+                "https://attacker.example",
+            );
+
+        await expect(
+            readerAuth.verify(
+                {
+                    readerAuthentication: {
+                        sessionTranscript: otherTranscript,
+                        itemsRequest,
+                    },
+                },
+                mdocContext,
+            ),
+        ).rejects.toThrow();
+    });
+
+    it("embeds the readerAuth in the DeviceRequest DocRequest", async () => {
+        const { sessionTranscript, itemsRequest } =
+            await buildTranscriptAndItems();
+        const readerAuth = await buildReaderAuth(
+            itemsRequest,
+            sessionTranscript,
+            signingJwk,
+            certificateChain,
+        );
+
+        const withAuth = DeviceRequest.decode(
+            new Uint8Array(buildDeviceRequestCbor(itemsRequest, readerAuth)),
+        );
+        expect(withAuth.docRequests[0].readerAuth).toBeDefined();
+
+        const withoutAuth = DeviceRequest.decode(
+            new Uint8Array(buildDeviceRequestCbor(itemsRequest)),
+        );
+        expect(withoutAuth.docRequests[0].readerAuth).toBeUndefined();
+    });
+});

--- a/apps/backend/src/verifier/presentations/entities/presentation-config.entity.ts
+++ b/apps/backend/src/verifier/presentations/entities/presentation-config.entity.ts
@@ -11,13 +11,13 @@ import {
     IsDefined,
     IsArray,
     IsBoolean,
-    Matches,
     IsEnum,
     IsNotEmpty,
     IsNumber,
     IsObject,
     IsOptional,
     IsString,
+    Matches,
     Min,
     ValidateIf,
     Validate,
@@ -666,4 +666,20 @@ export class PresentationConfig {
     @IsString()
     @Column("varchar", { nullable: true })
     accessKeyChainId?: string | null;
+
+    /**
+     * Enable reader authentication for the ISO 18013-7 Annex C (DC API) flow.
+     *
+     * When `true`, the DeviceRequest embeds a detached `readerAuth` COSE_Sign1
+     * signed with the tenant's Access key chain (selected by
+     * {@link accessKeyChainId}), letting the wallet cryptographically
+     * authenticate the verifier — the mDOC equivalent of the signed request
+     * object used in the OID4VP flow. Defaults to disabled (null/false).
+     *
+     * Only affects `response_type: "iso-18013-7"` offers.
+     */
+    @IsOptional()
+    @IsBoolean()
+    @Column("boolean", { nullable: true })
+    readerAuth?: boolean | null;
 }

--- a/docs/getting-started/presentation/presentation-configuration.md
+++ b/docs/getting-started/presentation/presentation-configuration.md
@@ -30,6 +30,7 @@ For creating request payloads and runtime overrides, see
 - `transaction_data`: **OPTIONAL** - Array of transaction data objects to include in the OID4VP authorization request. See [Transaction Data](transaction-data.md) for details.
 - `skewSeconds`: **OPTIONAL** - Clock skew tolerance in seconds for credential JWT time validation. Defaults to `60` seconds.
 - `statusCheckMode`: **OPTIONAL** - Controls how credential status list checks are handled during presentation verification. Supported values are `strict` (default), `best_effort`, and `disabled`.
+- `readerAuth`: **OPTIONAL** - Enable reader authentication for the ISO 18013-7 Annex C (DC API) flow. When `true`, the `DeviceRequest` embeds a detached `readerAuth` COSE_Sign1 signed with the tenant's Access key chain, letting the wallet cryptographically authenticate the verifier. Defaults to disabled. See [Reader Authentication (ISO 18013-7)](#reader-authentication-iso-18013-7) below.
 
 !!! Info
 
@@ -94,6 +95,46 @@ Notes:
 - `purpose` should be configured per presentation config.
 - Shared defaults such as `privacy_policy` or `support_uri` can be configured once at tenant level in `registrar.json` via `registrationCertificateDefaults`.
 - If you already have a registrar certificate JWT, you can set `registrationCert.jwt` to reuse it.
+
+---
+
+## Reader Authentication (ISO 18013-7)
+
+`readerAuth` adds cryptographic **verifier** authentication to the ISO 18013-7
+Annex C (Digital Credentials API) flow — the mDOC equivalent of the signed
+request object used in the OID4VP flow. It only affects
+`response_type: "iso-18013-7"` offers.
+
+When `readerAuth: true`, EUDIPLO signs
+
+```text
+ReaderAuthentication = ["ReaderAuthentication", SessionTranscript, ItemsRequestBytes]
+```
+
+as a **detached COSE_Sign1** using the tenant's Access key chain (selected by
+`accessKeyChainId`, or the tenant default), and embeds it as `readerAuth` in the
+`DocRequest`. The wallet validates the signature against the reader's
+certificate chain (carried in the `x5chain` header), authenticating the verifier
+before releasing any attributes.
+
+The `SessionTranscript` bound by the signature is the same DCAPIHandover
+transcript the wallet derives from the `encryptionInfo` and the browser origin,
+so the signature is tied to this exact request and origin.
+
+```json
+{
+    "id": "age-over-18-dc-api",
+    "readerAuth": true,
+    "dcql_query": { "credentials": [ ... ] }
+}
+```
+
+!!! note
+
+    Signing extracts the Access private key as a JWK, so KMS-backed
+    non-extractable keys are not yet supported for reader authentication. When
+    `readerAuth` is omitted or `false`, the `DeviceRequest` is sent unsigned
+    (the previous behaviour).
 
 ---
 

--- a/docs/getting-started/presentation/presentation-requests.md
+++ b/docs/getting-started/presentation/presentation-requests.md
@@ -114,6 +114,13 @@ The browser forwards both values to the wallet via
 Webhook delivery, `redirectUri`, and single-use semantics behave exactly as
 in the other flows.
 
+!!! tip "Reader authentication"
+
+    Set [`readerAuth: true`](presentation-configuration.md#reader-authentication-iso-18013-7)
+    on the presentation configuration to embed a signed `readerAuth` in the
+    `device_request`, letting the wallet cryptographically authenticate the
+    verifier. The request payload here is unchanged.
+
 ---
 
 ## Session and Result Retrieval


### PR DESCRIPTION
## 📝 Description

Adds opt-in **reader authentication** to the ISO 18013-7 Annex C (Digital
Credentials API) flow — the mDOC equivalent of the signed request object in
OID4VP. With `readerAuth: true` on a presentation config, the `DeviceRequest`
embeds a detached `readerAuth` COSE_Sign1 over `ReaderAuthentication`, signed
with the tenant's Access key chain, so the wallet can cryptographically
authenticate the verifier. Defaults to disabled (previous behaviour unchanged).

## 🔄 Type of Change

- [x] 🚀 New feature (non-breaking change which adds functionality)

## 💥 Breaking Changes

- **API/config**: `PresentationConfig` gains an optional `readerAuth` boolean
  (default disabled).
- **Database**: migration `1774000000000-AddReaderAuthToPresentationConfig`
  adds a nullable column; no manual steps.

## 🧪 Testing

- [x] Unit tests pass — `reader-auth.spec.ts` covers a sign→verify round-trip.
- [x] Backend builds; `knip`/Biome/markdownlint clean.
- [ ] Wallet-validated end-to-end (round-trip check only, not yet validated
      against a wallet).

## ✔️ Checklist

- [x] Follows the code style of this project
- [x] Self-reviewed
- [x] Commented hard-to-understand areas
- [x] Corresponding docs updated
- [x] No new warnings
- [x] Tests added
- [x] New and existing unit tests pass locally

## 📋 Additional Notes

Generated OpenAPI schemas / SDK are **not** regenerated in this PR (they require
a running backend); please regenerate on merge. Signing extracts the Access
private key as a JWK, so KMS-backed non-extractable keys are not yet supported
for reader auth.