### PR TITLE
fix(verifier): honor per-request webhook override in ISO 18013-7 offe…

### DIFF
--- a/apps/backend/src/verifier/iso18013/iso18013.service.spec.ts
+++ b/apps/backend/src/verifier/iso18013/iso18013.service.spec.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Isolate createOffer's config→session logic from the real CBOR/crypto builders.
+vi.mock("./cbor-request", () => ({
+    buildEncryptionInfo: vi.fn(() => Buffer.from("ei")),
+    buildItemsRequest: vi.fn(() => ({})),
+    buildDeviceRequestCbor: vi.fn(() => Buffer.from("dr")),
+    buildIsoMdocDcApiTranscript: vi.fn(),
+    parseEncryptedResponse: vi.fn(),
+    buildReaderAuth: vi.fn(),
+}));
+
+import { Iso18013Service } from "./iso18013.service";
+
+const CONFIG_WEBHOOK = { url: "https://config.example/hook" } as any;
+const OVERRIDE_WEBHOOK = {
+    url: "https://override.example/hook",
+    auth: {
+        type: "apiKey",
+        config: { headerName: "X-Callback-Secret", value: "s3cret" },
+    },
+} as any;
+
+describe("Iso18013Service.createOffer per-request webhook override", () => {
+    let sessionCreate: ReturnType<typeof vi.fn>;
+    let service: Iso18013Service;
+
+    beforeEach(() => {
+        sessionCreate = vi.fn().mockResolvedValue(undefined);
+        const presentationsService = {
+            getPresentationConfig: vi.fn().mockResolvedValue({
+                dcql_query: {
+                    credentials: [
+                        {
+                            format: "mso_mdoc",
+                            meta: { doctype: "eu.europa.ec.av.1" },
+                            claims: [],
+                        },
+                    ],
+                },
+                webhookEndpointId: "endpoint-1",
+                readerAuth: false,
+                lifeTime: 300,
+            }),
+        };
+        const encryptionService = {
+            getEncryptionPublicKey: vi
+                .fn()
+                .mockResolvedValue({ x: "x", y: "y" }),
+        };
+        const sessionService = { create: sessionCreate };
+        const webhookEndpointRepo = {
+            findOneBy: vi.fn().mockResolvedValue({
+                url: "https://config.example/hook",
+            }),
+        };
+
+        service = new Iso18013Service(
+            presentationsService as any,
+            sessionService as any,
+            encryptionService as any,
+            {} as any, // mdocverifierService
+            {} as any, // webhookService
+            {} as any, // auditLogService
+            {} as any, // configService
+            {} as any, // certService
+            {} as any, // keyChainService
+            webhookEndpointRepo as any,
+            {} as any, // logger
+        );
+    });
+
+    it("persists the per-request webhook override on the session", async () => {
+        await service.createOffer(
+            "req",
+            "tenant",
+            "https://origin.example",
+            undefined,
+            OVERRIDE_WEBHOOK,
+        );
+
+        expect(sessionCreate).toHaveBeenCalledWith(
+            expect.objectContaining({ parsedWebhook: OVERRIDE_WEBHOOK }),
+        );
+    });
+
+    it("falls back to the configured webhook when no override is given", async () => {
+        await service.createOffer("req", "tenant", "https://origin.example");
+
+        expect(sessionCreate).toHaveBeenCalledWith(
+            expect.objectContaining({ parsedWebhook: CONFIG_WEBHOOK }),
+        );
+    });
+});

--- a/apps/backend/src/verifier/iso18013/iso18013.service.ts
+++ b/apps/backend/src/verifier/iso18013/iso18013.service.ts
@@ -33,6 +33,7 @@ import {
     VerifierOptions,
 } from "../../shared/trust/types";
 import { AuditLogService } from "../../shared/utils/logger/audit-log.service";
+import { WebhookConfig } from "../../shared/utils/webhook/webhook.dto";
 import { WebhookService } from "../../shared/utils/webhook/webhook.service";
 import { MdocverifierService } from "../presentations/credential/mdocverifier/mdocverifier.service";
 import {
@@ -50,7 +51,6 @@ import {
     parseEncryptedResponse,
 } from "./cbor-request";
 import { hpkeOpen } from "./hpke";
-import { WebhookConfig } from "../../shared/utils/webhook/webhook.dto";
 
 export interface Iso18013Offer {
     session: string;
@@ -115,6 +115,7 @@ export class Iso18013Service {
         tenantId: string,
         origin: string,
         skewSeconds?: number,
+        webhook?: WebhookConfig,
     ): Promise<Iso18013Offer> {
         const config = await this.presentationsService.getPresentationConfig(
             requestId,
@@ -186,10 +187,11 @@ export class Iso18013Service {
         const expiresAt = new Date(
             Date.now() + (config.lifeTime ?? 300) * 1000,
         );
-        const resolvedWebhook = await this.resolveWebhookFromEndpoint(
+        const endpointWebhook = await this.resolveWebhookFromEndpoint(
             config.webhookEndpointId,
             tenantId,
         );
+        const resolvedWebhook = webhook ?? endpointWebhook;
 
         await this.sessionService.create({
             id: sessionId,

--- a/apps/backend/src/verifier/verifier-offer/verifier-offer.controller.ts
+++ b/apps/backend/src/verifier/verifier-offer/verifier-offer.controller.ts
@@ -94,6 +94,7 @@ export class VerifierOfferController {
                 user.entity!.id,
                 origin,
                 body.skewSeconds,
+                body.webhook,
             );
             return res.status(201).json(offer);
         }


### PR DESCRIPTION
## 📝 Description

The ISO 18013-7 (org-iso-mdoc, DC API) offer flow ignores the per-request
`webhook` override that the OID4VP flow honors and that the offer DTO documents
("If not provided, the configured webhook from the configuration will be
used"). EUDIPLO therefore always calls back the webhook stored in the
presentation config, never the one supplied per offer — breaking the
webhook-proxy pattern (an integrator that substitutes its own callback
URL/credential per offer loses that override on ISO 18013-7).

Fix (mirrors OID4VP): thread the per-request webhook into
`Iso18013Service.createOffer` and persist it with override-first precedence
(`webhook ?? config.webhook`), falling back to the configured webhook when the
caller omits one. The response consumer already reads `session.parsedWebhook`
first, so no change is needed there.

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 🧪 Testing

- [x] Unit tests (`iso18013.service.spec.ts`): an ISO 18013-7 offer with a
      per-request webhook persists it on the session; without one it falls back
      to the configured webhook.
- [x] Backend builds; Biome/knip clean.

## ✔️ Checklist

- [x] Follows the code style of this project
- [x] Self-reviewed
- [x] No new warnings
- [x] Tests added that prove the fix
- [x] New and existing unit tests pass locally

## 📋 Additional Notes

The DTO already documents the override; this aligns ISO 18013-7 with OID4VP.
