### PR TITLE
fix(issuer): avoid reserved authorization server id in default issuance config fallback

### DIFF
--- a/apps/backend/src/issuer/configuration/issuance/issuance.service.ts
+++ b/apps/backend/src/issuer/configuration/issuance/issuance.service.ts
@@ -269,6 +269,16 @@ export class IssuanceService {
             existingConfig = await this.getIssuanceConfiguration(tenantId);
         } catch {
             // No existing config, will create new
+            existingConfig = { 
+                tenantId, 
+                authorizationServers: [
+                    {
+                        type: "built-in",
+                        id: "issuer-built-in",
+                        enabled: true,
+                    }
+                ] 
+            };
         }
 
         // Filter out undefined values from the incoming config.

--- a/apps/backend/src/issuer/configuration/issuance/issuance.service.ts
+++ b/apps/backend/src/issuer/configuration/issuance/issuance.service.ts
@@ -269,15 +269,15 @@ export class IssuanceService {
             existingConfig = await this.getIssuanceConfiguration(tenantId);
         } catch {
             // No existing config, will create new
-            existingConfig = { 
-                tenantId, 
+            existingConfig = {
+                tenantId,
                 authorizationServers: [
                     {
                         type: "built-in",
                         id: "issuer-built-in",
                         enabled: true,
-                    }
-                ] 
+                    },
+                ],
             };
         }
 


### PR DESCRIPTION
## 📝 Description

Fixes the default issuance configuration fallback so it does not create a built-in authorization server with a reserved id.

When no issuance config exists yet, the fallback now creates the built-in authorization server with id `issuer-built-in` instead of `built-in`, preventing this error:

- `Authorization server id 'built-in' is reserved`

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test improvements
- [ ] 🏗️ Build/CI changes

## 💥 Breaking Changes (if applicable)

- **API changes**: none
- **Environment variables**: none
- **Config import format**: none
- **Database**: none

## 🧪 Testing

Describe the tests that you ran to verify your changes:

- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] E2E tests pass
- [x] Manual testing performed

**Test Configuration**:

- Node.js version: not captured
- OS: macOS
- Test environment: local development

## 📸 Screenshots (if applicable)

N/A

## ✔️ Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## 📋 Additional Notes

This change keeps reserved-id validation intact and only adjusts the auto-generated fallback default to a non-reserved id.