### PR TITLE
fix: validate client ids and surface unavailable user management

### DIFF
--- a/apps/backend/src/auth/auth.service.ts
+++ b/apps/backend/src/auth/auth.service.ts
@@ -78,6 +78,8 @@ export class AuthService {
             );
         }
 
+        console.log(clientId);
+
         const client = await this.clients.validateClientCredentials(
             clientId,
             clientSecret,

--- a/apps/backend/src/auth/auth.service.ts
+++ b/apps/backend/src/auth/auth.service.ts
@@ -76,9 +76,7 @@ export class AuthService {
             throw new UnauthorizedException(
                 "Client credentials must be provided either in Authorization header (Basic auth) or request body",
             );
-        }
-
-        console.log(clientId);
+        }    
 
         const client = await this.clients.validateClientCredentials(
             clientId,

--- a/apps/backend/src/auth/auth.service.ts
+++ b/apps/backend/src/auth/auth.service.ts
@@ -76,7 +76,7 @@ export class AuthService {
             throw new UnauthorizedException(
                 "Client credentials must be provided either in Authorization header (Basic auth) or request body",
             );
-        }    
+        }
 
         const client = await this.clients.validateClientCredentials(
             clientId,

--- a/apps/backend/src/auth/client/schemas/client.schema.ts
+++ b/apps/backend/src/auth/client/schemas/client.schema.ts
@@ -6,9 +6,16 @@ const rolesSchema = z
     .min(1)
     .describe("Roles assigned to the client. At least one role is required.");
 
+const clientIdSchema = z
+    .string()
+    .trim()
+    .min(1)
+    .regex(/^[A-Za-z0-9._:-]+$/, "Client ID must contain only letters, numbers, and . _ : -")
+    .describe("Unique client identifier.");
+
 export const CreateClientSchema = z
     .object({
-        clientId: z.string().min(1).describe("Unique client identifier."),
+        clientId: clientIdSchema,
         secret: z
             .string()
             .min(1)

--- a/apps/backend/src/auth/client/schemas/client.schema.ts
+++ b/apps/backend/src/auth/client/schemas/client.schema.ts
@@ -10,7 +10,10 @@ const clientIdSchema = z
     .string()
     .trim()
     .min(1)
-    .regex(/^[A-Za-z0-9._:-]+$/, "Client ID must contain only letters, numbers, and . _ : -")
+    .regex(
+        /^[A-Za-z0-9._:-]+$/,
+        "Client ID must contain only letters, numbers, and . _ : -",
+    )
     .describe("Unique client identifier.");
 
 export const CreateClientSchema = z

--- a/apps/backend/test/issuance/issuance-config.e2e-spec.ts
+++ b/apps/backend/test/issuance/issuance-config.e2e-spec.ts
@@ -62,7 +62,7 @@ describe("Issuance - Configuration", () => {
         expect(res.body.authorizationServers).toBeDefined();
         expect(res.body.authorizationServers).toHaveLength(1);
         expect(res.body.authorizationServers[0]).toMatchObject({
-            type: "built-in",            
+            type: "built-in",
         });
     });
 

--- a/apps/backend/test/issuance/issuance-config.e2e-spec.ts
+++ b/apps/backend/test/issuance/issuance-config.e2e-spec.ts
@@ -52,6 +52,20 @@ describe("Issuance - Configuration", () => {
             .expect(201);
     }
 
+    test("get should create a default issuance config when none exists", async () => {
+        const res = await request(app.getHttpServer())
+            .get("/issuer/config")
+            .trustLocalhost()
+            .set("Authorization", `Bearer ${authToken}`)
+            .expect(200);
+
+        expect(res.body.authorizationServers).toBeDefined();
+        expect(res.body.authorizationServers).toHaveLength(1);
+        expect(res.body.authorizationServers[0]).toMatchObject({
+            type: "built-in",            
+        });
+    });
+
     test("partial update should preserve existing config values", async () => {
         // Step 1: Ensure a valid baseline configuration exists
         await ensureBaselineConfig();

--- a/apps/backend/test/shared/config-import.service.spec.ts
+++ b/apps/backend/test/shared/config-import.service.spec.ts
@@ -86,6 +86,22 @@ describe("ConfigImportService", () => {
         expect(result.isValid).toBe(false);
     });
 
+    it("rejects client IDs containing whitespace or unsupported characters", async () => {
+        const result = await service.validateConfig(
+            "/tmp/tenant-a/clients/client.json",
+            "client.json",
+            {
+                clientId: "car entry",
+                roles: ["clients:manage"],
+            },
+            CreateClientSchema,
+            { name: "tenant-a" },
+            "client config",
+        );
+
+        expect(result.isValid).toBe(false);
+    });
+
     it("includes the file path in validation error logs", async () => {
         const errorSpy = vi
             .spyOn(Logger.prototype, "error")

--- a/apps/client/src/app/tenants/client/client-create/client-create.component.html
+++ b/apps/client/src/app/tenants/client/client-create/client-create.component.html
@@ -23,6 +23,11 @@
           @if (clientForm.get('clientId')?.hasError('minlength')) {
             <mat-error> Client ID must be at least 1 character long </mat-error>
           }
+          @if (clientForm.get('clientId')?.hasError('invalidClientId')) {
+            <mat-error>
+              Client ID may only contain letters, numbers, and the characters . _ : -
+            </mat-error>
+          }
         </mat-form-field>
 
         <mat-form-field appearance="outline">

--- a/apps/client/src/app/tenants/client/client-create/client-create.component.ts
+++ b/apps/client/src/app/tenants/client/client-create/client-create.component.ts
@@ -13,6 +13,8 @@ import {
   clientControllerGetClient,
   clientControllerUpdateClient,
   credentialConfigControllerGetConfigs,
+  type CreateClientDto,
+  type UpdateClientDto,
 } from '@eudiplo/sdk-core';
 import { ApiService } from '../../../core';
 import { JwtService, roles } from '../../../services/jwt.service';
@@ -66,7 +68,7 @@ export class ClientCreateComponent implements OnInit {
     private readonly jwtService: JwtService
   ) {
     this.clientForm = this.fb.group({
-      clientId: ['', [Validators.required, Validators.minLength(1)]],
+      clientId: ['', [Validators.required, Validators.minLength(1), this.clientIdValidator]],
       description: [''],
       roles: [[], [Validators.required]],
       allowedPresentationConfigs: [[]],
@@ -119,14 +121,77 @@ export class ClientCreateComponent implements OnInit {
     }
   }
 
+  private buildCreateClientPayload(): CreateClientDto {
+    const rawValue = this.clientForm.getRawValue() as Partial<CreateClientDto> & {
+      clientId?: unknown;
+      description?: unknown;
+      allowedPresentationConfigs?: unknown;
+      allowedIssuanceConfigs?: unknown;
+      roles?: string[];
+    };
+    const clientId = typeof rawValue.clientId === 'string' ? rawValue.clientId.trim() : '';
+    const description =
+      typeof rawValue.description === 'string' ? rawValue.description.trim() : rawValue.description;
+
+    return {
+      clientId,
+      description: description || undefined,
+      roles: rawValue.roles ?? [],
+      allowedPresentationConfigs: this.normalizeStringList(rawValue.allowedPresentationConfigs),
+      allowedIssuanceConfigs: this.normalizeStringList(rawValue.allowedIssuanceConfigs),
+    };
+  }
+
+  private buildUpdateClientPayload(): UpdateClientDto {
+    const rawValue = this.clientForm.getRawValue() as Partial<UpdateClientDto> & {
+      description?: unknown;
+      allowedPresentationConfigs?: unknown;
+      allowedIssuanceConfigs?: unknown;
+      roles?: string[];
+    };
+    const description =
+      typeof rawValue.description === 'string' ? rawValue.description.trim() : rawValue.description;
+
+    return {
+      description: description || undefined,
+      roles: rawValue.roles ?? [],
+      allowedPresentationConfigs: this.normalizeStringList(rawValue.allowedPresentationConfigs),
+      allowedIssuanceConfigs: this.normalizeStringList(rawValue.allowedIssuanceConfigs),
+    };
+  }
+
+  private clientIdValidator(control: { value: string | null | undefined }): Record<string, boolean> | null {
+    const value = control.value?.trim();
+    if (!value) {
+      return null;
+    }
+
+    const validPattern = /^[A-Za-z0-9._:-]+$/;
+    return validPattern.test(value) ? null : { invalidClientId: true };
+  }
+
+  private normalizeStringList(value: unknown): string[] | undefined {
+    if (Array.isArray(value)) {
+      return value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0);
+    }
+
+    if (typeof value === 'string' && value.trim().length > 0) {
+      return [value.trim()];
+    }
+
+    return [];
+  }
+
   async onSubmit(): Promise<void> {
     this.isSubmitting = true;
 
     try {
       if (this.loaded) {
+        const payload = this.buildUpdateClientPayload();
+
         await clientControllerUpdateClient({
           path: { id: this.id! },
-          body: this.clientForm.value,
+          body: payload,
         });
         this.snackBar.open('Client updated successfully', 'Close', {
           duration: 3000,
@@ -138,8 +203,10 @@ export class ClientCreateComponent implements OnInit {
           this.apiService.refreshAccessToken();
         }
       } else {
+        const payload = this.buildCreateClientPayload();
+
         const result = await clientControllerCreateClient({
-          body: this.clientForm.value,
+          body: payload,
         });
 
         // Cast to expected type since SDK returns generic response

--- a/apps/client/src/app/tenants/client/client-create/client-create.component.ts
+++ b/apps/client/src/app/tenants/client/client-create/client-create.component.ts
@@ -160,7 +160,9 @@ export class ClientCreateComponent implements OnInit {
     };
   }
 
-  private clientIdValidator(control: { value: string | null | undefined }): Record<string, boolean> | null {
+  private clientIdValidator(control: {
+    value: string | null | undefined;
+  }): Record<string, boolean> | null {
     const value = control.value?.trim();
     if (!value) {
       return null;
@@ -172,7 +174,9 @@ export class ClientCreateComponent implements OnInit {
 
   private normalizeStringList(value: unknown): string[] | undefined {
     if (Array.isArray(value)) {
-      return value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0);
+      return value.filter(
+        (item): item is string => typeof item === 'string' && item.trim().length > 0
+      );
     }
 
     if (typeof value === 'string' && value.trim().length > 0) {

--- a/apps/client/src/app/users/user-list/user-list.component.html
+++ b/apps/client/src/app/users/user-list/user-list.component.html
@@ -1,51 +1,70 @@
 <div fxLayout="row" fxLayoutAlign="space-between center">
   <h2>Users</h2>
-  <button matIconButton [routerLink]="['create']" matTooltip="Create New User">
+  <button
+    matIconButton
+    [routerLink]="['create']"
+    matTooltip="Create New User"
+    [disabled]="isUnavailable"
+  >
     <mat-icon>person_add</mat-icon>
   </button>
 </div>
 
 @if (!loading) {
-  <table mat-table [dataSource]="users" class="mat-elevation-z8">
-    <ng-container matColumnDef="username">
-      <th mat-header-cell *matHeaderCellDef>Username</th>
-      <td mat-cell *matCellDef="let user">{{ user.username }}</td>
-    </ng-container>
+  @if (isUnavailable) {
+    <mat-card class="mat-elevation-z2">
+      <mat-card-content>
+        <div fxLayout="column" fxLayoutGap="8px">
+          <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="8px">
+            <mat-icon color="warn">info</mat-icon>
+            <strong>User management is unavailable</strong>
+          </div>
+          <p>{{ unavailableMessage }}</p>
+        </div>
+      </mat-card-content>
+    </mat-card>
+  } @else {
+    <table mat-table [dataSource]="users" class="mat-elevation-z8">
+      <ng-container matColumnDef="username">
+        <th mat-header-cell *matHeaderCellDef>Username</th>
+        <td mat-cell *matCellDef="let user">{{ user.username }}</td>
+      </ng-container>
 
-    <ng-container matColumnDef="roles">
-      <th mat-header-cell *matHeaderCellDef>Roles</th>
-      <td mat-cell *matCellDef="let user">
-        <mat-chip-set>
-          @for (role of user.roles; track role) {
-            <span>
-              <mat-chip>{{ role }}</mat-chip>
-            </span>
-          }
-        </mat-chip-set>
-      </td>
-    </ng-container>
+      <ng-container matColumnDef="roles">
+        <th mat-header-cell *matHeaderCellDef>Roles</th>
+        <td mat-cell *matCellDef="let user">
+          <mat-chip-set>
+            @for (role of user.roles; track role) {
+              <span>
+                <mat-chip>{{ role }}</mat-chip>
+              </span>
+            }
+          </mat-chip-set>
+        </td>
+      </ng-container>
 
-    <ng-container matColumnDef="enabled">
-      <th mat-header-cell *matHeaderCellDef>Status</th>
-      <td mat-cell *matCellDef="let user">{{ user.enabled ? 'Enabled' : 'Disabled' }}</td>
-    </ng-container>
+      <ng-container matColumnDef="enabled">
+        <th mat-header-cell *matHeaderCellDef>Status</th>
+        <td mat-cell *matCellDef="let user">{{ user.enabled ? 'Enabled' : 'Disabled' }}</td>
+      </ng-container>
 
-    <ng-container matColumnDef="actions">
-      <th mat-header-cell *matHeaderCellDef>Actions</th>
-      <td mat-cell *matCellDef="let user">
-        <button matIconButton [routerLink]="[user.id]" matTooltip="View User Details">
-          <mat-icon>visibility</mat-icon>
-        </button>
-        <button matIconButton [routerLink]="[user.id, 'edit']" matTooltip="Edit User">
-          <mat-icon>edit</mat-icon>
-        </button>
-        <button matIconButton (click)="deleteUser(user)" matTooltip="Delete User">
-          <mat-icon>delete</mat-icon>
-        </button>
-      </td>
-    </ng-container>
+      <ng-container matColumnDef="actions">
+        <th mat-header-cell *matHeaderCellDef>Actions</th>
+        <td mat-cell *matCellDef="let user">
+          <button matIconButton [routerLink]="[user.id]" matTooltip="View User Details">
+            <mat-icon>visibility</mat-icon>
+          </button>
+          <button matIconButton [routerLink]="[user.id, 'edit']" matTooltip="Edit User">
+            <mat-icon>edit</mat-icon>
+          </button>
+          <button matIconButton (click)="deleteUser(user)" matTooltip="Delete User">
+            <mat-icon>delete</mat-icon>
+          </button>
+        </td>
+      </ng-container>
 
-    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-    <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
-  </table>
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+    </table>
+  }
 }

--- a/apps/client/src/app/users/user-list/user-list.component.ts
+++ b/apps/client/src/app/users/user-list/user-list.component.ts
@@ -32,6 +32,8 @@ import {
 export class UserListComponent implements OnInit {
   users: ManagedUserDto[] = [];
   loading = false;
+  isUnavailable = false;
+  unavailableMessage = '';
   displayedColumns: (keyof ManagedUserDto | 'actions')[] = [
     'username',
     'roles',
@@ -47,14 +49,85 @@ export class UserListComponent implements OnInit {
 
   async loadUsers(): Promise<void> {
     this.loading = true;
+    this.isUnavailable = false;
+    this.unavailableMessage = '';
+
     try {
       this.users = await userControllerGetUsers<true>().then((res) => res.data);
     } catch (error) {
-      console.error('Error loading users:', error);
-      this.snackBar.open('Failed to load users', 'Close', { duration: 3000 });
+      const message = this.getErrorMessage(error);
+
+      if (this.isUnavailableError(message, error)) {
+        this.isUnavailable = true;
+        this.unavailableMessage = message;
+        this.users = [];
+      } else {
+        console.error('Error loading users:', error);
+        this.snackBar.open('Failed to load users', 'Close', { duration: 3000 });
+      }
     } finally {
       this.loading = false;
     }
+  }
+
+  private getErrorMessage(error: unknown): string {
+    if (error instanceof Error && error.message) {
+      return error.message;
+    }
+
+    if (typeof error === 'string') {
+      return error;
+    }
+
+    if (typeof error === 'object' && error !== null) {
+      const maybeMessage = (error as { message?: unknown }).message;
+      if (typeof maybeMessage === 'string') {
+        return maybeMessage;
+      }
+
+      const maybeBody = (error as { body?: unknown }).body;
+      if (typeof maybeBody === 'string') {
+        return maybeBody;
+      }
+
+      if (typeof maybeBody === 'object' && maybeBody !== null) {
+        const bodyMessage = (maybeBody as { message?: unknown }).message;
+        if (typeof bodyMessage === 'string') {
+          return bodyMessage;
+        }
+      }
+    }
+
+    return 'Failed to load users';
+  }
+
+  private isUnavailableError(message: string, error: unknown): boolean {
+    const errorText = `${message} ${this.getErrorDetails(error)}`.toLowerCase();
+
+    return (
+      errorText.includes('human user management') ||
+      errorText.includes('external oidc provider') ||
+      errorText.includes('not implemented') ||
+      (typeof error === 'object' && error !== null && 'status' in error && (error as { status?: number }).status === 501)
+    );
+  }
+
+  private getErrorDetails(error: unknown): string {
+    if (typeof error !== 'object' || error === null) {
+      return '';
+    }
+
+    const maybeBody = (error as { body?: unknown }).body;
+    if (typeof maybeBody === 'string') {
+      return maybeBody;
+    }
+
+    if (typeof maybeBody === 'object' && maybeBody !== null) {
+      const bodyText = JSON.stringify(maybeBody);
+      return bodyText;
+    }
+
+    return '';
   }
 
   async deleteUser(user: ManagedUserDto): Promise<void> {

--- a/apps/client/src/app/users/user-list/user-list.component.ts
+++ b/apps/client/src/app/users/user-list/user-list.component.ts
@@ -108,7 +108,10 @@ export class UserListComponent implements OnInit {
       errorText.includes('human user management') ||
       errorText.includes('external oidc provider') ||
       errorText.includes('not implemented') ||
-      (typeof error === 'object' && error !== null && 'status' in error && (error as { status?: number }).status === 501)
+      (typeof error === 'object' &&
+        error !== null &&
+        'status' in error &&
+        (error as { status?: number }).status === 501)
     );
   }
 

--- a/docs/architecture/configuration-import.md
+++ b/docs/architecture/configuration-import.md
@@ -217,6 +217,12 @@ see [Status Management](./status-management.md).
 
 Define client-specific configurations, including client IDs, secrets, and permissions.
 
+!!! note "Client ID format"
+
+    Client IDs in imported configuration files must be non-empty and may only contain
+    letters, numbers, and the characters `.`, `_`, `:`, and `-`. Whitespace and
+    other special characters are rejected.
+
 **Schema Reference**:
 [Client Config API](../api/openapi.md)
 

--- a/docs/architecture/tenant.md
+++ b/docs/architecture/tenant.md
@@ -45,6 +45,12 @@ When a protected endpoint is called, EUDIPLO enforces tenant isolation and role-
 - Clients can be either managed by EUDIPLO by storing the client secrets (securely hashed with bcrypt) in the database or by using an external OIDC provider like Keycloak.
 - The web client authenticates against the OIDC provider and interacts with EUDIPLO using the provided access token.
 
+!!! note "Client ID format"
+
+    Client IDs must be non-empty and may only contain letters, numbers, and the
+    characters `.`, `_`, `:`, and `-`. Whitespace and other special characters are
+    rejected.
+
 From the UI you can:
 
 - Create and delete tenants


### PR DESCRIPTION
## Summary
- normalize empty values before client payload submission
- enforce stricter client ID validation on the backend and in the client form
- surface an unavailable state for human user management when the current setup does not support it
- document the client ID restriction in the architecture docs
- add regression coverage for issuance config initialization behavior

## Testing
- Verified the Angular client typecheck path successfully
- Attempted the issuance-config e2e suite, but the local run was blocked by a port conflict on port 3000 in this environment