### PR TITLE
fix: align CLI standalone release to multi-platform builds

### DIFF
--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -102,15 +102,14 @@ jobs:
       - name: Build CLI
         run: pnpm --filter @eudiplo/cli build
 
+      - name: Run CLI tests
+        run: pnpm --filter @eudiplo/cli test
+
       - name: Build CLI SEA
         run: pnpm --filter @eudiplo/cli build:sea
 
-      - name: Upload CLI SEA artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: eudiplo-cli-sea-${{ github.run_id }}
-          path: apps/cli/dist-sea/eudiplo
-          if-no-files-found: error
+      - name: Smoke test standalone CLI
+        run: ./apps/cli/dist-sea/eudiplo --help
 
   build-backend:
     name: Build Backend

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,21 +14,18 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  release:
-    name: Create Versioned Release
+  prepare-release:
+    name: Prepare versioned release
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      packages: write
-      pull-requests: write
-      actions: read
-      pages: write
-      id-token: write
+    outputs:
+      has_release: ${{ steps.version_check.outputs.has_release }}
+      is_major: ${{ steps.version_check.outputs.is_major }}
+      next_version: ${{ steps.version_check.outputs.next_version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
-          fetch-depth: 0 # Fetch full history for mike versioning
+          fetch-depth: 0
 
       - name: Require the main branch
         if: github.ref != 'refs/heads/main'
@@ -55,9 +52,7 @@ jobs:
             );
 
             if (!successfulRun) {
-              core.setFailed(
-                `No successful CI / Docker push run exists for ${context.sha}.`,
-              );
+              core.setFailed(`No successful CI / Docker push run exists for ${context.sha}.`);
               return;
             }
 
@@ -78,27 +73,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build SDK
-        run: pnpm --filter @eudiplo/sdk-core build
-
-      - name: Build CLI
-        run: pnpm --filter @eudiplo/cli build
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Verify immutable Docker source images
-        run: |
-          docker buildx imagetools inspect "ghcr.io/openwallet-foundation/eudiplo:sha-${GITHUB_SHA}"
-          docker buildx imagetools inspect "ghcr.io/openwallet-foundation/eudiplo-client:sha-${GITHUB_SHA}"
-
       - name: Check for major version bump
         id: version_check
         env:
@@ -112,7 +86,7 @@ jobs:
             echo "semantic-release dry-run failed (see output above)" >&2
             exit "$DRY_EXIT"
           fi
-          # Extract the next version from dry-run output
+
           NEXT_VERSION=$(echo "$DRY_OUTPUT" | grep -oP "The next release version is \K[0-9]+\.[0-9]+\.[0-9]+" || echo "")
           CURRENT_VERSION=$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo "0.0.0")
 
@@ -129,7 +103,6 @@ jobs:
           echo "has_release=true" >> "$GITHUB_OUTPUT"
           echo "next_version=$NEXT_VERSION" >> "$GITHUB_OUTPUT"
 
-          # Extract major versions
           CURRENT_MAJOR=$(echo "$CURRENT_VERSION" | cut -d. -f1)
           NEXT_MAJOR=$(echo "$NEXT_VERSION" | cut -d. -f1)
 
@@ -155,38 +128,179 @@ jobs:
           echo "A major version bump was detected but not confirmed."
           echo "To release a major version, trigger this workflow manually with:"
           echo "  confirm_major: CONFIRM"
-          echo ""
-          echo "This safeguard prevents accidental breaking changes from being released."
           exit 1
+
+  build-cli-release:
+    name: Build CLI (${{ matrix.target }})
+    needs: prepare-release
+    if: needs.prepare-release.outputs.has_release == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            target: linux-x64
+          - runner: ubuntu-24.04-arm
+            target: linux-arm64
+          - runner: macos-15
+            target: macos-arm64
+          - runner: windows-2025
+            target: windows-x64
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v5
+        name: Install pnpm
+        with:
+          run_install: false
+
+      - name: Install Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 26
+          cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Sync CLI version
+        shell: bash
+        run: node scripts/sync-cli-version.js "${{ needs.prepare-release.outputs.next_version }}"
+
+      - name: Build CLI
+        shell: bash
+        run: pnpm --filter @eudiplo/cli build
+
+      - name: Build standalone CLI SEA
+        shell: bash
+        run: pnpm --filter @eudiplo/cli build:sea
+
+      - name: Smoke test executable
+        shell: bash
+        run: |
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
+            ./apps/cli/dist-sea/eudiplo.exe --help
+          else
+            ./apps/cli/dist-sea/eudiplo --help
+          fi
+
+      - name: Package binary
+        shell: bash
+        run: |
+          set -e
+          mkdir -p release
+          ARCHIVE_NAME="eudiplo-v${{ needs.prepare-release.outputs.next_version }}-${{ matrix.target }}"
+          if [[ "${{ matrix.target }}" == "windows-x64" ]]; then
+            powershell -NoProfile -ExecutionPolicy Bypass -Command "Compress-Archive -Path 'apps/cli/dist-sea/eudiplo.exe' -DestinationPath 'release/${ARCHIVE_NAME}.zip' -Force"
+          else
+            chmod +x apps/cli/dist-sea/eudiplo
+            tar -C apps/cli/dist-sea -czf "release/${ARCHIVE_NAME}.tar.gz" eudiplo
+          fi
+
+      - name: Upload packaged CLI artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: cli-${{ matrix.target }}
+          path: release/*
+          if-no-files-found: error
+          retention-days: 1
+
+  publish-release:
+    name: Publish GitHub Release
+    needs: [prepare-release, build-cli-release]
+    if: needs.prepare-release.outputs.has_release == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: write
+      actions: read
+      pages: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Download packaged CLI artifacts
+        uses: actions/download-artifact@v8
+        with:
+          pattern: cli-*
+          path: release
+          merge-multiple: true
+
+      - name: Generate checksums
+        shell: bash
+        run: |
+          set -e
+          mkdir -p release
+          find release -maxdepth 1 -type f \( -name '*.tar.gz' -o -name '*.zip' \) -print0 | sort -z | xargs -0 sha256sum > release/SHA256SUMS.txt
+          echo "Generated checksums:"
+          cat release/SHA256SUMS.txt
+
+      - uses: pnpm/action-setup@v5
+        name: Install pnpm
+        with:
+          run_install: false
+
+      - name: Install Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 26
+          cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Set release version
+        id: release_version
+        run: |
+          echo "version=${{ needs.prepare-release.outputs.next_version }}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify immutable Docker source images
+        run: |
+          docker buildx imagetools inspect "ghcr.io/openwallet-foundation/eudiplo:sha-${GITHUB_SHA}"
+          docker buildx imagetools inspect "ghcr.io/openwallet-foundation/eudiplo-client:sha-${GITHUB_SHA}"
 
       - name: Run semantic-release
         id: semantic_release
         env:
+          EUDIPLO_RELEASE_VERSION: ${{ needs.prepare-release.outputs.next_version }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
           DOCKER_REGISTRY_USER: ${{ github.actor }}
           DOCKER_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
           DOCKER_SOURCE_SHA: ${{ github.sha }}
         run: |
-          echo "Running semantic-release..."
+          echo "Running semantic-release with release assets ready..."
           npx semantic-release
 
-          NEXT_VERSION="${{ steps.version_check.outputs.next_version }}"
+          NEXT_VERSION="${{ needs.prepare-release.outputs.next_version }}"
           EXPECTED_TAG="v${NEXT_VERSION}"
-
           if ! git ls-remote --exit-code --tags origin "refs/tags/${EXPECTED_TAG}" >/dev/null; then
             echo "semantic-release did not publish the expected tag ${EXPECTED_TAG}"
             exit 1
           fi
 
-          echo "New release detected: ${EXPECTED_TAG}"
           echo "new_release=true" >> "$GITHUB_OUTPUT"
           echo "version=${EXPECTED_TAG}" >> "$GITHUB_OUTPUT"
-
-      - name: Debug release detection
-        run: |
-          echo "New release: ${{ steps.semantic_release.outputs.new_release }}"
-          echo "Version: ${{ steps.semantic_release.outputs.version }}"
 
       - name: Set up Python for docs
         if: steps.semantic_release.outputs.new_release == 'true'

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -32,7 +32,7 @@ module.exports = {
         [
             '@semantic-release/exec',
             {
-                prepareCmd: 'node scripts/sync-sdk-version.js ${nextRelease.version} && node scripts/sync-cli-version.js ${nextRelease.version} && node scripts/build-cli-sea.mjs',
+                prepareCmd: 'node scripts/sync-sdk-version.js ${nextRelease.version} && node scripts/sync-cli-version.js ${nextRelease.version}',
                 publishCmd: 'chmod +x scripts/release-docker.sh && DOCKER_RELEASE_VERSION=${nextRelease.version} ./scripts/release-docker.sh',
             },
         ],
@@ -48,8 +48,24 @@ module.exports = {
         ['@semantic-release/github', {
             assets: [
                 {
-                    path: 'apps/cli/dist-sea/eudiplo',
-                    label: 'eudiplo-sea-linux-x64',
+                    path: 'release/eudiplo-v${nextRelease.version}-linux-x64.tar.gz',
+                    label: 'eudiplo-v${nextRelease.version}-linux-x64.tar.gz',
+                },
+                {
+                    path: 'release/eudiplo-v${nextRelease.version}-linux-arm64.tar.gz',
+                    label: 'eudiplo-v${nextRelease.version}-linux-arm64.tar.gz',
+                },
+                {
+                    path: 'release/eudiplo-v${nextRelease.version}-macos-arm64.tar.gz',
+                    label: 'eudiplo-v${nextRelease.version}-macos-arm64.tar.gz',
+                },
+                {
+                    path: 'release/eudiplo-v${nextRelease.version}-windows-x64.zip',
+                    label: 'eudiplo-v${nextRelease.version}-windows-x64.zip',
+                },
+                {
+                    path: 'release/SHA256SUMS.txt',
+                    label: 'SHA256SUMS.txt',
                 },
             ],
             addReleases: 'bottom',

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -110,8 +110,44 @@ To produce a standalone CLI binary with Node.js SEA support, run:
 pnpm --filter @eudiplo/cli build:sea
 ```
 
-This writes the executable to `apps/cli/dist-sea/eudiplo` and bundles the
-Compose template as a SEA asset.
+This writes the executable to `apps/cli/dist-sea/eudiplo` on Linux/macOS and
+`apps/cli/dist-sea/eudiplo.exe` on Windows, while bundling the Compose template
+as a SEA asset.
 
-The GitHub release workflow also publishes that SEA binary as a release asset,
-so consumers can download the standalone executable without cloning the repo.
+### Supported standalone platforms
+
+The versioned release publishes archive files for the currently supported native
+platforms:
+
+- Linux x64: `eudiplo-vVERSION-linux-x64.tar.gz`
+- Linux arm64: `eudiplo-vVERSION-linux-arm64.tar.gz`
+- macOS arm64: `eudiplo-vVERSION-macos-arm64.tar.gz`
+- Windows x64: `eudiplo-vVERSION-windows-x64.zip`
+
+### Install and verify a release archive
+
+Extract the archive for the matching platform and run the executable directly:
+
+```bash
+# Linux / macOS
+curl -LO https://github.com/openwallet-foundation/eudiplo/releases/download/vVERSION/eudiplo-vVERSION-linux-x64.tar.gz
+mkdir -p ~/.local/bin
+ tar -xzf eudiplo-vVERSION-linux-x64.tar.gz -C ~/.local/bin
+ ~/.local/bin/eudiplo --help
+
+# Windows PowerShell
+Invoke-WebRequest -Uri "https://github.com/openwallet-foundation/eudiplo/releases/download/vVERSION/eudiplo-vVERSION-windows-x64.zip" -OutFile "eudiplo-vVERSION-windows-x64.zip"
+Expand-Archive -Path .\eudiplo-vVERSION-windows-x64.zip -DestinationPath .
+.\eudiplo.exe --help
+```
+
+The release also attaches `SHA256SUMS.txt`. Verify the downloaded archive before
+running it:
+
+```bash
+sha256sum -c SHA256SUMS.txt
+```
+
+The standalone binary does not replace Docker or Docker Compose. You still need
+Docker to run the local deployment stack, but you do not need a local Node.js
+installation just to use the CLI itself.

--- a/scripts/build-cli-sea.mjs
+++ b/scripts/build-cli-sea.mjs
@@ -1,34 +1,105 @@
-import { rmSync } from "node:fs";
 import { execFileSync } from "node:child_process";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { arch, platform } from "node:process";
 import { fileURLToPath } from "node:url";
-import { platform } from "node:process";
 
 const packageDirectory = new URL("../apps/cli/", import.meta.url);
 const packagePath = fileURLToPath(packageDirectory);
+const distSeaDirectory = join(packagePath, "dist-sea");
+const baseSeaConfigPath = join(packagePath, "sea-config.json");
+const generatedSeaConfigPath = join(distSeaDirectory, "sea-config.generated.json");
 
-rmSync(new URL("dist-sea", packageDirectory), { recursive: true, force: true });
+function ensureBundle() {
+    const packageManagerExecutable = process.env.npm_execpath;
 
-const packageManagerExecutable = process.env.npm_execpath;
-if (packageManagerExecutable) {
-    execFileSync(process.execPath, [packageManagerExecutable, "run", "build:sea:bundle"], {
-        cwd: packagePath,
-        stdio: "inherit",
-    });
-} else {
+    if (packageManagerExecutable) {
+        execFileSync(process.execPath, [packageManagerExecutable, "run", "build:sea:bundle"], {
+            cwd: packagePath,
+            stdio: "inherit",
+        });
+        return;
+    }
+
     execFileSync("pnpm", ["run", "build:sea:bundle"], {
         cwd: packagePath,
         stdio: "inherit",
     });
 }
 
-execFileSync(process.execPath, ["--build-sea", "sea-config.json"], {
-    cwd: packagePath,
-    stdio: "inherit",
-});
+function detectBuildTarget() {
+    const byPlatform = {
+        linux: {
+            x64: "linux-x64",
+            arm64: "linux-arm64",
+        },
+        darwin: {
+            arm64: "macos-arm64",
+        },
+        win32: {
+            x64: "windows-x64",
+        },
+    };
 
-if (platform === "darwin") {
-    execFileSync("/usr/bin/codesign", ["--sign", "-", "dist-sea/eudiplo"], {
+    const target = byPlatform[platform]?.[arch];
+    if (!target) {
+        throw new Error(
+            `Unsupported platform/architecture for SEA build: ${platform}/${arch}. Supported targets: linux/x64, linux/arm64, darwin/arm64, win32/x64.`,
+        );
+    }
+
+    return target;
+}
+
+function createEffectiveSeaConfig() {
+    const baseConfig = JSON.parse(readFileSync(baseSeaConfigPath, "utf-8"));
+    const outputFilename = platform === "win32" ? "eudiplo.exe" : "eudiplo";
+    const generatedConfig = {
+        ...baseConfig,
+        main: "dist-sea/index.js",
+        output: `dist-sea/${outputFilename}`,
+        assets: {
+            "templates/docker-compose.yml": "templates/docker-compose.yml",
+        },
+    };
+
+    writeFileSync(generatedSeaConfigPath, `${JSON.stringify(generatedConfig, null, 4)}\n`);
+    return outputFilename;
+}
+
+function cleanup() {
+    rmSync(generatedSeaConfigPath, { force: true });
+}
+
+try {
+    const target = detectBuildTarget();
+    rmSync(distSeaDirectory, { recursive: true, force: true });
+    mkdirSync(distSeaDirectory, { recursive: true });
+
+    ensureBundle();
+
+    const outputFilename = createEffectiveSeaConfig();
+    const outputPath = join(distSeaDirectory, outputFilename);
+
+    console.log(`Building SEA for ${target} (${platform}/${arch}) -> ${outputPath}`);
+
+    execFileSync(process.execPath, ["--build-sea", generatedSeaConfigPath], {
         cwd: packagePath,
         stdio: "inherit",
     });
+
+    if (platform === "darwin") {
+        execFileSync("/usr/bin/codesign", ["--sign", "-", outputPath], {
+            cwd: packagePath,
+            stdio: "inherit",
+        });
+    }
+
+    console.log(`SEA build complete: ${outputPath}`);
+} catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`SEA build failed: ${message}`);
+    process.exit(1);
+} finally {
+    cleanup();
 }

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 REPO="openwallet-foundation/eudiplo"
-RELEASE_BASE="https://github.com/${REPO}/releases/latest/download"
+GITHUB_API="https://api.github.com/repos/${REPO}/releases/latest"
 INSTALL_DIR="${EUDIPLO_INSTALL_DIR:-$HOME/.local/bin}"
 
 fail() {
@@ -10,32 +10,7 @@ fail() {
   exit 1
 }
 
-detect_asset() {
-  local os arch
-  os="$(uname -s)"
-  arch="$(uname -m)"
-
-  case "$os" in
-    Linux)
-      case "$arch" in
-        x86_64|amd64)
-          echo "eudiplo-sea-linux-x64"
-          ;;
-        *)
-          fail "Standalone CLI builds are currently published only for Linux x64. Install the npm package instead: npm install -g @eudiplo/cli"
-          ;;
-      esac
-      ;;
-    Darwin)
-      fail "Standalone CLI builds are currently published only for Linux x64. Install the npm package instead: npm install -g @eudiplo/cli"
-      ;;
-    *)
-      fail "Unsupported operating system: $os. Standalone CLI builds are currently published only for Linux x64. Install the npm package instead: npm install -g @eudiplo/cli"
-      ;;
-  esac
-}
-
-ensure_tool() {
+require_tool() {
   command -v curl >/dev/null 2>&1 || fail "curl is required but not installed"
 }
 
@@ -43,8 +18,52 @@ ensure_npm_fallback() {
   command -v npm >/dev/null 2>&1 || fail "npm is required for the fallback install on this platform"
 }
 
+resolve_latest_tag() {
+  curl -fsSL "$GITHUB_API" | grep -o '"tag_name": *"[^"]*"' | head -n 1 | cut -d'"' -f4
+}
+
+detect_asset() {
+  local os arch tag
+  os="$(uname -s)"
+  arch="$(uname -m)"
+  tag="$(resolve_latest_tag)"
+
+  if [[ -z "$tag" ]]; then
+    fail "Could not resolve the latest EUDIPLO release tag. Install the npm package instead: npm install -g @eudiplo/cli"
+  fi
+
+  case "$os" in
+    Linux)
+      case "$arch" in
+        x86_64|amd64)
+          echo "eudiplo-${tag}-linux-x64.tar.gz"
+          ;;
+        arm64|aarch64)
+          echo "eudiplo-${tag}-linux-arm64.tar.gz"
+          ;;
+        *)
+          fail "Standalone CLI builds are not published for this Linux architecture. Install the npm package instead: npm install -g @eudiplo/cli"
+          ;;
+      esac
+      ;;
+    Darwin)
+      case "$arch" in
+        arm64|aarch64)
+          echo "eudiplo-${tag}-macos-arm64.tar.gz"
+          ;;
+        *)
+          fail "Standalone CLI builds are not published for this macOS architecture. Install the npm package instead: npm install -g @eudiplo/cli"
+          ;;
+      esac
+      ;;
+    *)
+      fail "Unsupported operating system: $os. Install the npm package instead: npm install -g @eudiplo/cli"
+      ;;
+  esac
+}
+
 fallback_to_npm_install() {
-  echo "Standalone CLI binary is currently published only for Linux x64. Falling back to the npm package install for this machine."
+  echo "Standalone CLI binary is not available for this platform. Falling back to the npm package install."
   ensure_npm_fallback
   npm install -g @eudiplo/cli
   echo "Installed @eudiplo/cli via npm"
@@ -52,26 +71,30 @@ fallback_to_npm_install() {
 }
 
 main() {
-  ensure_tool
+  require_tool
 
-  local asset install_path download_url tmp_file
-  if [[ "$(uname -s)" != "Linux" || "$(uname -m)" != "x86_64" && "$(uname -m)" != "amd64" ]]; then
+  local asset install_path download_url tmp_file archive_dir
+  if [[ "$(uname -s)" == "Linux" && ( "$(uname -m)" == "x86_64" || "$(uname -m)" == "amd64" || "$(uname -m)" == "arm64" || "$(uname -m)" == "aarch64" ) ]] || [[ "$(uname -s)" == "Darwin" && ( "$(uname -m)" == "arm64" || "$(uname -m)" == "aarch64" ) ]]; then
+    :
+  else
     fallback_to_npm_install
   fi
 
   asset="$(detect_asset)"
-  download_url="${RELEASE_BASE}/${asset}"
+  download_url="https://github.com/${REPO}/releases/download/$(resolve_latest_tag)/${asset}"
   install_path="${INSTALL_DIR}/eudiplo"
 
   mkdir -p "${INSTALL_DIR}"
 
   tmp_file="$(mktemp "${TMPDIR:-/tmp}/eudiplo-install.XXXXXX")"
-  trap 'rm -f "$tmp_file"' EXIT
+  archive_dir="$(mktemp -d "${TMPDIR:-/tmp}/eudiplo-archive.XXXXXX")"
+  trap 'rm -f "$tmp_file"; rm -rf "$archive_dir"' EXIT
 
   echo "Downloading ${asset} from ${download_url}"
   curl -fsSL "$download_url" -o "$tmp_file"
 
-  install -m 755 "$tmp_file" "$install_path"
+  tar -xzf "$tmp_file" -C "$archive_dir"
+  install -m 755 "$archive_dir/eudiplo" "$install_path"
   echo "Installed EUDIPLO CLI to: ${install_path}"
 
   if ! printf '%s:' "$PATH" | grep -Fq ":${INSTALL_DIR}:"; then

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -19,31 +19,18 @@ detect_asset() {
     Linux)
       case "$arch" in
         x86_64|amd64)
-          echo "eudiplo-seal-linux-x64"
-          ;;
-        arm64|aarch64)
-          echo "eudiplo-seal-linux-arm64"
+          echo "eudiplo-sea-linux-x64"
           ;;
         *)
-          fail "Unsupported Linux architecture: $arch"
+          fail "Standalone CLI builds are currently published only for Linux x64. Install the npm package instead: npm install -g @eudiplo/cli"
           ;;
       esac
       ;;
     Darwin)
-      case "$arch" in
-        x86_64|amd64)
-          echo "eudiplo-seal-macos-x64"
-          ;;
-        arm64|aarch64)
-          echo "eudiplo-seal-macos-arm64"
-          ;;
-        *)
-          fail "Unsupported macOS architecture: $arch"
-          ;;
-      esac
+      fail "Standalone CLI builds are currently published only for Linux x64. Install the npm package instead: npm install -g @eudiplo/cli"
       ;;
     *)
-      fail "Unsupported operating system: $os"
+      fail "Unsupported operating system: $os. Standalone CLI builds are currently published only for Linux x64. Install the npm package instead: npm install -g @eudiplo/cli"
       ;;
   esac
 }
@@ -52,10 +39,26 @@ ensure_tool() {
   command -v curl >/dev/null 2>&1 || fail "curl is required but not installed"
 }
 
+ensure_npm_fallback() {
+  command -v npm >/dev/null 2>&1 || fail "npm is required for the fallback install on this platform"
+}
+
+fallback_to_npm_install() {
+  echo "Standalone CLI binary is currently published only for Linux x64. Falling back to the npm package install for this machine."
+  ensure_npm_fallback
+  npm install -g @eudiplo/cli
+  echo "Installed @eudiplo/cli via npm"
+  exit 0
+}
+
 main() {
   ensure_tool
 
   local asset install_path download_url tmp_file
+  if [[ "$(uname -s)" != "Linux" || "$(uname -m)" != "x86_64" && "$(uname -m)" != "amd64" ]]; then
+    fallback_to_npm_install
+  fi
+
   asset="$(detect_asset)"
   download_url="${RELEASE_BASE}/${asset}"
   install_path="${INSTALL_DIR}/eudiplo"


### PR DESCRIPTION
## Summary

This PR fixes the standalone CLI release mismatch by aligning the published assets, installer logic, and CI release matrix with the actual supported OS targets.

## What changed

- Added multi-platform SEA build support for Linux x64, Linux arm64, macOS arm64, and Windows x64
- Updated the GitHub release workflow to build a release matrix instead of a single Linux binary
- Generated SHA256 checksums and attached all CLI archives to the GitHub Release
- Updated the install script to avoid 404s and fallback to npm when the standalone binary is unavailable
- Updated CLI documentation to describe the supported release archives and verification steps

## Validation

- Local CLI build and SEA build were verified in this workspace.
- The release workflow itself still needs a real GitHub Actions run to confirm the fully published asset matrix on the production release path.

## Notes

A temporary MR/PR validation run is useful as a smoke test for the workflow, but it should not be used to cut a production release unless the repository owners explicitly want a pre-release check.