### PR TITLE
fix: handle optional and clearable tenant fields

### DIFF
--- a/apps/backend/src/auth/tenant/entitites/tenant.entity.ts
+++ b/apps/backend/src/auth/tenant/entitites/tenant.entity.ts
@@ -28,9 +28,12 @@ export class TenantEntity {
     /**
      * The description of the tenant.
      */
-    @ApiPropertyOptional({ description: "Tenant description" })
-    @Column({ nullable: true })
-    description?: string;
+    @ApiPropertyOptional({
+        description: "Tenant description",
+        nullable: true,
+    })
+    @Column("varchar", { nullable: true })
+    description?: string | null;
 
     /**
      * The current status of the tenant.

--- a/apps/backend/src/auth/tenant/schemas/create-tenant.schema.spec.ts
+++ b/apps/backend/src/auth/tenant/schemas/create-tenant.schema.spec.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "vitest";
+import { CreateTenantSchema, UpdateTenantSchema } from "./create-tenant.schema";
+
+describe("tenant request schemas", () => {
+    test("allows create without a description", () => {
+        expect(
+            CreateTenantSchema.parse({ id: "tenant", name: "Tenant" }),
+        ).not.toHaveProperty("description");
+    });
+
+    test("trims non-blank create descriptions", () => {
+        expect(
+            CreateTenantSchema.parse({
+                id: "tenant",
+                name: "Tenant",
+                description: "  Example tenant  ",
+            }).description,
+        ).toBe("Example tenant");
+    });
+
+    test.each(["", "   "])(
+        "rejects a blank create description (%j)",
+        (description) => {
+            expect(
+                CreateTenantSchema.safeParse({
+                    id: "tenant",
+                    name: "Tenant",
+                    description,
+                }).success,
+            ).toBe(false);
+        },
+    );
+
+    test("keeps omitted update fields omitted without applying create defaults", () => {
+        expect(UpdateTenantSchema.parse({})).toEqual({});
+    });
+
+    test("trims non-blank update descriptions", () => {
+        expect(
+            UpdateTenantSchema.parse({ description: "  Updated  " }),
+        ).toEqual({ description: "Updated" });
+    });
+
+    test("allows an update description to be cleared", () => {
+        expect(UpdateTenantSchema.parse({ description: null })).toEqual({
+            description: null,
+        });
+    });
+
+    test.each(["", "   "])(
+        "rejects a blank update description (%j)",
+        (description) => {
+            expect(UpdateTenantSchema.safeParse({ description }).success).toBe(
+                false,
+            );
+        },
+    );
+
+    test("rejects create-only properties in updates", () => {
+        expect(
+            UpdateTenantSchema.safeParse({ roles: ["clients:manage"] }).success,
+        ).toBe(false);
+        expect(UpdateTenantSchema.safeParse({ id: "tenant" }).success).toBe(
+            false,
+        );
+    });
+});

--- a/apps/backend/src/auth/tenant/schemas/create-tenant.schema.ts
+++ b/apps/backend/src/auth/tenant/schemas/create-tenant.schema.ts
@@ -7,21 +7,17 @@ const RoleSchema = z.enum(
     allRoles as [(typeof allRoles)[number], ...(typeof allRoles)[number][]],
 );
 
+const NonBlankStringSchema = z.string().trim().min(1);
+
 export const CreateTenantSchema = z
     .strictObject({
-        id: z.string().trim().min(1).describe("Unique tenant identifier."),
-        name: z
-            .string()
-            .trim()
-            .min(1)
-            .default("EUDIPLO")
-            .describe("Display name of the tenant."),
-        description: z
-            .string()
-            .trim()
-            .min(1)
-            .optional()
-            .describe("Optional tenant description."),
+        id: NonBlankStringSchema.describe("Unique tenant identifier."),
+        name: NonBlankStringSchema.default("EUDIPLO").describe(
+            "Display name of the tenant.",
+        ),
+        description: NonBlankStringSchema.optional().describe(
+            "Optional tenant description.",
+        ),
         roles: z
             .array(RoleSchema)
             .optional()
@@ -40,10 +36,23 @@ export const ImportTenantSchema = CreateTenantSchema.pick({
     description: true,
 }).describe("Payload used when importing tenant metadata from config files.");
 
-export const UpdateTenantSchema = CreateTenantSchema.omit({
-    id: true,
-})
-    .partial()
+export const UpdateTenantSchema = z
+    .strictObject({
+        name: NonBlankStringSchema.optional().describe(
+            "Display name of the tenant.",
+        ),
+        description: NonBlankStringSchema.nullable()
+            .optional()
+            .describe(
+                "Tenant description. Omit to keep the current value or set to null to remove it.",
+            ),
+        sessionConfig: SessionStorageConfigSchema.optional().describe(
+            "Optional tenant-specific session storage configuration.",
+        ),
+        statusListConfig: StatusListConfigSchema.optional().describe(
+            "Optional tenant-specific status list defaults.",
+        ),
+    })
     .describe("Payload for partially updating tenant metadata.");
 
 export type CreateTenant = z.infer<typeof CreateTenantSchema>;

--- a/apps/backend/src/auth/tenant/tenant.service.spec.ts
+++ b/apps/backend/src/auth/tenant/tenant.service.spec.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { TenantEntity } from "./entitites/tenant.entity";
+import { TenantService } from "./tenant.service";
+
+describe("TenantService updates", () => {
+    let storedTenant: TenantEntity;
+    let repository: {
+        findOneOrFail: ReturnType<typeof vi.fn>;
+        update: ReturnType<typeof vi.fn>;
+    };
+    let service: TenantService;
+
+    beforeEach(() => {
+        storedTenant = {
+            id: "tenant",
+            name: "Tenant",
+            description: "Existing description",
+            status: "active",
+            clients: [],
+        };
+        repository = {
+            findOneOrFail: vi.fn(async () => ({ ...storedTenant })),
+            update: vi.fn(async (_criteria, update) => {
+                Object.assign(storedTenant, update);
+                return { affected: 1 };
+            }),
+        };
+
+        service = new TenantService(
+            {} as never,
+            {} as never,
+            {} as never,
+            {} as never,
+            repository as never,
+            {
+                getUpDownCounter: vi.fn(() => ({ add: vi.fn() })),
+            } as never,
+            {} as never,
+            { registerTenantSetup: vi.fn() } as never,
+            {} as never,
+        );
+    });
+
+    test("preserves the existing description when it is omitted", async () => {
+        const updated = await service.updateTenant("tenant", {
+            name: "Renamed",
+        });
+
+        expect(updated.description).toBe("Existing description");
+        expect(repository.update).toHaveBeenCalledWith(
+            { id: "tenant" },
+            { name: "Renamed" },
+        );
+    });
+
+    test("replaces an existing description", async () => {
+        const updated = await service.updateTenant("tenant", {
+            description: "Updated description",
+        });
+
+        expect(updated.description).toBe("Updated description");
+    });
+
+    test("persists null to clear an existing description", async () => {
+        const updated = await service.updateTenant("tenant", {
+            description: null,
+        });
+
+        expect(updated.description).toBeNull();
+        expect(repository.update).toHaveBeenCalledWith(
+            { id: "tenant" },
+            { description: null },
+        );
+    });
+});

--- a/apps/backend/test/openapi.e2e-spec.ts
+++ b/apps/backend/test/openapi.e2e-spec.ts
@@ -1,6 +1,6 @@
 import { INestApplication } from "@nestjs/common";
-import { Test, type TestingModule } from "@nestjs/testing";
 import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
+import { Test, type TestingModule } from "@nestjs/testing";
 import { cleanupOpenApiDoc } from "nestjs-zod";
 import { App } from "supertest/types";
 import { beforeAll, describe, expect, test } from "vitest";
@@ -45,11 +45,37 @@ describe("OpenAPI contract", () => {
             app,
             new DocumentBuilder()
                 .setTitle("EUDIPLO")
+                .setOpenAPIVersion("3.1.0")
                 .setVersion("test")
                 .build(),
         );
 
         document = cleanupOpenApiDoc(swaggerDocument);
+    });
+
+    test("documents tenant description clearing without create-only PATCH fields", () => {
+        const createTenantSchema = document.components?.schemas
+            ?.CreateTenantDto as any;
+        const updateTenantSchema = document.components?.schemas
+            ?.UpdateTenantDto as any;
+        const tenantResponseSchema = document.components?.schemas
+            ?.TenantResponseDto as any;
+
+        expect(createTenantSchema.properties.description).not.toMatchObject({
+            nullable: true,
+        });
+        expect(updateTenantSchema.properties.description.anyOf).toEqual(
+            expect.arrayContaining([{ type: "null" }]),
+        );
+        expect(updateTenantSchema.properties.description.description).toContain(
+            "set to null to remove it",
+        );
+        expect(updateTenantSchema.properties.name.default).toBeUndefined();
+        expect(updateTenantSchema.properties.roles).toBeUndefined();
+        expect(updateTenantSchema.properties.id).toBeUndefined();
+        expect(tenantResponseSchema.properties.description).toMatchObject({
+            nullable: true,
+        });
     });
 
     test("documents key JSON, form, binary, SSE, and no-content responses", () => {

--- a/apps/client/src/app/tenants/tenant-create/tenant-create.component.spec.ts
+++ b/apps/client/src/app/tenants/tenant-create/tenant-create.component.spec.ts
@@ -1,22 +1,148 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import '@angular/compiler';
+import { FormBuilder } from '@angular/forms';
+import { of } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const sdkMocks = vi.hoisted(() => ({
+  getTenant: vi.fn(),
+  initTenant: vi.fn(),
+  updateTenant: vi.fn(),
+}));
+
+vi.mock('@eudiplo/sdk-core', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@eudiplo/sdk-core')>()),
+  tenantControllerGetTenant: sdkMocks.getTenant,
+  tenantControllerInitTenant: sdkMocks.initTenant,
+  tenantControllerUpdateTenant: sdkMocks.updateTenant,
+}));
 
 import { TenantCreateComponent } from './tenant-create.component';
 
 describe('TenantCreateComponent', () => {
   let component: TenantCreateComponent;
-  let fixture: ComponentFixture<TenantCreateComponent>;
+  let routeId: string | null;
+  let router: { navigate: ReturnType<typeof vi.fn> };
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [TenantCreateComponent],
-    }).compileComponents();
+  beforeEach(() => {
+    vi.clearAllMocks();
+    routeId = null;
+    router = { navigate: vi.fn().mockResolvedValue(true) };
+    sdkMocks.initTenant.mockResolvedValue({ data: {} });
+    sdkMocks.updateTenant.mockResolvedValue({ data: {} });
 
-    fixture = TestBed.createComponent(TenantCreateComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+    component = new TenantCreateComponent(
+      new FormBuilder(),
+      { open: vi.fn() } as never,
+      router as never,
+      {
+        snapshot: { paramMap: { get: vi.fn(() => routeId) } },
+      } as never,
+      { open: vi.fn(() => ({ afterClosed: () => of(undefined) })) } as never,
+      { getBaseUrl: vi.fn(() => 'http://localhost:3000') } as never
+    );
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  it('omits an empty description from create requests', async () => {
+    component.tenantForm.setValue({
+      id: ' tenant ',
+      name: ' Tenant ',
+      description: '   ',
+      roles: ['clients:manage'],
+    });
+
+    await component.onSubmit();
+
+    expect(sdkMocks.initTenant).toHaveBeenCalledWith({
+      body: {
+        id: 'tenant',
+        name: 'Tenant',
+        roles: ['clients:manage'],
+      },
+    });
+  });
+
+  it('trims a non-empty create description', async () => {
+    component.tenantForm.setValue({
+      id: 'tenant',
+      name: 'Tenant',
+      description: '  Example tenant  ',
+      roles: ['clients:manage'],
+    });
+
+    await component.onSubmit();
+
+    expect(sdkMocks.initTenant).toHaveBeenCalledWith({
+      body: expect.objectContaining({ description: 'Example tenant' }),
+    });
+  });
+
+  it('omits an untouched description and create-only fields from updates', async () => {
+    routeId = 'tenant';
+    component.isEditMode = true;
+    component.tenantForm.patchValue({
+      id: 'tenant',
+      name: ' Renamed ',
+      description: 'Existing description',
+      roles: ['tenants:manage'],
+    });
+    component.tenantForm.markAsPristine();
+
+    await component.onSubmit();
+
+    expect(sdkMocks.updateTenant).toHaveBeenCalledWith({
+      path: { id: 'tenant' },
+      body: { name: 'Renamed' },
+    });
+  });
+
+  it('sends null when an existing description is intentionally cleared', async () => {
+    routeId = 'tenant';
+    component.isEditMode = true;
+    component.tenantForm.patchValue({
+      id: 'tenant',
+      name: 'Tenant',
+      description: 'Existing description',
+    });
+    component.tenantForm.markAsPristine();
+    component.tenantForm.get('description')!.setValue('   ');
+    component.tenantForm.get('description')!.markAsDirty();
+
+    await component.onSubmit();
+
+    expect(sdkMocks.updateTenant).toHaveBeenCalledWith({
+      path: { id: 'tenant' },
+      body: { name: 'Tenant', description: null },
+    });
+  });
+
+  it('trims an edited update description', async () => {
+    routeId = 'tenant';
+    component.isEditMode = true;
+    component.tenantForm.patchValue({
+      id: 'tenant',
+      name: 'Tenant',
+      description: 'Existing description',
+    });
+    component.tenantForm.markAsPristine();
+    component.tenantForm.get('description')!.setValue('  Updated description  ');
+    component.tenantForm.get('description')!.markAsDirty();
+
+    await component.onSubmit();
+
+    expect(sdkMocks.updateTenant).toHaveBeenCalledWith({
+      path: { id: 'tenant' },
+      body: { name: 'Tenant', description: 'Updated description' },
+    });
+  });
+
+  it('leaves the form pristine after loading tenant data', async () => {
+    sdkMocks.getTenant.mockResolvedValue({
+      data: { id: 'tenant', name: 'Tenant', description: null },
+    });
+
+    await (component as unknown as { loadTenant(id: string): Promise<void> }).loadTenant('tenant');
+
+    expect(component.tenantForm.pristine).toBe(true);
+    expect(component.tenantForm.get('description')!.value).toBe('');
   });
 });

--- a/apps/client/src/app/tenants/tenant-create/tenant-create.component.ts
+++ b/apps/client/src/app/tenants/tenant-create/tenant-create.component.ts
@@ -82,10 +82,11 @@ export class TenantCreateComponent implements OnInit {
       this.tenantForm.patchValue({
         id: tenant.data.id,
         name: tenant.data.name,
-        description: tenant.data.description,
+        description: tenant.data.description ?? '',
       });
       // Disable ID field in edit mode
       this.tenantForm.get('id')?.disable();
+      this.tenantForm.markAsPristine();
     } catch {
       this.snackBar.open('Failed to load tenant', 'Close', { duration: 3000 });
       this.router.navigate(['../'], { relativeTo: this.route });
@@ -102,14 +103,31 @@ export class TenantCreateComponent implements OnInit {
     try {
       if (this.isEditMode) {
         const id = this.route.snapshot.paramMap.get('id')!;
+        const descriptionControl = this.tenantForm.get('description')!;
+        const description = descriptionControl.value.trim();
+        const body = {
+          name: this.tenantForm.get('name')!.value.trim(),
+          ...(descriptionControl.dirty
+            ? { description: description === '' ? null : description }
+            : {}),
+        };
+
         await tenantControllerUpdateTenant<true>({
           path: { id },
-          body: this.tenantForm.value,
+          body,
         });
         this.snackBar.open('Tenant updated successfully', 'Close', { duration: 3000 });
         await this.router.navigate(['../'], { relativeTo: this.route });
       } else {
-        const result = await tenantControllerInitTenant<true>({ body: this.tenantForm.value });
+        const value = this.tenantForm.getRawValue();
+        const description = value.description.trim();
+        const body = {
+          id: value.id.trim(),
+          name: value.name.trim(),
+          roles: value.roles,
+          ...(description ? { description } : {}),
+        };
+        const result = await tenantControllerInitTenant<true>({ body });
 
         // Cast to expected type since SDK returns generic response
         // The backend returns { ...tenant, client: { clientId, clientSecret } } on creation
@@ -131,11 +149,11 @@ export class TenantCreateComponent implements OnInit {
 
           // Wait for dialog to close before navigating
           dialogRef.afterClosed().subscribe(() => {
-            this.router.navigate(['../', this.tenantForm.value.id], { relativeTo: this.route });
+            this.router.navigate(['../', body.id], { relativeTo: this.route });
           });
         } else {
           this.snackBar.open('Tenant created successfully', 'Close', { duration: 3000 });
-          await this.router.navigate(['../', this.tenantForm.value.id], { relativeTo: this.route });
+          await this.router.navigate(['../', body.id], { relativeTo: this.route });
         }
       }
     } catch (error) {

--- a/apps/client/src/app/utils/schemas.json
+++ b/apps/client/src/app/utils/schemas.json
@@ -10778,32 +10778,21 @@
       "type": "object",
       "properties": {
         "name": {
-          "default": "EUDIPLO",
           "description": "Display name of the tenant.",
           "type": "string",
           "minLength": 1
         },
         "description": {
-          "description": "Optional tenant description.",
-          "type": "string",
-          "minLength": 1
-        },
-        "roles": {
-          "description": "Optional default role assignments for the tenant.",
-          "type": "array",
-          "items": {
-            "type": "string",
-            "enum": [
-              "tenants:manage",
-              "issuance:offer",
-              "issuance:manage",
-              "presentation:request",
-              "presentation:manage",
-              "clients:manage",
-              "users:manage",
-              "registrar:manage"
-            ]
-          }
+          "description": "Tenant description. Omit to keep the current value or set to null to remove it.",
+          "anyOf": [
+            {
+              "type": "string",
+              "minLength": 1
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "sessionConfig": {
           "description": "Optional tenant-specific session storage configuration.",

--- a/packages/eudiplo-sdk-core/src/api/schemas.gen.ts
+++ b/packages/eudiplo-sdk-core/src/api/schemas.gen.ts
@@ -394,8 +394,16 @@ export const UpdateTenantDtoSchema = {
             description: 'The name of the tenant.'
         },
         description: {
-            type: 'string',
-            description: 'The description of the tenant.'
+            description: 'Tenant description. Omit to keep the current value or set to null to remove it.',
+            anyOf: [
+                {
+                    type: 'string',
+                    minLength: 1
+                },
+                {
+                    type: 'null'
+                }
+            ]
         },
         sessionConfig: {
             description: 'Session storage configuration. Controls TTL and cleanup behavior.',
@@ -404,22 +412,6 @@ export const UpdateTenantDtoSchema = {
                     $ref: '#/components/schemas/SessionStorageConfig'
                 }
             ]
-        },
-        roles: {
-            type: 'array',
-            items: {
-                type: 'string',
-                enum: [
-                    'presentation:manage',
-                    'presentation:request',
-                    'issuance:manage',
-                    'issuance:offer',
-                    'clients:manage',
-                    'users:manage',
-                    'tenants:manage',
-                    'registrar:manage'
-                ]
-            }
         }
     }
 } as const;

--- a/packages/eudiplo-sdk-core/src/api/types.gen.ts
+++ b/packages/eudiplo-sdk-core/src/api/types.gen.ts
@@ -192,14 +192,13 @@ export type UpdateTenantDto = {
      */
     name?: string;
     /**
-     * The description of the tenant.
+     * Tenant description. Omit to keep the current value or set to null to remove it.
      */
-    description?: string;
+    description?: string | null;
     /**
      * Session storage configuration. Controls TTL and cleanup behavior.
      */
     sessionConfig?: SessionStorageConfig;
-    roles?: Array<'presentation:manage' | 'presentation:request' | 'issuance:manage' | 'issuance:offer' | 'clients:manage' | 'users:manage' | 'tenants:manage' | 'registrar:manage'>;
 };
 
 export type AuditLogResponseDto = {

--- a/schemas/UpdateTenantDto.schema.json
+++ b/schemas/UpdateTenantDto.schema.json
@@ -3,32 +3,21 @@
   "type": "object",
   "properties": {
     "name": {
-      "default": "EUDIPLO",
       "description": "Display name of the tenant.",
       "type": "string",
       "minLength": 1
     },
     "description": {
-      "description": "Optional tenant description.",
-      "type": "string",
-      "minLength": 1
-    },
-    "roles": {
-      "description": "Optional default role assignments for the tenant.",
-      "type": "array",
-      "items": {
-        "type": "string",
-        "enum": [
-          "tenants:manage",
-          "issuance:offer",
-          "issuance:manage",
-          "presentation:request",
-          "presentation:manage",
-          "clients:manage",
-          "users:manage",
-          "registrar:manage"
-        ]
-      }
+      "description": "Tenant description. Omit to keep the current value or set to null to remove it.",
+      "anyOf": [
+        {
+          "type": "string",
+          "minLength": 1
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "sessionConfig": {
       "description": "Optional tenant-specific session storage configuration.",


### PR DESCRIPTION
## Summary

- define separate create and update tenant schemas so PATCH requests do not inherit create defaults or accept create-only roles
- support explicit description removal with `description: null` while continuing to reject blank strings
- map Angular create and update forms to omission, clearing, and trimmed-string semantics
- regenerate the tenant JSON Schema and SDK contract artifacts
- add backend schema, persistence, OpenAPI, and client payload tests

## Root cause

After the tenant DTO migration to Zod, optional strings correctly rejected empty values, but Angular text controls submitted unfilled descriptions as `""`. The update schema was also derived from the create schema, which exposed the create-time name default and accepted roles on PATCH requests.

## Impact

Tenants can now be created without a description. Updates preserve untouched descriptions, clear them with `null`, or replace them with a trimmed non-blank value. Update requests no longer contain or accept `id` or `roles`.

## Validation

- backend unit suite: 103 tests passed
- OpenAPI contract tests: 2 tests passed
- focused tenant client tests: 6 tests passed
- backend and SDK builds passed
- client TypeScript compilation passed
- backend/client lint and formatting checks passed
- generated tenant contracts verified for nullable descriptions, omitted roles, and no PATCH name default

Local Angular bundling under Node 26.1.0 aborted with `SIGABRT`; focused client tests and application TypeScript compilation pass.

Closes #918
