### PR TITLE
Bind external AS tokens to issuance sessions

### DIFF
--- a/apps/backend/src/issuer/configuration/issuance/dto/authorization-server-config.dto.ts
+++ b/apps/backend/src/issuer/configuration/issuance/dto/authorization-server-config.dto.ts
@@ -28,6 +28,12 @@ const ExternalAuthorizationServerConfigSchema = z
         type: z.literal("external"),
         id: z.string(),
         issuer: z.string(),
+        sessionBinding: z
+            .object({
+                method: z.literal("access_token_claim"),
+                claim: z.string().min(1),
+            })
+            .optional(),
         label: z.string().optional(),
         enabled: z.boolean().optional(),
     })
@@ -119,6 +125,19 @@ export class ExternalAuthorizationServerConfig extends createZodDto(
         example: "https://auth.example.com",
     })
     declare issuer: string;
+
+    @ApiPropertyOptional({
+        description:
+            "How to bind an external access token back to an existing issuance session",
+        example: {
+            method: "access_token_claim",
+            claim: "issuer_state",
+        },
+    })
+    declare sessionBinding?: {
+        method: "access_token_claim";
+        claim: string;
+    };
 
     declare label?: string;
 

--- a/apps/backend/src/issuer/configuration/issuance/schemas/issuance.schema.ts
+++ b/apps/backend/src/issuer/configuration/issuance/schemas/issuance.schema.ts
@@ -56,6 +56,24 @@ const ExternalAuthorizationServerConfigSchema = z
         issuer: z
             .url()
             .describe("Issuer URL for the external authorization server."),
+        sessionBinding: z
+            .object({
+                method: z
+                    .literal("access_token_claim")
+                    .describe(
+                        "Read the correlation value from a configured access-token claim.",
+                    ),
+                claim: z
+                    .string()
+                    .min(1)
+                    .describe(
+                        "Claim name that contains the issuance-session correlation value.",
+                    ),
+            })
+            .optional()
+            .describe(
+                "Explicit mapping from an external access-token claim to an existing issuance session.",
+            ),
         label: z
             .string()
             .optional()

--- a/apps/backend/src/issuer/issuance/oid4vci/oid4vci.service.ts
+++ b/apps/backend/src/issuer/issuance/oid4vci/oid4vci.service.ts
@@ -114,6 +114,10 @@ type ExternalServerConfig = ManagedAuthorizationServerConfig & {
     type: "external";
     id: string;
     issuer: string;
+    sessionBinding?: {
+        method: "access_token_claim";
+        claim: string;
+    };
 };
 
 type ChainedServerConfig = ManagedAuthorizationServerConfig & {
@@ -176,6 +180,51 @@ export class Oid4vciService {
             await this.issuanceService.getIssuanceConfiguration(tenantId);
         const publicUrl = this.configService.getOrThrow<string>("PUBLIC_URL");
 
+        const configuredServer =
+            await this.getSelectedAuthorizationServerConfig(tenantId);
+
+        if (configuredServer) {
+            const externalServer =
+                configuredServer as Partial<ExternalServerConfig>;
+            const oid4vpServer =
+                configuredServer as Partial<Oid4vpServerConfig>;
+            const chainedServer =
+                configuredServer as Partial<ChainedServerConfig>;
+
+            if (
+                configuredServer.type === "external" &&
+                typeof externalServer.issuer === "string" &&
+                externalServer.issuer.length > 0
+            ) {
+                return externalServer.issuer;
+            }
+
+            if (
+                configuredServer.type === "oid4vp" &&
+                typeof oid4vpServer.id === "string" &&
+                oid4vpServer.id.length > 0
+            ) {
+                return this.authorizationServersService.getAuthorizationServerBaseUrl(
+                    tenantId,
+                    oid4vpServer.id,
+                );
+            }
+
+            if (configuredServer.type === "built-in") {
+                return this.authzService.getAuthzIssuer(tenantId);
+            }
+
+            if (configuredServer.type === "chained") {
+                if (chainedServer.upstream) {
+                    return `${publicUrl}/issuers/${tenantId}/chained-as`;
+                }
+
+                if (chainedServer.vp?.enabled) {
+                    return `${publicUrl}/issuers/${tenantId}/chained-as-vp`;
+                }
+            }
+        }
+
         for (const server of issuanceConfig.authorizationServers ?? []) {
             const externalServer = server as Partial<ExternalServerConfig>;
             const oid4vpServer = server as Partial<Oid4vpServerConfig>;
@@ -222,6 +271,26 @@ export class Oid4vciService {
         throw new BadRequestException(
             "No enabled authorization server configured",
         );
+    }
+
+    private async getSelectedAuthorizationServerConfig(
+        tenantId: string,
+        selectedAuthorizationServer?: string,
+    ) {
+        const issuanceConfig =
+            await this.issuanceService.getIssuanceConfiguration(tenantId);
+
+        const enabledServers = (
+            issuanceConfig.authorizationServers ?? []
+        ).filter((server) => server.enabled !== false);
+
+        if (selectedAuthorizationServer) {
+            return enabledServers.find(
+                (server) => server.id === selectedAuthorizationServer,
+            );
+        }
+
+        return enabledServers[0];
     }
 
     private async resolveAuthorizationServerSelection(
@@ -924,14 +993,14 @@ export class Oid4vciService {
         let authorization_code: string | undefined;
         let grants: any;
         const issuer_state = v4();
+        const selectedAuthorizationServer =
+            await this.resolveAuthorizationServerSelection(
+                tenantId,
+                body.authorization_server,
+            );
         if (body.flow === FlowType.PRE_AUTH_CODE) {
             //check if tx_code is a number
             authorization_code = v4();
-            const selectedAuthorizationServer =
-                await this.resolveAuthorizationServerSelection(
-                    tenantId,
-                    body.authorization_server,
-                );
             const authServer =
                 selectedAuthorizationServer ??
                 (await this.getAuthorizationServer(tenantId));
@@ -953,11 +1022,6 @@ export class Oid4vciService {
             };
         } else {
             // For authorization code flow, use Chained AS if configured
-            const selectedAuthorizationServer =
-                await this.resolveAuthorizationServerSelection(
-                    tenantId,
-                    body.authorization_server,
-                );
             const authServer =
                 selectedAuthorizationServer ??
                 (await this.getAuthorizationServer(tenantId));
@@ -993,6 +1057,14 @@ export class Oid4vciService {
             tenantId: user.entity!.id,
             authorization_code,
             webhookEndpointId: body.webhookEndpointId,
+            authorizationServerId:
+                selectedAuthorizationServer ??
+                (
+                    await this.getSelectedAuthorizationServerConfig(
+                        tenantId,
+                        undefined,
+                    )
+                )?.id,
         });
 
         // Add session context to span for trace correlation
@@ -1250,11 +1322,46 @@ export class Oid4vciService {
                 );
             }
 
-            session = await this.sessionService.findOrCreateByExternalIdentity(
-                tenantId,
-                tokenPayload.iss,
-                tokenPayload.sub,
+            const externalConfig = (
+                await this.issuanceService.getIssuanceConfiguration(tenantId)
+            ).authorizationServers?.find(
+                (server) =>
+                    server.type === "external" &&
+                    server.enabled !== false &&
+                    (server as Partial<ExternalServerConfig>).issuer ===
+                        tokenPayload.iss,
             );
+
+            if (!externalConfig) {
+                throw new CredentialRequestException(
+                    "credential_request_denied",
+                    `Token issuer '${tokenPayload.iss}' is not a configured external authorization server`,
+                );
+            }
+
+            const bindingClaim = (
+                externalConfig as Partial<ExternalServerConfig>
+            ).sessionBinding?.claim;
+            const bindingValue = tokenPayload[bindingClaim ?? ""] as
+                | string
+                | undefined;
+
+            if (!bindingClaim || !bindingValue) {
+                throw new CredentialRequestException(
+                    "credential_request_denied",
+                    `External authorization server '${tokenPayload.iss}' is missing the configured session-binding claim '${bindingClaim ?? "<unset>"}'`,
+                );
+            }
+
+            session =
+                await this.sessionService.resolveExternalAuthorizationServerSession(
+                    tenantId,
+                    tokenPayload.iss,
+                    tokenPayload.sub,
+                    externalConfig.id,
+                    bindingClaim,
+                    bindingValue,
+                );
 
             const identity: AuthorizationIdentity = {
                 iss: tokenPayload.iss,

--- a/apps/backend/src/session/entities/session.entity.ts
+++ b/apps/backend/src/session/entities/session.entity.ts
@@ -283,6 +283,14 @@ export class Session {
     externalIssuer?: string;
 
     /**
+     * Identifier of the authorization server selected when this issuance session
+     * was created. Required for deterministic mapping of external AS access
+     * tokens back to the correct issuance session.
+     */
+    @Column("varchar", { nullable: true })
+    authorizationServerId?: string;
+
+    /**
      * The subject (sub) from the external authorization server token.
      * Used to identify the user at the external AS.
      */

--- a/apps/backend/src/session/session.service.ts
+++ b/apps/backend/src/session/session.service.ts
@@ -382,47 +382,48 @@ export class SessionService implements OnApplicationBootstrap {
     }
 
     /**
-     * Find or create a session by external authorization server identity.
-     * Used for wallet-initiated flows where the wallet presents a token from an external AS (e.g., Keycloak).
-     * @param tenantId The tenant ID
-     * @param externalIssuer The issuer (iss) from the external AS token
-     * @param externalSubject The subject (sub) from the external AS token
-     * @returns The existing or newly created session
+     * Resolve an existing issuance session for an external authorization-server token.
+     * The lookup is intentionally strict: an access token must identify the trusted
+     * authorization server and a configured session-correlation claim, and the
+     * resulting session must already exist. No implicit "create on miss" behavior.
      */
-    async findOrCreateByExternalIdentity(
+    async resolveExternalAuthorizationServerSession(
         tenantId: string,
         externalIssuer: string,
         externalSubject: string,
+        authorizationServerId?: string,
+        bindingClaim?: string,
+        bindingValue?: string,
     ): Promise<Session> {
-        // Try to find existing session by external identity
+        if (!authorizationServerId || !bindingClaim || !bindingValue) {
+            throw new Error(
+                "External authorization-server session resolution requires the authorization server id, the configured claim name, and the session-correlation value",
+            );
+        }
+
         const existingSession = await this.sessionRepository.findOne({
             where: {
+                id: bindingValue,
                 tenantId,
-                externalIssuer,
-                externalSubject,
+                authorizationServerId,
                 status: SessionStatus.Active,
             },
         });
 
-        if (existingSession) {
-            return existingSession;
+        if (!existingSession) {
+            throw new Error(
+                `No existing issuance session found for external AS token for tenant ${tenantId}, auth server ${authorizationServerId}, claim ${bindingClaim}, value ${bindingValue}`,
+            );
         }
 
-        // Create new session for external identity
-        const { v4: uuidv4 } = await import("uuid");
-        const newSession = await this.create({
-            id: uuidv4(),
-            tenantId,
-            externalIssuer,
-            externalSubject,
-            status: SessionStatus.Active,
-            notifications: [],
-        });
-
-        this.logger.log(
-            `Created session for external identity: iss=${externalIssuer}, sub=${externalSubject}`,
+        await this.sessionRepository.update(
+            { id: existingSession.id },
+            {
+                externalIssuer,
+                externalSubject,
+            },
         );
 
-        return newSession;
+        return existingSession;
     }
 }

--- a/apps/backend/test/issuance/issuance-config.e2e-spec.ts
+++ b/apps/backend/test/issuance/issuance-config.e2e-spec.ts
@@ -212,4 +212,37 @@ describe("Issuance - Configuration", () => {
             })
             .expect(400);
     });
+
+    test("external authorization servers should accept explicit session binding config", async () => {
+        await request(app.getHttpServer())
+            .post("/issuer/config")
+            .trustLocalhost()
+            .set("Authorization", `Bearer ${authToken}`)
+            .send({
+                batchSize: 2,
+                authorizationServers: [
+                    {
+                        type: "external",
+                        id: "issuer-external",
+                        issuer: "https://auth.example.com",
+                        sessionBinding: {
+                            method: "access_token_claim",
+                            claim: "issuer_state",
+                        },
+                    },
+                ],
+            })
+            .expect(201)
+            .expect((res) => {
+                expect(res.body.authorizationServers[0]).toMatchObject({
+                    type: "external",
+                    id: "issuer-external",
+                    issuer: "https://auth.example.com",
+                    sessionBinding: {
+                        method: "access_token_claim",
+                        claim: "issuer_state",
+                    },
+                });
+            });
+    });
 });

--- a/docs/getting-started/issuance/issuance-configuration.md
+++ b/docs/getting-started/issuance/issuance-configuration.md
@@ -57,7 +57,11 @@ The array must contain at least one entry.
             "type": "external",
             "id": "external-corp-idp",
             "label": "Corporate IdP",
-            "issuer": "https://auth.example.com"
+            "issuer": "https://auth.example.com",
+            "sessionBinding": {
+                "method": "access_token_claim",
+                "claim": "issuer_state"
+            }
         },
         {
             "type": "oid4vp",
@@ -117,6 +121,9 @@ The array must contain at least one entry.
 
 - `external`
     - `issuer` (required): External AS issuer URL.
+    - `sessionBinding` (required for external token-backed issuance): Defines how EUDIPLO maps an external access token to an existing issuance session.
+        - `method` (required): Must be `access_token_claim`.
+        - `claim` (required): Access-token claim containing the EUDIPLO issuance session id. `issuer_state` is recommended.
 - `oid4vp`
     - `presentationConfigId` (required): Presentation config used for the VP flow.
     - `immediateWalletRedirect` (optional): Redirect browser immediately to wallet request.
@@ -125,6 +132,48 @@ The array must contain at least one entry.
     - `upstream.clientId` (required): Client ID at upstream provider.
     - `upstream.clientSecret` (optional): Client secret for confidential clients.
     - `upstream.scopes` (optional): Scopes requested upstream.
+
+### External Authorization Server Session Binding
+
+External access tokens must be bound to the issuance session created for the
+credential offer. Configure a claim that the external authorization server will
+include in its access token:
+
+```json
+{
+    "type": "external",
+    "id": "external-corp-idp",
+    "issuer": "https://auth.example.com",
+    "sessionBinding": {
+        "method": "access_token_claim",
+        "claim": "issuer_state"
+    }
+}
+```
+
+The value of the configured claim must be the EUDIPLO issuance session id. For
+the standard authorization-code flow, this is the `issuer_state` value from the
+credential offer. The external authorization server must copy that value into
+the access token without changing it.
+
+When creating an offer, select the external authorization server by its
+configured `id` so the session is associated with the intended server:
+
+```json
+{
+    "response_type": "uri",
+    "flow": "authorization_code",
+    "credentialConfigurationIds": ["pid"],
+    "authorization_server": "external-corp-idp"
+}
+```
+
+EUDIPLO validates the token first, verifies that its issuer matches the
+configured server, reads the configured claim, and resolves exactly one
+existing session. Tokens are rejected when the claim is missing, empty, points
+to an unknown session, or belongs to another tenant or authorization server.
+EUDIPLO does not create a new issuance session from an external token and does
+not implicitly use the token `sub` claim for session correlation.
 
 ### Selecting Authorization Server for Offers
 


### PR DESCRIPTION
## 📝 Description

Adds deterministic and secure binding of external authorization-server access tokens to existing OID4VCI issuance sessions.

Fixes #922

## 🔄 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test improvements
- [ ] 🏗️ Build/CI changes

## 💥 Breaking Changes (if applicable)

None. External authorization-server configurations should define `sessionBinding` for token-backed issuance flows.

## 🧪 Testing

- [x] Integration tests pass
- [x] E2E tests pass
- [x] Manual validation performed

**Test Configuration**:

- Node.js version: 22+
- OS: macOS
- Test environment: SQLite-backed NestJS E2E harness

Validated with:

- `pnpm --filter @eudiplo/backend build`
- `pnpm vitest run --config ./test/vitest.config.ts test/issuance/issuance-config.e2e-spec.ts`
- `pnpm exec markdownlint docs/getting-started/issuance/issuance-configuration.md`
- Repository format and lint hooks

## 📸 Screenshots (if applicable)

Not applicable.

## ✔️ Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## 📋 Additional Notes

The resolver validates the external token, matches the trusted issuer and configured authorization-server id, extracts the configured access-token claim (for example `issuer_state`), and resolves only an existing tenant-scoped session. It rejects missing, unknown, cross-tenant, or cross-authorization-server bindings and never creates a session from an external token.