### PR TITLE
Configure issuance notification endpoint

### DIFF
--- a/apps/backend/src/database/migrations/1775000000000-AddNotificationEndpointEnabledToIssuanceConfig.ts
+++ b/apps/backend/src/database/migrations/1775000000000-AddNotificationEndpointEnabledToIssuanceConfig.ts
@@ -1,0 +1,65 @@
+import { MigrationInterface, QueryRunner, TableColumn } from "typeorm";
+
+/**
+ * Add notificationEndpointEnabled column to issuance_config table.
+ *
+ * This defaults to true so existing issuance configurations continue to expose
+ * the notification endpoint unless explicitly disabled on a per-config basis.
+ */
+export class AddNotificationEndpointEnabledToIssuanceConfig1775000000000
+    implements MigrationInterface
+{
+    name = "AddNotificationEndpointEnabledToIssuanceConfig1775000000000";
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const table = await queryRunner.getTable("issuance_config");
+        if (!table) {
+            console.log(
+                "[Migration] issuance_config table not found — skipping (schema may not exist yet).",
+            );
+            return;
+        }
+
+        const hasColumn = table.columns.some(
+            (col) => col.name === "notificationEndpointEnabled",
+        );
+        if (hasColumn) {
+            console.log(
+                "[Migration] notificationEndpointEnabled column already exists — skipping.",
+            );
+            return;
+        }
+
+        await queryRunner.addColumn(
+            "issuance_config",
+            new TableColumn({
+                name: "notificationEndpointEnabled",
+                type: "boolean",
+                isNullable: false,
+                default: true,
+            }),
+        );
+
+        console.log(
+            "[Migration] Added notificationEndpointEnabled column to issuance_config.",
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const table = await queryRunner.getTable("issuance_config");
+        if (table) {
+            const hasColumn = table.columns.some(
+                (col) => col.name === "notificationEndpointEnabled",
+            );
+            if (hasColumn) {
+                await queryRunner.dropColumn(
+                    "issuance_config",
+                    "notificationEndpointEnabled",
+                );
+                console.log(
+                    "[Migration] Removed notificationEndpointEnabled column from issuance_config.",
+                );
+            }
+        }
+    }
+}

--- a/apps/backend/src/database/migrations/index.ts
+++ b/apps/backend/src/database/migrations/index.ts
@@ -40,3 +40,4 @@ export { AddVerifierSkewSeconds1772000000000 } from "./1772000000000-AddVerifier
 export { AddPresentationStatusCheckMode1773000000000 } from "./1773000000000-AddPresentationStatusCheckMode";
 export { AddReaderAuthToPresentationConfig1774000000000 } from "./1774000000000-AddReaderAuthToPresentationConfig";
 export { AddRootExternalKeyIdToKeyChain1774000000000 } from "./1774000000000-AddRootExternalKeyIdToKeyChain";
+export { AddNotificationEndpointEnabledToIssuanceConfig1775000000000 } from "./1775000000000-AddNotificationEndpointEnabledToIssuanceConfig";

--- a/apps/backend/src/issuer/configuration/issuance/entities/issuance-config.entity.ts
+++ b/apps/backend/src/issuer/configuration/issuance/entities/issuance-config.entity.ts
@@ -183,6 +183,19 @@ export class IssuanceConfig {
     display!: DisplayInfo[];
 
     /**
+     * Whether the OID4VCI notification endpoint is advertised and accepts
+     * requests for this issuance configuration.
+     * Default: true
+     */
+    @ApiPropertyOptional({
+        description:
+            "Whether the OID4VCI notification endpoint is exposed for this issuance configuration.",
+        default: true,
+    })
+    @Column("boolean", { default: true })
+    notificationEndpointEnabled?: boolean;
+
+    /**
      * Whether to advertise support for credential response encryption in the
      * credential issuer metadata (`credential_response_encryption`). When
      * enabled, wallets MAY request encrypted credential responses. Some

--- a/apps/backend/src/issuer/configuration/issuance/issuance.service.ts
+++ b/apps/backend/src/issuer/configuration/issuance/issuance.service.ts
@@ -428,6 +428,7 @@ export class IssuanceService {
             federation: config.federation,
             registrationCertificate,
             registrationCertificateCache,
+            notificationEndpointEnabled: config.notificationEndpointEnabled,
             credentialResponseEncryption: config.credentialResponseEncryption,
             credentialRequestEncryption: config.credentialRequestEncryption,
             txCodeMaxAttempts: config.txCodeMaxAttempts,

--- a/apps/backend/src/issuer/configuration/issuance/schemas/issuance.schema.ts
+++ b/apps/backend/src/issuer/configuration/issuance/schemas/issuance.schema.ts
@@ -336,6 +336,12 @@ export const IssuanceConfigSchema = z
             .array(DisplayInfoSchema)
             .optional()
             .describe("Localized issuer metadata shown to wallets."),
+        notificationEndpointEnabled: z
+            .boolean()
+            .optional()
+            .describe(
+                "Whether the OID4VCI notification endpoint is exposed for this issuance configuration.",
+            ),
         credentialResponseEncryption: z
             .boolean()
             .optional()

--- a/apps/backend/src/issuer/issuance/oid4vci/oid4vci.service.ts
+++ b/apps/backend/src/issuer/issuance/oid4vci/oid4vci.service.ts
@@ -934,6 +934,11 @@ export class Oid4vciService {
             issuer_info,
         );
 
+        const notificationEndpoint =
+            issuanceConfig.notificationEndpointEnabled !== false
+                ? `${credential_issuer}/vci/notification`
+                : undefined;
+
         const credentialIssuer = issuer.createCredentialIssuerMetadata({
             credential_issuer,
             credential_configurations_supported:
@@ -943,7 +948,7 @@ export class Oid4vciService {
             credential_endpoint: `${credential_issuer}/vci/credential`,
             deferred_credential_endpoint: `${credential_issuer}/vci/deferred_credential`,
             authorization_servers: authServers,
-            notification_endpoint: `${credential_issuer}/vci/notification`,
+            notification_endpoint: notificationEndpoint,
             nonce_endpoint: `${credential_issuer}/vci/nonce`,
             display:
                 issuanceConfig.display !== null
@@ -1956,11 +1961,17 @@ export class Oid4vciService {
         body: NotificationRequestDto,
         tenantId: string,
     ) {
+        const issuanceConfig =
+            await this.issuanceService.getIssuanceConfiguration(tenantId);
+        if (issuanceConfig.notificationEndpointEnabled === false) {
+            throw new NotFoundException(
+                "Notification endpoint is disabled for this issuance config",
+            );
+        }
+
         const issuer = this.getIssuer(tenantId);
         const resourceServer = this.getResourceServer(tenantId);
         const issuerMetadata = await this.issuerMetadata(tenantId, issuer);
-        const issuanceConfig =
-            await this.issuanceService.getIssuanceConfiguration(tenantId);
         const headers = getHeadersFromRequest(req);
 
         const allowedAuthenticationSchemes: SupportedAuthenticationScheme[] = [

--- a/apps/backend/test/issuance/issuance-metadata.e2e-spec.ts
+++ b/apps/backend/test/issuance/issuance-metadata.e2e-spec.ts
@@ -74,6 +74,59 @@ describe("Issuance - Metadata", () => {
         expect(payload.iss).toBeDefined();
     });
 
+    test("metadata omits notification endpoint when disabled", async () => {
+        await request(app.getHttpServer())
+            .post("/issuer/config")
+            .trustLocalhost()
+            .set("Authorization", `Bearer ${authToken}`)
+            .send({
+                notificationEndpointEnabled: false,
+                authorizationServers: [
+                    {
+                        id: "issuer-built-in",
+                        type: "built-in",
+                        enabled: true,
+                    },
+                ],
+            })
+            .expect(201);
+
+        const res = await request(app.getHttpServer())
+            .get("/.well-known/openid-credential-issuer/issuers/root")
+            .trustLocalhost()
+            .set("Accept", "application/json")
+            .expect(200);
+
+        expect(res.body.notification_endpoint).toBeUndefined();
+    });
+
+    test("disabled notification endpoint is rejected", async () => {
+        await request(app.getHttpServer())
+            .post("/issuer/config")
+            .trustLocalhost()
+            .set("Authorization", `Bearer ${authToken}`)
+            .send({
+                notificationEndpointEnabled: false,
+                authorizationServers: [
+                    {
+                        id: "issuer-built-in",
+                        type: "built-in",
+                        enabled: true,
+                    },
+                ],
+            })
+            .expect(201);
+
+        await request(app.getHttpServer())
+            .post("/issuers/root/vci/notification")
+            .trustLocalhost()
+            .send({
+                notification_id: "does-not-matter",
+                event: "credential_accepted",
+            })
+            .expect(404);
+    });
+
     test("create oid4vci offer", async () => {
         const res = await request(app.getHttpServer())
             .post("/issuer/offer")

--- a/apps/client/src/app/issuance/issuance-config/issuance-config-create/issuance-config-create.component.html
+++ b/apps/client/src/app/issuance/issuance-config/issuance-config-create/issuance-config-create.component.html
@@ -75,6 +75,17 @@
                   >
                 </div>
               </mat-slide-toggle>
+
+              <mat-slide-toggle formControlName="notificationEndpointEnabled">
+                <div fxLayout="column">
+                  <span><strong>Enable Notification Endpoint</strong></span>
+                  <span class="toggle-description"
+                    >Advertise the issuer notification endpoint in metadata and accept notification
+                    callbacks. Disable this when the issuer does not support push-style credential
+                    status notifications.</span
+                  >
+                </div>
+              </mat-slide-toggle>
             </mat-card-content>
           </mat-card>
 

--- a/apps/client/src/app/issuance/issuance-config/issuance-config-create/issuance-config-create.component.ts
+++ b/apps/client/src/app/issuance/issuance-config/issuance-config-create/issuance-config-create.component.ts
@@ -142,6 +142,7 @@ export class IssuanceConfigCreateComponent implements OnInit {
       txCodeMaxAttempts: new FormControl<number | null>(null, [Validators.min(1)]),
       credentialResponseEncryption: new FormControl(false),
       credentialRequestEncryption: new FormControl(false),
+      notificationEndpointEnabled: new FormControl(true),
       walletAttestationRequired: new FormControl(false),
       walletProviderTrustLists: this.fb.array([]),
       federation: this.fb.group({
@@ -160,7 +161,7 @@ export class IssuanceConfigCreateComponent implements OnInit {
         privacyPolicy: [''],
         supportUri: [''],
       }),
-    } as { [k in keyof IssuanceConfig]: any });
+    } as any);
   }
 
   ngOnInit(): void {
@@ -400,6 +401,9 @@ export class IssuanceConfigCreateComponent implements OnInit {
         credentialRequestEncryption:
           (config as { credentialRequestEncryption?: boolean }).credentialRequestEncryption ??
           false,
+        notificationEndpointEnabled:
+          (config as { notificationEndpointEnabled?: boolean }).notificationEndpointEnabled ??
+          true,
         walletAttestationRequired: config.walletAttestationRequired ?? false,
         txCodeMaxAttempts: config.txCodeMaxAttempts ?? null,
         registrationCertificate: {
@@ -592,6 +596,7 @@ export class IssuanceConfigCreateComponent implements OnInit {
       dPopRequired: formValue.dPopRequired,
       credentialResponseEncryption: formValue.credentialResponseEncryption ?? false,
       credentialRequestEncryption: formValue.credentialRequestEncryption ?? false,
+      notificationEndpointEnabled: formValue.notificationEndpointEnabled ?? true,
       txCodeMaxAttempts: formValue.txCodeMaxAttempts ?? undefined,
       authorizationServers:
         unifiedAuthorizationServers.length > 0 ? unifiedAuthorizationServers : [],

--- a/apps/client/src/app/issuance/issuance-config/issuance-config-create/issuance-config-create.component.ts
+++ b/apps/client/src/app/issuance/issuance-config/issuance-config-create/issuance-config-create.component.ts
@@ -402,8 +402,7 @@ export class IssuanceConfigCreateComponent implements OnInit {
           (config as { credentialRequestEncryption?: boolean }).credentialRequestEncryption ??
           false,
         notificationEndpointEnabled:
-          (config as { notificationEndpointEnabled?: boolean }).notificationEndpointEnabled ??
-          true,
+          (config as { notificationEndpointEnabled?: boolean }).notificationEndpointEnabled ?? true,
         walletAttestationRequired: config.walletAttestationRequired ?? false,
         txCodeMaxAttempts: config.txCodeMaxAttempts ?? null,
         registrationCertificate: {

--- a/apps/client/src/app/issuance/issuance-config/issuance-config-show/issuance-config-show.component.html
+++ b/apps/client/src/app/issuance/issuance-config/issuance-config-show/issuance-config-show.component.html
@@ -43,6 +43,22 @@
                   <span matListItemTitle>Batch Size</span>
                   <span matListItemLine>{{ config.batchSize || 1 }} credential(s) per request</span>
                 </mat-list-item>
+                <mat-list-item>
+                  <mat-icon
+                    matListItemIcon
+                    [class]="config.notificationEndpointEnabled === false ? 'icon-disabled' : ''"
+                  >
+                    {{
+                      config.notificationEndpointEnabled === false
+                        ? 'notifications_off'
+                        : 'notifications'
+                    }}
+                  </mat-icon>
+                  <span matListItemTitle>Notification Endpoint</span>
+                  <span matListItemLine>
+                    {{ config.notificationEndpointEnabled === false ? 'Disabled' : 'Enabled' }}
+                  </span>
+                </mat-list-item>
               </mat-list>
             </mat-card-content>
           </mat-card>

--- a/apps/client/src/app/utils/schemas.json
+++ b/apps/client/src/app/utils/schemas.json
@@ -1,9 +1,7 @@
 [
   {
     "uri": "./GrafanaConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/GrafanaConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/GrafanaConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./GrafanaConfigDto.schema.json",
@@ -26,18 +24,13 @@
           "example": "loki"
         }
       },
-      "required": [
-        "tempoUid",
-        "lokiUid"
-      ],
+      "required": ["tempoUid", "lokiUid"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./FrontendConfigResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/FrontendConfigResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/FrontendConfigResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./FrontendConfigResponseDto.schema.json",
@@ -53,17 +46,13 @@
           ]
         }
       },
-      "required": [
-        "grafana"
-      ],
+      "required": ["grafana"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./RoleDto.schema.json",
-    "fileMatch": [
-      "a://b/RoleDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/RoleDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./RoleDto.schema.json",
@@ -86,17 +75,13 @@
           "example": "issuance:manage"
         }
       },
-      "required": [
-        "role"
-      ],
+      "required": ["role"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./ClientCredentialsDto.schema.json",
-    "fileMatch": [
-      "a://b/ClientCredentialsDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ClientCredentialsDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./ClientCredentialsDto.schema.json",
@@ -116,18 +101,13 @@
           "minLength": 1
         }
       },
-      "required": [
-        "client_id",
-        "client_secret"
-      ],
+      "required": ["client_id", "client_secret"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./TokenResponse.schema.json",
-    "fileMatch": [
-      "a://b/TokenResponse*.schema.json"
-    ],
+    "fileMatch": ["a://b/TokenResponse*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./TokenResponse.schema.json",
@@ -150,20 +130,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "access_token",
-        "token_type",
-        "expires_in",
-        "state"
-      ],
+      "required": ["access_token", "token_type", "expires_in", "state"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./TenantEntity.schema.json",
-    "fileMatch": [
-      "a://b/TenantEntity*.schema.json"
-    ],
+    "fileMatch": ["a://b/TenantEntity*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./TenantEntity.schema.json",
@@ -214,20 +187,13 @@
           }
         }
       },
-      "required": [
-        "id",
-        "name",
-        "status",
-        "clients"
-      ],
+      "required": ["id", "name", "status", "clients"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./ClientEntity.schema.json",
-    "fileMatch": [
-      "a://b/ClientEntity*.schema.json"
-    ],
+    "fileMatch": ["a://b/ClientEntity*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./ClientEntity.schema.json",
@@ -237,10 +203,7 @@
         "allowedPresentationConfigs": {
           "nullable": true,
           "description": "List of presentation config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": [
-            "age-verification",
-            "kyc-basic"
-          ],
+          "example": ["age-verification", "kyc-basic"],
           "type": "array",
           "items": {
             "type": "string"
@@ -249,10 +212,7 @@
         "allowedIssuanceConfigs": {
           "nullable": true,
           "description": "List of issuance config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": [
-            "pid",
-            "mdl"
-          ],
+          "example": ["pid", "mdl"],
           "type": "array",
           "items": {
             "type": "string"
@@ -300,18 +260,13 @@
           ]
         }
       },
-      "required": [
-        "clientId",
-        "roles"
-      ],
+      "required": ["clientId", "roles"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./AuditLogResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/AuditLogResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/AuditLogResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./AuditLogResponseDto.schema.json",
@@ -348,11 +303,7 @@
           "type": "string"
         },
         "actorType": {
-          "enum": [
-            "user",
-            "client",
-            "system"
-          ],
+          "enum": ["user", "client", "system"],
           "type": "string"
         },
         "actorId": {
@@ -383,21 +334,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "id",
-        "tenantId",
-        "actionType",
-        "actorType",
-        "timestamp"
-      ],
+      "required": ["id", "tenantId", "actionType", "actorType", "timestamp"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./ClientSecretResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/ClientSecretResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ClientSecretResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./ClientSecretResponseDto.schema.json",
@@ -408,17 +351,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "secret"
-      ],
+      "required": ["secret"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./StatusListAggregationDto.schema.json",
-    "fileMatch": [
-      "a://b/StatusListAggregationDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/StatusListAggregationDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./StatusListAggregationDto.schema.json",
@@ -437,17 +376,13 @@
           }
         }
       },
-      "required": [
-        "status_lists"
-      ],
+      "required": ["status_lists"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./StatusListResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/StatusListResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/StatusListResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./StatusListResponseDto.schema.json",
@@ -478,12 +413,7 @@
         },
         "bits": {
           "description": "Bits per status value",
-          "enum": [
-            1,
-            2,
-            4,
-            8
-          ],
+          "enum": [1, 2, 4, 8],
           "type": "number",
           "example": 1
         },
@@ -536,9 +466,7 @@
   },
   {
     "uri": "./AuthorizeQueries.schema.json",
-    "fileMatch": [
-      "a://b/AuthorizeQueries*.schema.json"
-    ],
+    "fileMatch": ["a://b/AuthorizeQueries*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./AuthorizeQueries.schema.json",
@@ -599,9 +527,7 @@
   },
   {
     "uri": "./OfferRequestDto.schema.json",
-    "fileMatch": [
-      "a://b/OfferRequestDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/OfferRequestDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./OfferRequestDto.schema.json",
@@ -623,11 +549,7 @@
               "const": "iso-18013-7"
             }
           ],
-          "enum": [
-            "uri",
-            "dc-api",
-            "iso-18013-7"
-          ],
+          "enum": ["uri", "dc-api", "iso-18013-7"],
           "examples": [
             {
               "value": "qrcode"
@@ -652,19 +574,14 @@
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "inline"
-                    ]
+                    "enum": ["inline"]
                   },
                   "claims": {
                     "type": "object",
                     "additionalProperties": true
                   }
                 },
-                "required": [
-                  "type",
-                  "claims"
-                ],
+                "required": ["type", "claims"],
                 "additionalProperties": false
               },
               {
@@ -672,18 +589,13 @@
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "attributeProvider"
-                    ]
+                    "enum": ["attributeProvider"]
                   },
                   "attributeProviderId": {
                     "type": "string"
                   }
                 },
-                "required": [
-                  "type",
-                  "attributeProviderId"
-                ],
+                "required": ["type", "attributeProviderId"],
                 "additionalProperties": false
               },
               {
@@ -691,9 +603,7 @@
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "webhook"
-                    ]
+                    "enum": ["webhook"]
                   },
                   "webhook": {
                     "type": "object",
@@ -705,16 +615,11 @@
                         "type": "object"
                       }
                     },
-                    "required": [
-                      "url"
-                    ],
+                    "required": ["url"],
                     "additionalProperties": false
                   }
                 },
-                "required": [
-                  "type",
-                  "webhook"
-                ],
+                "required": ["type", "webhook"],
                 "additionalProperties": false
               }
             ]
@@ -742,10 +647,7 @@
             }
           ],
           "description": "The flow type for the offer request.",
-          "enum": [
-            "authorization_code",
-            "pre_authorized_code"
-          ]
+          "enum": ["authorization_code", "pre_authorized_code"]
         },
         "tx_code": {
           "type": "string",
@@ -767,19 +669,13 @@
           "description": "ID of the webhook endpoint to notify about the status of the issuance process."
         }
       },
-      "required": [
-        "response_type",
-        "flow",
-        "credentialConfigurationIds"
-      ],
+      "required": ["response_type", "flow", "credentialConfigurationIds"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./WebHookAuthConfigNone.schema.json",
-    "fileMatch": [
-      "a://b/WebHookAuthConfigNone*.schema.json"
-    ],
+    "fileMatch": ["a://b/WebHookAuthConfigNone*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./WebHookAuthConfigNone.schema.json",
@@ -793,17 +689,13 @@
           "enum": []
         }
       },
-      "required": [
-        "type"
-      ],
+      "required": ["type"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./ApiKeyConfig.schema.json",
-    "fileMatch": [
-      "a://b/ApiKeyConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/ApiKeyConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./ApiKeyConfig.schema.json",
@@ -819,18 +711,13 @@
           "description": "The value of the API key to be sent in the header."
         }
       },
-      "required": [
-        "headerName",
-        "value"
-      ],
+      "required": ["headerName", "value"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./WebHookAuthConfigHeader.schema.json",
-    "fileMatch": [
-      "a://b/WebHookAuthConfigHeader*.schema.json"
-    ],
+    "fileMatch": ["a://b/WebHookAuthConfigHeader*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./WebHookAuthConfigHeader.schema.json",
@@ -861,18 +748,13 @@
           ]
         }
       },
-      "required": [
-        "type",
-        "config"
-      ],
+      "required": ["type", "config"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./Session.schema.json",
-    "fileMatch": [
-      "a://b/Session*.schema.json"
-    ],
+    "fileMatch": ["a://b/Session*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./Session.schema.json",
@@ -881,13 +763,7 @@
       "properties": {
         "status": {
           "description": "Status of the session.",
-          "enum": [
-            "active",
-            "fetched",
-            "completed",
-            "expired",
-            "failed"
-          ],
+          "enum": ["active", "fetched", "completed", "expired", "failed"],
           "type": "string"
         },
         "id": {
@@ -1093,9 +969,7 @@
   },
   {
     "uri": "./PaginatedSessionResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/PaginatedSessionResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/PaginatedSessionResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./PaginatedSessionResponseDto.schema.json",
@@ -1126,21 +1000,13 @@
           "description": "Total number of pages"
         }
       },
-      "required": [
-        "items",
-        "total",
-        "page",
-        "pageSize",
-        "totalPages"
-      ],
+      "required": ["items", "total", "page", "pageSize", "totalPages"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./SessionLogEntryResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/SessionLogEntryResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/SessionLogEntryResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./SessionLogEntryResponseDto.schema.json",
@@ -1163,11 +1029,7 @@
         "level": {
           "type": "string",
           "description": "Log level",
-          "enum": [
-            "info",
-            "warn",
-            "error"
-          ]
+          "enum": ["info", "warn", "error"]
         },
         "stage": {
           "type": "string",
@@ -1183,21 +1045,13 @@
           "description": "Additional structured detail"
         }
       },
-      "required": [
-        "id",
-        "sessionId",
-        "timestamp",
-        "level",
-        "message"
-      ],
+      "required": ["id", "sessionId", "timestamp", "level", "message"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./StatusUpdateDto.schema.json",
-    "fileMatch": [
-      "a://b/StatusUpdateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/StatusUpdateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./StatusUpdateDto.schema.json",
@@ -1221,18 +1075,13 @@
           "description": "New credential status: 0 = valid, 1 = revoked, 2 = suspended."
         }
       },
-      "required": [
-        "sessionId",
-        "status"
-      ],
+      "required": ["sessionId", "status"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./UpdateSessionConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateSessionConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateSessionConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./UpdateSessionConfigDto.schema.json",
@@ -1257,10 +1106,7 @@
         },
         "cleanupMode": {
           "type": "string",
-          "enum": [
-            "full",
-            "anonymize"
-          ],
+          "enum": ["full", "anonymize"],
           "description": "Cleanup mode: 'full' deletes everything, 'anonymize' keeps metadata but removes PII.",
           "default": "full"
         }
@@ -1270,9 +1116,7 @@
   },
   {
     "uri": "./ManagedUserDto.schema.json",
-    "fileMatch": [
-      "a://b/ManagedUserDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ManagedUserDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./ManagedUserDto.schema.json",
@@ -1321,20 +1165,13 @@
           "description": "One-time temporary password returned only on user creation."
         }
       },
-      "required": [
-        "id",
-        "username",
-        "enabled",
-        "roles"
-      ],
+      "required": ["id", "username", "enabled", "roles"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./CreateUserDto.schema.json",
-    "fileMatch": [
-      "a://b/CreateUserDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CreateUserDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./CreateUserDto.schema.json",
@@ -1370,18 +1207,13 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "username",
-        "roles"
-      ],
+      "required": ["username", "roles"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./UpdateUserDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateUserDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateUserDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./UpdateUserDto.schema.json",
@@ -1426,9 +1258,7 @@
   },
   {
     "uri": "./AuthenticationMethodNone.schema.json",
-    "fileMatch": [
-      "a://b/AuthenticationMethodNone*.schema.json"
-    ],
+    "fileMatch": ["a://b/AuthenticationMethodNone*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./AuthenticationMethodNone.schema.json",
@@ -1440,17 +1270,13 @@
           "const": "none"
         }
       },
-      "required": [
-        "method"
-      ],
+      "required": ["method"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./AuthenticationUrlConfig.schema.json",
-    "fileMatch": [
-      "a://b/AuthenticationUrlConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/AuthenticationUrlConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./AuthenticationUrlConfig.schema.json",
@@ -1476,9 +1302,7 @@
                       "const": "none"
                     }
                   },
-                  "required": [
-                    "type"
-                  ],
+                  "required": ["type"],
                   "additionalProperties": false
                 },
                 {
@@ -1498,17 +1322,11 @@
                           "type": "string"
                         }
                       },
-                      "required": [
-                        "headerName",
-                        "value"
-                      ],
+                      "required": ["headerName", "value"],
                       "additionalProperties": false
                     }
                   },
-                  "required": [
-                    "type",
-                    "config"
-                  ],
+                  "required": ["type", "config"],
                   "additionalProperties": false
                 }
               ]
@@ -1529,17 +1347,13 @@
           ]
         }
       },
-      "required": [
-        "url"
-      ],
+      "required": ["url"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./AuthenticationMethodAuth.schema.json",
-    "fileMatch": [
-      "a://b/AuthenticationMethodAuth*.schema.json"
-    ],
+    "fileMatch": ["a://b/AuthenticationMethodAuth*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./AuthenticationMethodAuth.schema.json",
@@ -1571,9 +1385,7 @@
                           "const": "none"
                         }
                       },
-                      "required": [
-                        "type"
-                      ],
+                      "required": ["type"],
                       "additionalProperties": false
                     },
                     {
@@ -1593,17 +1405,11 @@
                               "type": "string"
                             }
                           },
-                          "required": [
-                            "headerName",
-                            "value"
-                          ],
+                          "required": ["headerName", "value"],
                           "additionalProperties": false
                         }
                       },
-                      "required": [
-                        "type",
-                        "config"
-                      ],
+                      "required": ["type", "config"],
                       "additionalProperties": false
                     }
                   ]
@@ -1615,10 +1421,7 @@
                   }
                 }
               },
-              "required": [
-                "url",
-                "auth"
-              ],
+              "required": ["url", "auth"],
               "additionalProperties": false
             }
           },
@@ -1630,18 +1433,13 @@
           ]
         }
       },
-      "required": [
-        "method",
-        "config"
-      ],
+      "required": ["method", "config"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./PresentationDuringIssuanceConfig.schema.json",
-    "fileMatch": [
-      "a://b/PresentationDuringIssuanceConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/PresentationDuringIssuanceConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./PresentationDuringIssuanceConfig.schema.json",
@@ -1653,17 +1451,13 @@
           "description": "Link to the presentation configuration that is relevant for the issuance process"
         }
       },
-      "required": [
-        "type"
-      ],
+      "required": ["type"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./AuthenticationMethodPresentation.schema.json",
-    "fileMatch": [
-      "a://b/AuthenticationMethodPresentation*.schema.json"
-    ],
+    "fileMatch": ["a://b/AuthenticationMethodPresentation*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./AuthenticationMethodPresentation.schema.json",
@@ -1688,18 +1482,13 @@
           ]
         }
       },
-      "required": [
-        "method",
-        "config"
-      ],
+      "required": ["method", "config"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./ManagedAuthorizationServerConfig.schema.json",
-    "fileMatch": [
-      "a://b/ManagedAuthorizationServerConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/ManagedAuthorizationServerConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./ManagedAuthorizationServerConfig.schema.json",
@@ -1708,12 +1497,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": [
-            "external",
-            "oid4vp",
-            "chained",
-            "built-in"
-          ],
+          "enum": ["external", "oid4vp", "chained", "built-in"],
           "description": "Authorization server implementation type",
           "example": "external"
         },
@@ -1733,18 +1517,13 @@
           "default": true
         }
       },
-      "required": [
-        "type",
-        "id"
-      ],
+      "required": ["type", "id"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./ExternalAuthorizationServerConfig.schema.json",
-    "fileMatch": [
-      "a://b/ExternalAuthorizationServerConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/ExternalAuthorizationServerConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./ExternalAuthorizationServerConfig.schema.json",
@@ -1755,9 +1534,7 @@
           "type": "string",
           "const": "external",
           "description": "Authorization server implementation type",
-          "enum": [
-            "external"
-          ],
+          "enum": ["external"],
           "example": "external"
         },
         "id": {
@@ -1777,19 +1554,13 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "type",
-        "id",
-        "issuer"
-      ],
+      "required": ["type", "id", "issuer"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./ChainedAsTokenConfig.schema.json",
-    "fileMatch": [
-      "a://b/ChainedAsTokenConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/ChainedAsTokenConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./ChainedAsTokenConfig.schema.json",
@@ -1823,9 +1594,7 @@
   },
   {
     "uri": "./Oid4VpAuthorizationServerConfig.schema.json",
-    "fileMatch": [
-      "a://b/Oid4VpAuthorizationServerConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/Oid4VpAuthorizationServerConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./Oid4VpAuthorizationServerConfig.schema.json",
@@ -1836,9 +1605,7 @@
           "type": "string",
           "const": "oid4vp",
           "description": "Authorization server implementation type",
-          "enum": [
-            "oid4vp"
-          ],
+          "enum": ["oid4vp"],
           "example": "oid4vp"
         },
         "id": {
@@ -1893,19 +1660,13 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "type",
-        "id",
-        "presentationConfigId"
-      ],
+      "required": ["type", "id", "presentationConfigId"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./UpstreamOidcConfig.schema.json",
-    "fileMatch": [
-      "a://b/UpstreamOidcConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpstreamOidcConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./UpstreamOidcConfig.schema.json",
@@ -1931,25 +1692,17 @@
             "type": "string"
           },
           "description": "Scopes to request from the upstream provider",
-          "default": [
-            "openid",
-            "profile"
-          ],
+          "default": ["openid", "profile"],
           "type": "array"
         }
       },
-      "required": [
-        "issuer",
-        "clientId"
-      ],
+      "required": ["issuer", "clientId"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./ChainedAuthorizationServerConfig.schema.json",
-    "fileMatch": [
-      "a://b/ChainedAuthorizationServerConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/ChainedAuthorizationServerConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./ChainedAuthorizationServerConfig.schema.json",
@@ -1960,9 +1713,7 @@
           "type": "string",
           "const": "chained",
           "description": "Authorization server implementation type",
-          "enum": [
-            "chained"
-          ],
+          "enum": ["chained"],
           "example": "chained"
         },
         "id": {
@@ -2033,19 +1784,13 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "type",
-        "id",
-        "upstream"
-      ],
+      "required": ["type", "id", "upstream"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./BuiltInAuthorizationServerConfig.schema.json",
-    "fileMatch": [
-      "a://b/BuiltInAuthorizationServerConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/BuiltInAuthorizationServerConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./BuiltInAuthorizationServerConfig.schema.json",
@@ -2056,9 +1801,7 @@
           "type": "string",
           "const": "built-in",
           "description": "Authorization server implementation type",
-          "enum": [
-            "built-in"
-          ],
+          "enum": ["built-in"],
           "example": "built-in"
         },
         "id": {
@@ -2103,18 +1846,13 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "type",
-        "id"
-      ],
+      "required": ["type", "id"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./WalletProviderTrustListRefDto.schema.json",
-    "fileMatch": [
-      "a://b/WalletProviderTrustListRefDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/WalletProviderTrustListRefDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./WalletProviderTrustListRefDto.schema.json",
@@ -2135,17 +1873,13 @@
           "description": "Base64 DER-encoded X.509 certificate used to verify the trust-list JWT signature."
         }
       },
-      "required": [
-        "url"
-      ],
+      "required": ["url"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./FederationTrustAnchorConfig.schema.json",
-    "fileMatch": [
-      "a://b/FederationTrustAnchorConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/FederationTrustAnchorConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./FederationTrustAnchorConfig.schema.json",
@@ -2163,18 +1897,13 @@
           "example": "https://ta.example.org/.well-known/openid-federation"
         }
       },
-      "required": [
-        "entityId",
-        "entityConfigurationUri"
-      ],
+      "required": ["entityId", "entityConfigurationUri"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./FederationConfig.schema.json",
-    "fileMatch": [
-      "a://b/FederationConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/FederationConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./FederationConfig.schema.json",
@@ -2183,20 +1912,13 @@
       "properties": {
         "role": {
           "type": "string",
-          "enum": [
-            "trust_anchor",
-            "intermediate",
-            "leaf"
-          ],
+          "enum": ["trust_anchor", "intermediate", "leaf"],
           "description": "Role this tenant plays in the OpenID Federation topology.",
           "default": "leaf"
         },
         "mode": {
           "type": "string",
-          "enum": [
-            "federation-only",
-            "hybrid"
-          ],
+          "enum": ["federation-only", "hybrid"],
           "description": "Trust decision strategy when both LoTE trust lists and OpenID Federation are configured.",
           "default": "hybrid"
         },
@@ -2226,27 +1948,20 @@
                 "type": "string"
               }
             },
-            "required": [
-              "entityId",
-              "entityConfigurationUri"
-            ],
+            "required": ["entityId", "entityConfigurationUri"],
             "additionalProperties": false
           },
           "description": "Configured federation trust anchors.",
           "type": "array"
         }
       },
-      "required": [
-        "trustAnchors"
-      ],
+      "required": ["trustAnchors"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./IssuerRegistrationCertificateConfig.schema.json",
-    "fileMatch": [
-      "a://b/IssuerRegistrationCertificateConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/IssuerRegistrationCertificateConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./IssuerRegistrationCertificateConfig.schema.json",
@@ -2260,10 +1975,7 @@
         },
         "mode": {
           "type": "string",
-          "enum": [
-            "import",
-            "generate"
-          ],
+          "enum": ["import", "generate"],
           "description": "import: use an existing JWT, generate: create via registrar using attestation data derived from configured credential configurations.",
           "default": "generate"
         },
@@ -2287,9 +1999,7 @@
   },
   {
     "uri": "./IssuerRegistrationCertificateCache.schema.json",
-    "fileMatch": [
-      "a://b/IssuerRegistrationCertificateCache*.schema.json"
-    ],
+    "fileMatch": ["a://b/IssuerRegistrationCertificateCache*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./IssuerRegistrationCertificateCache.schema.json",
@@ -2322,9 +2032,7 @@
   },
   {
     "uri": "./DisplayLogo.schema.json",
-    "fileMatch": [
-      "a://b/DisplayLogo*.schema.json"
-    ],
+    "fileMatch": ["a://b/DisplayLogo*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./DisplayLogo.schema.json",
@@ -2338,17 +2046,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "uri"
-      ],
+      "required": ["uri"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./DisplayInfo.schema.json",
-    "fileMatch": [
-      "a://b/DisplayInfo*.schema.json"
-    ],
+    "fileMatch": ["a://b/DisplayInfo*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./DisplayInfo.schema.json",
@@ -2383,9 +2087,7 @@
   },
   {
     "uri": "./UpdateIssuanceDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateIssuanceDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateIssuanceDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./UpdateIssuanceDto.schema.json",
@@ -2434,12 +2136,7 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "external",
-                  "oid4vp",
-                  "chained",
-                  "built-in"
-                ]
+                "enum": ["external", "oid4vp", "chained", "built-in"]
               }
             }
           }
@@ -2520,9 +2217,7 @@
   },
   {
     "uri": "./ClaimsQuery.schema.json",
-    "fileMatch": [
-      "a://b/ClaimsQuery*.schema.json"
-    ],
+    "fileMatch": ["a://b/ClaimsQuery*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./ClaimsQuery.schema.json",
@@ -2545,17 +2240,13 @@
           }
         }
       },
-      "required": [
-        "path"
-      ],
+      "required": ["path"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./CredentialSetQuery.schema.json",
-    "fileMatch": [
-      "a://b/CredentialSetQuery*.schema.json"
-    ],
+    "fileMatch": ["a://b/CredentialSetQuery*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./CredentialSetQuery.schema.json",
@@ -2575,17 +2266,13 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "options"
-      ],
+      "required": ["options"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./PolicyCredential.schema.json",
-    "fileMatch": [
-      "a://b/PolicyCredential*.schema.json"
-    ],
+    "fileMatch": ["a://b/PolicyCredential*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./PolicyCredential.schema.json",
@@ -2605,17 +2292,13 @@
           "type": "array"
         }
       },
-      "required": [
-        "credentials"
-      ],
+      "required": ["credentials"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./AttestationBasedPolicy.schema.json",
-    "fileMatch": [
-      "a://b/AttestationBasedPolicy*.schema.json"
-    ],
+    "fileMatch": ["a://b/AttestationBasedPolicy*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./AttestationBasedPolicy.schema.json",
@@ -2643,26 +2326,19 @@
                 "items": {}
               }
             },
-            "required": [
-              "credentials"
-            ],
+            "required": ["credentials"],
             "additionalProperties": false
           },
           "type": "array"
         }
       },
-      "required": [
-        "policy",
-        "values"
-      ],
+      "required": ["policy", "values"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./NoneTrustPolicy.schema.json",
-    "fileMatch": [
-      "a://b/NoneTrustPolicy*.schema.json"
-    ],
+    "fileMatch": ["a://b/NoneTrustPolicy*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./NoneTrustPolicy.schema.json",
@@ -2673,17 +2349,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "policy"
-      ],
+      "required": ["policy"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./AllowListPolicy.schema.json",
-    "fileMatch": [
-      "a://b/AllowListPolicy*.schema.json"
-    ],
+    "fileMatch": ["a://b/AllowListPolicy*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./AllowListPolicy.schema.json",
@@ -2700,18 +2372,13 @@
           }
         }
       },
-      "required": [
-        "policy",
-        "values"
-      ],
+      "required": ["policy", "values"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./RootOfTrustPolicy.schema.json",
-    "fileMatch": [
-      "a://b/RootOfTrustPolicy*.schema.json"
-    ],
+    "fileMatch": ["a://b/RootOfTrustPolicy*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./RootOfTrustPolicy.schema.json",
@@ -2725,18 +2392,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "policy",
-        "values"
-      ],
+      "required": ["policy", "values"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./IaeActionOpenid4vpPresentation.schema.json",
-    "fileMatch": [
-      "a://b/IaeActionOpenid4vpPresentation*.schema.json"
-    ],
+    "fileMatch": ["a://b/IaeActionOpenid4vpPresentation*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./IaeActionOpenid4vpPresentation.schema.json",
@@ -2746,9 +2408,7 @@
         "type": {
           "type": "string",
           "const": "openid4vp_presentation",
-          "enum": [
-            "openid4vp_presentation"
-          ],
+          "enum": ["openid4vp_presentation"],
           "description": "Action type discriminator",
           "example": "openid4vp_presentation"
         },
@@ -2761,18 +2421,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "type",
-        "presentationConfigId"
-      ],
+      "required": ["type", "presentationConfigId"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./IaeActionRedirectToWeb.schema.json",
-    "fileMatch": [
-      "a://b/IaeActionRedirectToWeb*.schema.json"
-    ],
+    "fileMatch": ["a://b/IaeActionRedirectToWeb*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./IaeActionRedirectToWeb.schema.json",
@@ -2782,9 +2437,7 @@
         "type": {
           "type": "string",
           "const": "redirect_to_web",
-          "enum": [
-            "redirect_to_web"
-          ],
+          "enum": ["redirect_to_web"],
           "description": "Action type discriminator",
           "example": "redirect_to_web"
         },
@@ -2809,18 +2462,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "type",
-        "url"
-      ],
+      "required": ["type", "url"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./WebhookEndpointEntity.schema.json",
-    "fileMatch": [
-      "a://b/WebhookEndpointEntity*.schema.json"
-    ],
+    "fileMatch": ["a://b/WebhookEndpointEntity*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./WebhookEndpointEntity.schema.json",
@@ -2858,22 +2506,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "id",
-        "auth",
-        "tenantId",
-        "tenant",
-        "name",
-        "url"
-      ],
+      "required": ["id", "auth", "tenantId", "tenant", "name", "url"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./SchemaUriEntry.schema.json",
-    "fileMatch": [
-      "a://b/SchemaUriEntry*.schema.json"
-    ],
+    "fileMatch": ["a://b/SchemaUriEntry*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./SchemaUriEntry.schema.json",
@@ -2908,9 +2547,7 @@
   },
   {
     "uri": "./TrustAuthorityEntry.schema.json",
-    "fileMatch": [
-      "a://b/TrustAuthorityEntry*.schema.json"
-    ],
+    "fileMatch": ["a://b/TrustAuthorityEntry*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./TrustAuthorityEntry.schema.json",
@@ -2923,11 +2560,7 @@
         },
         "frameworkType": {
           "type": "string",
-          "enum": [
-            "aki",
-            "etsi_tl",
-            "openid_federation"
-          ],
+          "enum": ["aki", "etsi_tl", "openid_federation"],
           "description": "Trust framework type (ignored when trustListId is set)"
         },
         "value": {
@@ -2965,9 +2598,7 @@
   },
   {
     "uri": "./SchemaMetaConfig.schema.json",
-    "fileMatch": [
-      "a://b/SchemaMetaConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/SchemaMetaConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./SchemaMetaConfig.schema.json",
@@ -3006,12 +2637,7 @@
         },
         "bindingType": {
           "type": "string",
-          "enum": [
-            "claim",
-            "key",
-            "biometric",
-            "none"
-          ],
+          "enum": ["claim", "key", "biometric", "none"],
           "description": "Cryptographic binding type"
         },
         "schemaURIs": {
@@ -3049,11 +2675,7 @@
               },
               "frameworkType": {
                 "type": "string",
-                "enum": [
-                  "aki",
-                  "etsi_tl",
-                  "openid_federation"
-                ]
+                "enum": ["aki", "etsi_tl", "openid_federation"]
               },
               "value": {
                 "type": "string"
@@ -3084,9 +2706,7 @@
   },
   {
     "uri": "./KeyAttestationsRequired.schema.json",
-    "fileMatch": [
-      "a://b/KeyAttestationsRequired*.schema.json"
-    ],
+    "fileMatch": ["a://b/KeyAttestationsRequired*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./KeyAttestationsRequired.schema.json",
@@ -3098,10 +2718,7 @@
             "type": "string"
           },
           "description": "List of required key storage types (e.g., iso_18045_high, iso_18045_moderate)",
-          "example": [
-            "iso_18045_high",
-            "iso_18045_moderate"
-          ],
+          "example": ["iso_18045_high", "iso_18045_moderate"],
           "type": "array"
         },
         "user_authentication": {
@@ -3109,10 +2726,7 @@
             "type": "string"
           },
           "description": "List of required user authentication types (e.g., iso_18045_high, iso_18045_moderate)",
-          "example": [
-            "iso_18045_high",
-            "iso_18045_moderate"
-          ],
+          "example": ["iso_18045_high", "iso_18045_moderate"],
           "type": "array"
         }
       },
@@ -3121,9 +2735,7 @@
   },
   {
     "uri": "./DisplayImage.schema.json",
-    "fileMatch": [
-      "a://b/DisplayImage*.schema.json"
-    ],
+    "fileMatch": ["a://b/DisplayImage*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./DisplayImage.schema.json",
@@ -3134,17 +2746,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "uri"
-      ],
+      "required": ["uri"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./Display.schema.json",
-    "fileMatch": [
-      "a://b/Display*.schema.json"
-    ],
+    "fileMatch": ["a://b/Display*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./Display.schema.json",
@@ -3173,19 +2781,13 @@
           "$ref": "./DisplayImage.schema.json"
         }
       },
-      "required": [
-        "name",
-        "description",
-        "locale"
-      ],
+      "required": ["name", "description", "locale"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./IssuerMetadataCredentialConfig.schema.json",
-    "fileMatch": [
-      "a://b/IssuerMetadataCredentialConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/IssuerMetadataCredentialConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./IssuerMetadataCredentialConfig.schema.json",
@@ -3205,22 +2807,13 @@
           "type": "array",
           "items": {
             "type": "string",
-            "enum": [
-              "jwt",
-              "attestation"
-            ]
+            "enum": ["jwt", "attestation"]
           },
-          "example": [
-            "attestation",
-            "jwt"
-          ]
+          "example": ["attestation", "jwt"]
         },
         "format": {
           "type": "string",
-          "enum": [
-            "mso_mdoc",
-            "dc+sd-jwt"
-          ]
+          "enum": ["mso_mdoc", "dc+sd-jwt"]
         },
         "display": {
           "type": "array",
@@ -3236,18 +2829,13 @@
           "description": "Document type for mDOC credentials (e.g., \"org.iso.18013.5.1.mDL\").\nOnly applicable when format is \"mso_mdoc\"."
         }
       },
-      "required": [
-        "format",
-        "display"
-      ],
+      "required": ["format", "display"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./FieldDisplayDto.schema.json",
-    "fileMatch": [
-      "a://b/FieldDisplayDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/FieldDisplayDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./FieldDisplayDto.schema.json",
@@ -3268,18 +2856,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "name",
-        "locale"
-      ],
+      "required": ["name", "locale"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./ClaimFieldDefinitionDto.schema.json",
-    "fileMatch": [
-      "a://b/ClaimFieldDefinitionDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ClaimFieldDefinitionDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./ClaimFieldDefinitionDto.schema.json",
@@ -3302,21 +2885,11 @@
             ]
           },
           "description": "Path to claim value. For nested child fields this can be relative to the parent path.",
-          "example": [
-            "address",
-            "locality"
-          ]
+          "example": ["address", "locality"]
         },
         "type": {
           "type": "string",
-          "enum": [
-            "string",
-            "number",
-            "integer",
-            "boolean",
-            "object",
-            "array"
-          ],
+          "enum": ["string", "number", "integer", "boolean", "object", "array"],
           "description": "Claim value type"
         },
         "defaultValue": {
@@ -3371,10 +2944,7 @@
                 "type": "string"
               }
             },
-            "required": [
-              "locale",
-              "name"
-            ],
+            "required": ["locale", "name"],
             "additionalProperties": false
           },
           "type": "array"
@@ -3395,18 +2965,13 @@
           "type": "array"
         }
       },
-      "required": [
-        "path",
-        "type"
-      ],
+      "required": ["path", "type"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./AttributeProviderEntity.schema.json",
-    "fileMatch": [
-      "a://b/AttributeProviderEntity*.schema.json"
-    ],
+    "fileMatch": ["a://b/AttributeProviderEntity*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./AttributeProviderEntity.schema.json",
@@ -3443,22 +3008,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "auth",
-        "id",
-        "tenantId",
-        "tenant",
-        "name",
-        "url"
-      ],
+      "required": ["auth", "id", "tenantId", "tenant", "name", "url"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./KeyChainEntity.schema.json",
-    "fileMatch": [
-      "a://b/KeyChainEntity*.schema.json"
-    ],
+    "fileMatch": ["a://b/KeyChainEntity*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./KeyChainEntity.schema.json",
@@ -3488,21 +3044,12 @@
         "usageType": {
           "type": "string",
           "description": "The purpose/role of this key chain in the system.",
-          "enum": [
-            "access",
-            "attestation",
-            "trustList",
-            "statusList",
-            "encrypt"
-          ]
+          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"]
         },
         "usage": {
           "type": "string",
           "description": "The usage type of the keys (sign or encrypt).",
-          "enum": [
-            "sign",
-            "encrypt"
-          ]
+          "enum": ["sign", "encrypt"]
         },
         "kmsProvider": {
           "type": "string",
@@ -3586,9 +3133,7 @@
   },
   {
     "uri": "./CredentialConfig.schema.json",
-    "fileMatch": [
-      "a://b/CredentialConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/CredentialConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./CredentialConfig.schema.json",
@@ -3715,30 +3260,20 @@
         "sdJwtTrustFormat": {
           "nullable": true,
           "description": "For SD-JWT credentials: determines whether to include certificate chain (x5c)\nor use federation-based trust (iss claim).\nDefault: \"x5c\" (federation must be explicitly selected)",
-          "enum": [
-            "x5c",
-            "federation"
-          ],
+          "enum": ["x5c", "federation"],
           "type": "string"
         },
         "lifeTime": {
           "type": "number"
         }
       },
-      "required": [
-        "id",
-        "tenant",
-        "config",
-        "fields"
-      ],
+      "required": ["id", "tenant", "config", "fields"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./CredentialConfigUpdate.schema.json",
-    "fileMatch": [
-      "a://b/CredentialConfigUpdate*.schema.json"
-    ],
+    "fileMatch": ["a://b/CredentialConfigUpdate*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./CredentialConfigUpdate.schema.json",
@@ -3848,10 +3383,7 @@
         "sdJwtTrustFormat": {
           "nullable": true,
           "description": "For SD-JWT credentials: determines whether to include certificate chain (x5c)\nor use federation-based trust (iss claim).\nDefault: \"x5c\" (federation must be explicitly selected)",
-          "enum": [
-            "x5c",
-            "federation"
-          ],
+          "enum": ["x5c", "federation"],
           "type": "string"
         },
         "lifeTime": {
@@ -3863,9 +3395,7 @@
   },
   {
     "uri": "./SignSchemaMetaConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/SignSchemaMetaConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/SignSchemaMetaConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./SignSchemaMetaConfigDto.schema.json",
@@ -3897,12 +3427,7 @@
             },
             "bindingType": {
               "type": "string",
-              "enum": [
-                "claim",
-                "key",
-                "biometric",
-                "none"
-              ]
+              "enum": ["claim", "key", "biometric", "none"]
             },
             "schemaURIs": {
               "type": "array",
@@ -3939,11 +3464,7 @@
                   },
                   "frameworkType": {
                     "type": "string",
-                    "enum": [
-                      "aki",
-                      "etsi_tl",
-                      "openid_federation"
-                    ]
+                    "enum": ["aki", "etsi_tl", "openid_federation"]
                   },
                   "value": {
                     "type": "string"
@@ -3981,26 +3502,18 @@
         },
         "pinMode": {
           "type": "string",
-          "enum": [
-            "keep_current",
-            "update_to_new_version",
-            "replace_id"
-          ],
+          "enum": ["keep_current", "update_to_new_version", "replace_id"],
           "description": "How to update credential config pinning after publish. keep_current: do not change existing pin (unless empty). update_to_new_version: update pinned version under current id. replace_id: repoint pin to a different schema id.",
           "default": "keep_current"
         }
       },
-      "required": [
-        "config"
-      ],
+      "required": ["config"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./SignVersionSchemaMetaConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/SignVersionSchemaMetaConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/SignVersionSchemaMetaConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./SignVersionSchemaMetaConfigDto.schema.json",
@@ -4032,12 +3545,7 @@
             },
             "bindingType": {
               "type": "string",
-              "enum": [
-                "claim",
-                "key",
-                "biometric",
-                "none"
-              ]
+              "enum": ["claim", "key", "biometric", "none"]
             },
             "schemaURIs": {
               "type": "array",
@@ -4074,11 +3582,7 @@
                   },
                   "frameworkType": {
                     "type": "string",
-                    "enum": [
-                      "aki",
-                      "etsi_tl",
-                      "openid_federation"
-                    ]
+                    "enum": ["aki", "etsi_tl", "openid_federation"]
                   },
                   "value": {
                     "type": "string"
@@ -4116,26 +3620,18 @@
         },
         "pinMode": {
           "type": "string",
-          "enum": [
-            "keep_current",
-            "update_to_new_version",
-            "replace_id"
-          ],
+          "enum": ["keep_current", "update_to_new_version", "replace_id"],
           "description": "How to update credential config pinning after version publish. keep_current: do not change existing pin (unless empty). update_to_new_version: update pinned version under current id. replace_id: repoint pin to config.id.",
           "default": "keep_current"
         }
       },
-      "required": [
-        "config"
-      ],
+      "required": ["config"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./VocabularyEntryDto.schema.json",
-    "fileMatch": [
-      "a://b/VocabularyEntryDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/VocabularyEntryDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./VocabularyEntryDto.schema.json",
@@ -4151,10 +3647,7 @@
           "description": "Display label for UI rendering."
         },
         "status": {
-          "enum": [
-            "active",
-            "deprecated"
-          ],
+          "enum": ["active", "deprecated"],
           "type": "string",
           "description": "Vocabulary lifecycle status."
         },
@@ -4163,19 +3656,13 @@
           "description": "Replacement code when status is deprecated."
         }
       },
-      "required": [
-        "code",
-        "label",
-        "status"
-      ],
+      "required": ["code", "label", "status"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./SchemaMetadataVocabulariesDto.schema.json",
-    "fileMatch": [
-      "a://b/SchemaMetadataVocabulariesDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/SchemaMetadataVocabulariesDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./SchemaMetadataVocabulariesDto.schema.json",
@@ -4201,19 +3688,13 @@
           }
         }
       },
-      "required": [
-        "version",
-        "categories",
-        "tags"
-      ],
+      "required": ["version", "categories", "tags"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./MetadataSchemaDto.schema.json",
-    "fileMatch": [
-      "a://b/MetadataSchemaDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/MetadataSchemaDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./MetadataSchemaDto.schema.json",
@@ -4225,10 +3706,7 @@
           "description": "Unique identifier for this schema entry"
         },
         "formatIdentifier": {
-          "enum": [
-            "dc+sd-jwt",
-            "mso_mdoc"
-          ],
+          "enum": ["dc+sd-jwt", "mso_mdoc"],
           "type": "string",
           "description": "The credential format identifier"
         },
@@ -4246,18 +3724,13 @@
           "description": "Subresource Integrity hash for the schema"
         }
       },
-      "required": [
-        "id",
-        "formatIdentifier"
-      ],
+      "required": ["id", "formatIdentifier"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./TrustAuthorityDto.schema.json",
-    "fileMatch": [
-      "a://b/TrustAuthorityDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/TrustAuthorityDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./TrustAuthorityDto.schema.json",
@@ -4271,9 +3744,7 @@
         "frameworkType": {
           "type": "string",
           "description": "Type of trust framework",
-          "enum": [
-            "etsi_tl"
-          ]
+          "enum": ["etsi_tl"]
         },
         "value": {
           "type": "string",
@@ -4285,19 +3756,13 @@
           "description": "Verification method for the trust list signature (e.g., JWK)"
         }
       },
-      "required": [
-        "id",
-        "frameworkType",
-        "value"
-      ],
+      "required": ["id", "frameworkType", "value"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./IssuerOfferEntryDto.schema.json",
-    "fileMatch": [
-      "a://b/IssuerOfferEntryDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/IssuerOfferEntryDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./IssuerOfferEntryDto.schema.json",
@@ -4313,18 +3778,13 @@
           "description": "Human-readable description explaining when this issuer offer is relevant for the user."
         }
       },
-      "required": [
-        "credentialOfferUrl",
-        "description"
-      ],
+      "required": ["credentialOfferUrl", "description"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./AccessCertificateRefDto.schema.json",
-    "fileMatch": [
-      "a://b/AccessCertificateRefDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/AccessCertificateRefDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./AccessCertificateRefDto.schema.json",
@@ -4347,21 +3807,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "id",
-        "relyingPartyId",
-        "certificate",
-        "revoked",
-        "createdAt"
-      ],
+      "required": ["id", "relyingPartyId", "certificate", "revoked", "createdAt"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./SchemaMetadataResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/SchemaMetadataResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/SchemaMetadataResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./SchemaMetadataResponseDto.schema.json",
@@ -4395,12 +3847,7 @@
           "description": "Level of security (LoS) of this attestation"
         },
         "bindingType": {
-          "enum": [
-            "claim",
-            "key",
-            "biometric",
-            "none"
-          ],
+          "enum": ["claim", "key", "biometric", "none"],
           "type": "string",
           "description": "Required binding type between attestation and holder"
         },
@@ -4408,10 +3855,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "enum": [
-              "dc+sd-jwt",
-              "mso_mdoc"
-            ]
+            "enum": ["dc+sd-jwt", "mso_mdoc"]
           },
           "description": "Credential formats in which this attestation is available"
         },
@@ -4430,15 +3874,7 @@
           }
         },
         "category": {
-          "enum": [
-            "identity",
-            "health",
-            "finance",
-            "education",
-            "mobility",
-            "employment",
-            "other"
-          ],
+          "enum": ["identity", "health", "finance", "education", "mobility", "employment", "other"],
           "type": "string",
           "description": "Domain category for filtering"
         },
@@ -4526,9 +3962,7 @@
   },
   {
     "uri": "./UpdateIssuerOfferDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateIssuerOfferDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateIssuerOfferDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./UpdateIssuerOfferDto.schema.json",
@@ -4549,9 +3983,7 @@
   },
   {
     "uri": "./UpdateSchemaMetadataDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateSchemaMetadataDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateSchemaMetadataDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./UpdateSchemaMetadataDto.schema.json",
@@ -4560,15 +3992,7 @@
       "properties": {
         "category": {
           "type": "string",
-          "enum": [
-            "identity",
-            "health",
-            "finance",
-            "education",
-            "mobility",
-            "employment",
-            "other"
-          ],
+          "enum": ["identity", "health", "finance", "education", "mobility", "employment", "other"],
           "description": "Domain category for filtering"
         },
         "tags": {
@@ -4616,9 +4040,7 @@
   },
   {
     "uri": "./DeprecateSchemaMetadataDto.schema.json",
-    "fileMatch": [
-      "a://b/DeprecateSchemaMetadataDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/DeprecateSchemaMetadataDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./DeprecateSchemaMetadataDto.schema.json",
@@ -4638,17 +4060,13 @@
           "description": "The version that supersedes this one"
         }
       },
-      "required": [
-        "deprecated"
-      ],
+      "required": ["deprecated"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./TrustListEntityInfo.schema.json",
-    "fileMatch": [
-      "a://b/TrustListEntityInfo*.schema.json"
-    ],
+    "fileMatch": ["a://b/TrustListEntityInfo*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./TrustListEntityInfo.schema.json",
@@ -4680,17 +4098,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "name"
-      ],
+      "required": ["name"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./InternalTrustListEntity.schema.json",
-    "fileMatch": [
-      "a://b/InternalTrustListEntity*.schema.json"
-    ],
+    "fileMatch": ["a://b/InternalTrustListEntity*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./InternalTrustListEntity.schema.json",
@@ -4699,9 +4113,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": [
-            "internal"
-          ]
+          "enum": ["internal"]
         },
         "issuerKeyChainId": {
           "type": "string"
@@ -4713,20 +4125,13 @@
           "$ref": "./TrustListEntityInfo.schema.json"
         }
       },
-      "required": [
-        "type",
-        "issuerKeyChainId",
-        "revocationKeyChainId",
-        "info"
-      ],
+      "required": ["type", "issuerKeyChainId", "revocationKeyChainId", "info"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./ExternalTrustListEntity.schema.json",
-    "fileMatch": [
-      "a://b/ExternalTrustListEntity*.schema.json"
-    ],
+    "fileMatch": ["a://b/ExternalTrustListEntity*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./ExternalTrustListEntity.schema.json",
@@ -4735,9 +4140,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": [
-            "external"
-          ]
+          "enum": ["external"]
         },
         "issuerCertPem": {
           "type": "string"
@@ -4749,20 +4152,13 @@
           "$ref": "./TrustListEntityInfo.schema.json"
         }
       },
-      "required": [
-        "type",
-        "issuerCertPem",
-        "revocationCertPem",
-        "info"
-      ],
+      "required": ["type", "issuerCertPem", "revocationCertPem", "info"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./TrustList.schema.json",
-    "fileMatch": [
-      "a://b/TrustList*.schema.json"
-    ],
+    "fileMatch": ["a://b/TrustList*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./TrustList.schema.json",
@@ -4838,9 +4234,7 @@
   },
   {
     "uri": "./TrustListVersion.schema.json",
-    "fileMatch": [
-      "a://b/TrustListVersion*.schema.json"
-    ],
+    "fileMatch": ["a://b/TrustListVersion*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./TrustListVersion.schema.json",
@@ -4895,9 +4289,7 @@
   },
   {
     "uri": "./TrustListRef.schema.json",
-    "fileMatch": [
-      "a://b/TrustListRef*.schema.json"
-    ],
+    "fileMatch": ["a://b/TrustListRef*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./TrustListRef.schema.json",
@@ -4927,9 +4319,7 @@
   },
   {
     "uri": "./TrustedAuthorityQueryEtsiTl.schema.json",
-    "fileMatch": [
-      "a://b/TrustedAuthorityQueryEtsiTl*.schema.json"
-    ],
+    "fileMatch": ["a://b/TrustedAuthorityQueryEtsiTl*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./TrustedAuthorityQueryEtsiTl.schema.json",
@@ -4937,9 +4327,7 @@
       "type": "object",
       "properties": {
         "type": {
-          "enum": [
-            "etsi_tl"
-          ],
+          "enum": ["etsi_tl"],
           "type": "string",
           "default": "etsi_tl"
         },
@@ -4950,18 +4338,13 @@
           }
         }
       },
-      "required": [
-        "type",
-        "values"
-      ],
+      "required": ["type", "values"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./TrustedAuthorityQueryOpenIdFederation.schema.json",
-    "fileMatch": [
-      "a://b/TrustedAuthorityQueryOpenIdFederation*.schema.json"
-    ],
+    "fileMatch": ["a://b/TrustedAuthorityQueryOpenIdFederation*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./TrustedAuthorityQueryOpenIdFederation.schema.json",
@@ -4969,9 +4352,7 @@
       "type": "object",
       "properties": {
         "type": {
-          "enum": [
-            "openid_federation"
-          ],
+          "enum": ["openid_federation"],
           "type": "string",
           "default": "openid_federation"
         },
@@ -4982,18 +4363,13 @@
           }
         }
       },
-      "required": [
-        "type",
-        "values"
-      ],
+      "required": ["type", "values"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./DcSdJwtCredentialQueryMeta.schema.json",
-    "fileMatch": [
-      "a://b/DcSdJwtCredentialQueryMeta*.schema.json"
-    ],
+    "fileMatch": ["a://b/DcSdJwtCredentialQueryMeta*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./DcSdJwtCredentialQueryMeta.schema.json",
@@ -5008,17 +4384,13 @@
           "description": "VCT identifiers accepted for dc+sd-jwt credentials."
         }
       },
-      "required": [
-        "vct_values"
-      ],
+      "required": ["vct_values"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./MsoMdocCredentialQueryMeta.schema.json",
-    "fileMatch": [
-      "a://b/MsoMdocCredentialQueryMeta*.schema.json"
-    ],
+    "fileMatch": ["a://b/MsoMdocCredentialQueryMeta*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./MsoMdocCredentialQueryMeta.schema.json",
@@ -5030,17 +4402,13 @@
           "description": "Document type identifier accepted for mso_mdoc credentials."
         }
       },
-      "required": [
-        "doctype_value"
-      ],
+      "required": ["doctype_value"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./MsoMdocClaimsQuery.schema.json",
-    "fileMatch": [
-      "a://b/MsoMdocClaimsQuery*.schema.json"
-    ],
+    "fileMatch": ["a://b/MsoMdocClaimsQuery*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./MsoMdocClaimsQuery.schema.json",
@@ -5067,17 +4435,13 @@
           }
         }
       },
-      "required": [
-        "path"
-      ],
+      "required": ["path"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./CredentialQueryDcSdJwt.schema.json",
-    "fileMatch": [
-      "a://b/CredentialQueryDcSdJwt*.schema.json"
-    ],
+    "fileMatch": ["a://b/CredentialQueryDcSdJwt*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./CredentialQueryDcSdJwt.schema.json",
@@ -5087,9 +4451,7 @@
         "format": {
           "type": "string",
           "default": "dc+sd-jwt",
-          "enum": [
-            "dc+sd-jwt"
-          ],
+          "enum": ["dc+sd-jwt"],
           "description": "Credential format discriminator."
         },
         "claim_sets": {
@@ -5125,10 +4487,7 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "etsi_tl",
-                  "openid_federation"
-                ]
+                "enum": ["etsi_tl", "openid_federation"]
               }
             }
           }
@@ -5154,19 +4513,13 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "format",
-        "meta",
-        "id"
-      ],
+      "required": ["format", "meta", "id"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./CredentialQueryMsoMdoc.schema.json",
-    "fileMatch": [
-      "a://b/CredentialQueryMsoMdoc*.schema.json"
-    ],
+    "fileMatch": ["a://b/CredentialQueryMsoMdoc*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./CredentialQueryMsoMdoc.schema.json",
@@ -5176,9 +4529,7 @@
         "format": {
           "type": "string",
           "default": "mso_mdoc",
-          "enum": [
-            "mso_mdoc"
-          ],
+          "enum": ["mso_mdoc"],
           "description": "Credential format discriminator."
         },
         "claim_sets": {
@@ -5214,10 +4565,7 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "etsi_tl",
-                  "openid_federation"
-                ]
+                "enum": ["etsi_tl", "openid_federation"]
               }
             }
           }
@@ -5243,19 +4591,13 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "format",
-        "meta",
-        "id"
-      ],
+      "required": ["format", "meta", "id"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./RegistrationCertificatePurpose.schema.json",
-    "fileMatch": [
-      "a://b/RegistrationCertificatePurpose*.schema.json"
-    ],
+    "fileMatch": ["a://b/RegistrationCertificatePurpose*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./RegistrationCertificatePurpose.schema.json",
@@ -5269,18 +4611,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "lang",
-        "content"
-      ],
+      "required": ["lang", "content"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./RegistrationCertificateBody.schema.json",
-    "fileMatch": [
-      "a://b/RegistrationCertificateBody*.schema.json"
-    ],
+    "fileMatch": ["a://b/RegistrationCertificateBody*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./RegistrationCertificateBody.schema.json",
@@ -5307,10 +4644,7 @@
                 "type": "string"
               }
             },
-            "required": [
-              "lang",
-              "content"
-            ],
+            "required": ["lang", "content"],
             "additionalProperties": false
           },
           "type": "array"
@@ -5341,9 +4675,7 @@
   },
   {
     "uri": "./RegistrationCertificateRequest.schema.json",
-    "fileMatch": [
-      "a://b/RegistrationCertificateRequest*.schema.json"
-    ],
+    "fileMatch": ["a://b/RegistrationCertificateRequest*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./RegistrationCertificateRequest.schema.json",
@@ -5377,10 +4709,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "lang",
-                  "content"
-                ],
+                "required": ["lang", "content"],
                 "additionalProperties": false
               }
             },
@@ -5423,9 +4752,7 @@
   },
   {
     "uri": "./PresentationAttachment.schema.json",
-    "fileMatch": [
-      "a://b/PresentationAttachment*.schema.json"
-    ],
+    "fileMatch": ["a://b/PresentationAttachment*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./PresentationAttachment.schema.json",
@@ -5445,18 +4772,13 @@
           }
         }
       },
-      "required": [
-        "format",
-        "data"
-      ],
+      "required": ["format", "data"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./PresentationConfig.schema.json",
-    "fileMatch": [
-      "a://b/PresentationConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/PresentationConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./PresentationConfig.schema.json",
@@ -5470,11 +4792,7 @@
         },
         "statusCheckMode": {
           "description": "Status list verification mode for presentations: strict (default), best_effort, or disabled.",
-          "enum": [
-            "strict",
-            "best_effort",
-            "disabled"
-          ],
+          "enum": ["strict", "best_effort", "disabled"],
           "type": "string",
           "default": "strict"
         },
@@ -5571,21 +4889,13 @@
           "description": "Enable reader authentication for the ISO 18013-7 Annex C (DC API) flow.\n\nWhen `true`, the DeviceRequest embeds a detached `readerAuth` COSE_Sign1\nsigned with the tenant's Access key chain (selected by\n{@link accessKeyChainId}), letting the wallet cryptographically\nauthenticate the verifier — the mDOC equivalent of the signed request\nobject used in the OID4VP flow. Defaults to disabled (null/false).\n\nOnly affects `response_type: \"iso-18013-7\"` offers."
         }
       },
-      "required": [
-        "id",
-        "tenant",
-        "dcql_query",
-        "createdAt",
-        "updatedAt"
-      ],
+      "required": ["id", "tenant", "dcql_query", "createdAt", "updatedAt"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./ResolveIssuerMetadataDto.schema.json",
-    "fileMatch": [
-      "a://b/ResolveIssuerMetadataDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ResolveIssuerMetadataDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./ResolveIssuerMetadataDto.schema.json",
@@ -5599,17 +4909,13 @@
           "example": "https://issuer.example.com/issuers/tenant-a"
         }
       },
-      "required": [
-        "issuerUrl"
-      ],
+      "required": ["issuerUrl"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./ResolveSchemaMetadataDto.schema.json",
-    "fileMatch": [
-      "a://b/ResolveSchemaMetadataDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ResolveSchemaMetadataDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./ResolveSchemaMetadataDto.schema.json",
@@ -5623,17 +4929,13 @@
           "example": "https://registrar.example.com/schema-metadata/5c0d7dbb-ef2e-448b-b84f-b8103575947b"
         }
       },
-      "required": [
-        "schemaMetadataUrl"
-      ],
+      "required": ["schemaMetadataUrl"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./ResolveSchemaMetadataJwtDto.schema.json",
-    "fileMatch": [
-      "a://b/ResolveSchemaMetadataJwtDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ResolveSchemaMetadataJwtDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./ResolveSchemaMetadataJwtDto.schema.json",
@@ -5646,17 +4948,13 @@
           "example": "eyJ0eXAiOiJhdHRlc3RhdGlvbi1zY2hlbWErand0IiwiYWxnIjoiRVMyNTYiLCJ4NWMiOlsiTUlJQ01qQ0NBZGlnQXdJQkFnSVVDa0hwaTlPWHQ0QUJTY2NWbEl3UlJRdlE5cU1Rd0NnWUlLb1pJemowRUF3SXdLREVMTUFrR0ExVUVCaE1DUkVVeEdUQVhCZ05WQkFNTUVFZGxjbTFoYmlCU1pXZHBjM1J5WVhJd0hoY05Nall3TVRFMk1UQXdOVEE0V2hjTk1qZ3dNVEUyTVRBd05UQTRXakFvTVFzd0NRWURWUVFHRXdKRVJURVpNQmNHQTFVRUF3d1FSMlZ5YldGdUlGSmxaMmx6ZEhKaGNqQlpNQk1HQnlxR1NNNDlBZ0VHQ0NxR1NNNDlBd0VIQTBJQUJBUXQrK1dGQnJkVVJjYXkycmtyMG9pdW9zMDE2dlVLT2tsWVNJUVF4K1cvclcyOVc4bkE3SFMrNHMrNW0zWW5tUmRRcXphYWZDT3ZHYXhjSUd5UXFjQ2pnZDh3Z2R3d0hRWURWUjBPQkJZRUZQNGwyNXhUZWxBbnNEa0U2QXFlc09zd3pxWWxNQjhHQTFVZEl3UVlNQmFBRlA0bDI1eFRlbEFuc0RrRTZBcWVzT3N3enFZbE1CSUdBMVVkRXdFQi93UUlNQVlCQWY4Q0FRQXdEZ1lEVlIwUEFRSC9CQVFEQWdFR01Dd0dBMVVkRWdRbE1DT0dJV2gwZEhCek9pOHZjbVZuYVhOMGNtRnlMbVYxWkdrdGQyRnNiR1YwTG1SbGRqQklCZ05WSFI4RVFUQS9NRDJnTzZBNWhqZG9kSFJ3Y3pvdkwzSmxaMmx6ZEhKaGNpNWxkV1JwTFhkaGJHeGxkQzVrWlhZdmMzUmhkSFZ6TFcxaGJtRm5aVzFsYm5RdlkzSnNNQW9HQ0NxR1NNNDlCQU1DQTBnQU1FVUNJRFcxTXA0ZDc3a2oxWVVIWHlhVU1mMmNpbGtxTmpkL2RpdWpud3A4Ti9ISkFpRUF2WXlaK1IyUXFuUUJJUnZBL281aEVjVHJuNTNMQ2ZEQWZnWGt1OWxzZUIwPSJdIn0.eyJpZCI6Imh0dHA6Ly9sb2NhbGhvc3Q6MzAwMS9zY2hlbWEtbWV0YWRhdGEvNWMzNzFhMjEtZWIxOC00NzY3LTk4MTktMGIwMGY2NTQzY2QzIiwidmVyc2lvbiI6IjEuMC4wIn0.signature"
         }
       },
-      "required": [
-        "signedJwt"
-      ],
+      "required": ["signedJwt"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./PresentationConfigUpdateDto.schema.json",
-    "fileMatch": [
-      "a://b/PresentationConfigUpdateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/PresentationConfigUpdateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./PresentationConfigUpdateDto.schema.json",
@@ -5670,11 +4968,7 @@
         },
         "statusCheckMode": {
           "description": "Status list verification mode for presentations: strict (default), best_effort, or disabled.",
-          "enum": [
-            "strict",
-            "best_effort",
-            "disabled"
-          ],
+          "enum": ["strict", "best_effort", "disabled"],
           "type": "string",
           "default": "strict"
         },
@@ -5750,9 +5044,7 @@
   },
   {
     "uri": "./RegistrationCertificateDefaults.schema.json",
-    "fileMatch": [
-      "a://b/RegistrationCertificateDefaults*.schema.json"
-    ],
+    "fileMatch": ["a://b/RegistrationCertificateDefaults*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./RegistrationCertificateDefaults.schema.json",
@@ -5775,9 +5067,7 @@
   },
   {
     "uri": "./RegistrarConfigResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/RegistrarConfigResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/RegistrarConfigResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./RegistrarConfigResponseDto.schema.json",
@@ -5825,21 +5115,13 @@
           "example": true
         }
       },
-      "required": [
-        "registrarUrl",
-        "oidcUrl",
-        "clientId",
-        "username",
-        "hasPassword"
-      ],
+      "required": ["registrarUrl", "oidcUrl", "clientId", "username", "hasPassword"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./DeferredCredentialRequestDto.schema.json",
-    "fileMatch": [
-      "a://b/DeferredCredentialRequestDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/DeferredCredentialRequestDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./DeferredCredentialRequestDto.schema.json",
@@ -5852,17 +5134,13 @@
           "example": "8xLOxBtZp8"
         }
       },
-      "required": [
-        "transaction_id"
-      ],
+      "required": ["transaction_id"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./NotificationRequestDto.schema.json",
-    "fileMatch": [
-      "a://b/NotificationRequestDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/NotificationRequestDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./NotificationRequestDto.schema.json",
@@ -5874,25 +5152,16 @@
         },
         "event": {
           "type": "string",
-          "enum": [
-            "credential_accepted",
-            "credential_failure",
-            "credential_deleted"
-          ]
+          "enum": ["credential_accepted", "credential_failure", "credential_deleted"]
         }
       },
-      "required": [
-        "notification_id",
-        "event"
-      ],
+      "required": ["notification_id", "event"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./OfferResponse.schema.json",
-    "fileMatch": [
-      "a://b/OfferResponse*.schema.json"
-    ],
+    "fileMatch": ["a://b/OfferResponse*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./OfferResponse.schema.json",
@@ -5910,18 +5179,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "uri",
-        "session"
-      ],
+      "required": ["uri", "session"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./CompleteDeferredDto.schema.json",
-    "fileMatch": [
-      "a://b/CompleteDeferredDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CompleteDeferredDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./CompleteDeferredDto.schema.json",
@@ -5942,17 +5206,13 @@
           }
         }
       },
-      "required": [
-        "claims"
-      ],
+      "required": ["claims"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./DeferredOperationResponse.schema.json",
-    "fileMatch": [
-      "a://b/DeferredOperationResponse*.schema.json"
-    ],
+    "fileMatch": ["a://b/DeferredOperationResponse*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./DeferredOperationResponse.schema.json",
@@ -5965,13 +5225,7 @@
         },
         "status": {
           "description": "The new status of the transaction",
-          "enum": [
-            "pending",
-            "ready",
-            "retrieved",
-            "expired",
-            "failed"
-          ],
+          "enum": ["pending", "ready", "retrieved", "expired", "failed"],
           "type": "string"
         },
         "message": {
@@ -5979,18 +5233,13 @@
           "description": "Optional message"
         }
       },
-      "required": [
-        "transactionId",
-        "status"
-      ],
+      "required": ["transactionId", "status"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./FailDeferredDto.schema.json",
-    "fileMatch": [
-      "a://b/FailDeferredDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/FailDeferredDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./FailDeferredDto.schema.json",
@@ -6008,9 +5257,7 @@
   },
   {
     "uri": "./EC_Public.schema.json",
-    "fileMatch": [
-      "a://b/EC_Public*.schema.json"
-    ],
+    "fileMatch": ["a://b/EC_Public*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./EC_Public.schema.json",
@@ -6034,20 +5281,13 @@
           "description": "The y coordinate of the EC public key."
         }
       },
-      "required": [
-        "kty",
-        "crv",
-        "x",
-        "y"
-      ],
+      "required": ["kty", "crv", "x", "y"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./JwksResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/JwksResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/JwksResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./JwksResponseDto.schema.json",
@@ -6062,17 +5302,13 @@
           }
         }
       },
-      "required": [
-        "keys"
-      ],
+      "required": ["keys"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./AuthorizationResponse.schema.json",
-    "fileMatch": [
-      "a://b/AuthorizationResponse*.schema.json"
-    ],
+    "fileMatch": ["a://b/AuthorizationResponse*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./AuthorizationResponse.schema.json",
@@ -6108,9 +5344,7 @@
   },
   {
     "uri": "./Object.schema.json",
-    "fileMatch": [
-      "a://b/Object*.schema.json"
-    ],
+    "fileMatch": ["a://b/Object*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./Object.schema.json",
@@ -6122,9 +5356,7 @@
   },
   {
     "uri": "./ParResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/ParResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ParResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./ParResponseDto.schema.json",
@@ -6140,18 +5372,13 @@
           "description": "The expiration time for the request URI in seconds."
         }
       },
-      "required": [
-        "request_uri",
-        "expires_in"
-      ],
+      "required": ["request_uri", "expires_in"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./InteractiveAuthorizationRequestDto.schema.json",
-    "fileMatch": [
-      "a://b/InteractiveAuthorizationRequestDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/InteractiveAuthorizationRequestDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./InteractiveAuthorizationRequestDto.schema.json",
@@ -6206,9 +5433,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "type"
-                ],
+                "required": ["type"],
                 "additionalProperties": false
               }
             },
@@ -6252,9 +5477,7 @@
   },
   {
     "uri": "./InteractiveAuthorizationCodeResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/InteractiveAuthorizationCodeResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/InteractiveAuthorizationCodeResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./InteractiveAuthorizationCodeResponseDto.schema.json",
@@ -6272,18 +5495,13 @@
           "example": "auth-code-123"
         }
       },
-      "required": [
-        "status",
-        "code"
-      ],
+      "required": ["status", "code"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./InteractiveAuthorizationErrorResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/InteractiveAuthorizationErrorResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/InteractiveAuthorizationErrorResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./InteractiveAuthorizationErrorResponseDto.schema.json",
@@ -6301,17 +5519,13 @@
           "example": "Missing required parameter: interaction_types_supported"
         }
       },
-      "required": [
-        "error"
-      ],
+      "required": ["error"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./ChainedAsParResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/ChainedAsParResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ChainedAsParResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./ChainedAsParResponseDto.schema.json",
@@ -6329,18 +5543,13 @@
           "example": 600
         }
       },
-      "required": [
-        "request_uri",
-        "expires_in"
-      ],
+      "required": ["request_uri", "expires_in"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./ChainedAsErrorResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/ChainedAsErrorResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ChainedAsErrorResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./ChainedAsErrorResponseDto.schema.json",
@@ -6357,17 +5566,13 @@
           "description": "Human-readable error description"
         }
       },
-      "required": [
-        "error"
-      ],
+      "required": ["error"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./ChainedAsTokenRequestDto.schema.json",
-    "fileMatch": [
-      "a://b/ChainedAsTokenRequestDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ChainedAsTokenRequestDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./ChainedAsTokenRequestDto.schema.json",
@@ -6400,17 +5605,13 @@
           "description": "PKCE code verifier"
         }
       },
-      "required": [
-        "grant_type"
-      ],
+      "required": ["grant_type"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./ChainedAsTokenResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/ChainedAsTokenResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ChainedAsTokenResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./ChainedAsTokenResponseDto.schema.json",
@@ -6455,19 +5656,13 @@
           "description": "Refresh token (issued when refresh tokens are enabled)"
         }
       },
-      "required": [
-        "access_token",
-        "token_type",
-        "expires_in"
-      ],
+      "required": ["access_token", "token_type", "expires_in"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./KmsProviderCapabilitiesDto.schema.json",
-    "fileMatch": [
-      "a://b/KmsProviderCapabilitiesDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KmsProviderCapabilitiesDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./KmsProviderCapabilitiesDto.schema.json",
@@ -6491,9 +5686,7 @@
         },
         "supportedAlgs": {
           "description": "Signing algorithms supported by the provider.",
-          "example": [
-            "ES256"
-          ],
+          "example": ["ES256"],
           "type": "array",
           "items": {
             "type": "string"
@@ -6505,21 +5698,13 @@
           "example": "ES256"
         }
       },
-      "required": [
-        "canImport",
-        "canCreate",
-        "canDelete",
-        "supportedAlgs",
-        "defaultAlg"
-      ],
+      "required": ["canImport", "canCreate", "canDelete", "supportedAlgs", "defaultAlg"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./KmsProviderInfoDto.schema.json",
-    "fileMatch": [
-      "a://b/KmsProviderInfoDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KmsProviderInfoDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./KmsProviderInfoDto.schema.json",
@@ -6550,19 +5735,13 @@
           ]
         }
       },
-      "required": [
-        "name",
-        "type",
-        "capabilities"
-      ],
+      "required": ["name", "type", "capabilities"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./KmsProvidersResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/KmsProvidersResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KmsProvidersResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./KmsProvidersResponseDto.schema.json",
@@ -6582,18 +5761,13 @@
           "example": "db"
         }
       },
-      "required": [
-        "providers",
-        "default"
-      ],
+      "required": ["providers", "default"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./KmsTenantConfigResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/KmsTenantConfigResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KmsTenantConfigResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./KmsTenantConfigResponseDto.schema.json",
@@ -6619,17 +5793,13 @@
           ]
         }
       },
-      "required": [
-        "effectiveConfig"
-      ],
+      "required": ["effectiveConfig"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./CertificateInfoDto.schema.json",
-    "fileMatch": [
-      "a://b/CertificateInfoDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CertificateInfoDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./CertificateInfoDto.schema.json",
@@ -6663,17 +5833,13 @@
           "description": "Serial number."
         }
       },
-      "required": [
-        "pem"
-      ],
+      "required": ["pem"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./PublicKeyInfoDto.schema.json",
-    "fileMatch": [
-      "a://b/PublicKeyInfoDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/PublicKeyInfoDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./PublicKeyInfoDto.schema.json",
@@ -6700,17 +5866,13 @@
           "example": "P-256"
         }
       },
-      "required": [
-        "kty"
-      ],
+      "required": ["kty"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./RotationPolicyResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/RotationPolicyResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/RotationPolicyResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./RotationPolicyResponseDto.schema.json",
@@ -6735,17 +5897,13 @@
           "description": "Next scheduled rotation date."
         }
       },
-      "required": [
-        "enabled"
-      ],
+      "required": ["enabled"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./KeyChainResponseDto.schema.json",
-    "fileMatch": [
-      "a://b/KeyChainResponseDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KeyChainResponseDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./KeyChainResponseDto.schema.json",
@@ -6757,21 +5915,12 @@
           "description": "Unique identifier for the key chain."
         },
         "usageType": {
-          "enum": [
-            "access",
-            "attestation",
-            "trustList",
-            "statusList",
-            "encrypt"
-          ],
+          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"],
           "type": "string",
           "description": "Usage type of the key chain."
         },
         "type": {
-          "enum": [
-            "standalone",
-            "internalChain"
-          ],
+          "enum": ["standalone", "internalChain"],
           "type": "string",
           "description": "Type of key chain (standalone or internalChain)."
         },
@@ -6862,9 +6011,7 @@
   },
   {
     "uri": "./ExportEcJwk.schema.json",
-    "fileMatch": [
-      "a://b/ExportEcJwk*.schema.json"
-    ],
+    "fileMatch": ["a://b/ExportEcJwk*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./ExportEcJwk.schema.json",
@@ -6903,21 +6050,13 @@
           "description": "Key ID"
         }
       },
-      "required": [
-        "kty",
-        "crv",
-        "x",
-        "y",
-        "d"
-      ],
+      "required": ["kty", "crv", "x", "y", "d"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./ExportRotationPolicyDto.schema.json",
-    "fileMatch": [
-      "a://b/ExportRotationPolicyDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ExportRotationPolicyDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./ExportRotationPolicyDto.schema.json",
@@ -6937,17 +6076,13 @@
           "description": "Certificate validity in days."
         }
       },
-      "required": [
-        "enabled"
-      ],
+      "required": ["enabled"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./KeyChainExportDto.schema.json",
-    "fileMatch": [
-      "a://b/KeyChainExportDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KeyChainExportDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./KeyChainExportDto.schema.json",
@@ -6963,13 +6098,7 @@
           "description": "Human-readable description."
         },
         "usageType": {
-          "enum": [
-            "access",
-            "attestation",
-            "trustList",
-            "statusList",
-            "encrypt"
-          ],
+          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"],
           "type": "string",
           "description": "Usage type for this key chain."
         },
@@ -7001,19 +6130,13 @@
           ]
         }
       },
-      "required": [
-        "id",
-        "usageType",
-        "key"
-      ],
+      "required": ["id", "usageType", "key"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./EcJwk.schema.json",
-    "fileMatch": [
-      "a://b/EcJwk*.schema.json"
-    ],
+    "fileMatch": ["a://b/EcJwk*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./EcJwk.schema.json",
@@ -7042,21 +6165,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "kty",
-        "x",
-        "y",
-        "crv",
-        "d"
-      ],
+      "required": ["kty", "x", "y", "crv", "d"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./RotationPolicyImportDto.schema.json",
-    "fileMatch": [
-      "a://b/RotationPolicyImportDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/RotationPolicyImportDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./RotationPolicyImportDto.schema.json",
@@ -7083,17 +6198,13 @@
           "example": 365
         }
       },
-      "required": [
-        "enabled"
-      ],
+      "required": ["enabled"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./PresentationRequest.schema.json",
-    "fileMatch": [
-      "a://b/PresentationRequest*.schema.json"
-    ],
+    "fileMatch": ["a://b/PresentationRequest*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./PresentationRequest.schema.json",
@@ -7115,9 +6226,7 @@
                       "const": "none"
                     }
                   },
-                  "required": [
-                    "type"
-                  ],
+                  "required": ["type"],
                   "additionalProperties": false
                 },
                 {
@@ -7137,17 +6246,11 @@
                           "type": "string"
                         }
                       },
-                      "required": [
-                        "headerName",
-                        "value"
-                      ],
+                      "required": ["headerName", "value"],
                       "additionalProperties": false
                     }
                   },
-                  "required": [
-                    "type",
-                    "config"
-                  ],
+                  "required": ["type", "config"],
                   "additionalProperties": false
                 }
               ]
@@ -7183,11 +6286,7 @@
             }
           ],
           "description": "The type of response expected from the presentation request.",
-          "enum": [
-            "uri",
-            "dc-api",
-            "iso-18013-7"
-          ]
+          "enum": ["uri", "dc-api", "iso-18013-7"]
         },
         "requestId": {
           "type": "string",
@@ -7219,18 +6318,13 @@
           "description": "Optional clock skew tolerance for this presentation offer, in seconds.\nIf provided, this overrides the presentation configuration for the created session."
         }
       },
-      "required": [
-        "response_type",
-        "requestId"
-      ],
+      "required": ["response_type", "requestId"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./FileUploadDto.schema.json",
-    "fileMatch": [
-      "a://b/FileUploadDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/FileUploadDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./FileUploadDto.schema.json",
@@ -7242,17 +6336,13 @@
           "format": "binary"
         }
       },
-      "required": [
-        "file"
-      ],
+      "required": ["file"],
       "additionalProperties": false
     }
   },
   {
     "uri": "./AttributeProviderAuth.schema.json",
-    "fileMatch": [
-      "a://b/AttributeProviderAuth*.schema.json"
-    ],
+    "fileMatch": ["a://b/AttributeProviderAuth*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "oneOf": [
@@ -7265,9 +6355,7 @@
               "description": "Disable authentication for attribute provider calls."
             }
           },
-          "required": [
-            "type"
-          ],
+          "required": ["type"],
           "additionalProperties": false,
           "description": "No authentication variant."
         },
@@ -7293,18 +6381,12 @@
                   "description": "API key value."
                 }
               },
-              "required": [
-                "headerName",
-                "value"
-              ],
+              "required": ["headerName", "value"],
               "additionalProperties": false,
               "description": "API key authentication settings."
             }
           },
-          "required": [
-            "type",
-            "config"
-          ],
+          "required": ["type", "config"],
           "additionalProperties": false,
           "description": "API key authentication variant."
         }
@@ -7316,9 +6398,7 @@
   },
   {
     "uri": "./CertImportDto.schema.json",
-    "fileMatch": [
-      "a://b/CertImportDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CertImportDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -7347,9 +6427,7 @@
           "description": "Certificate chain entries, typically PEM-encoded certificates."
         }
       },
-      "required": [
-        "crt"
-      ],
+      "required": ["crt"],
       "additionalProperties": false,
       "$id": "./CertImportDto.schema.json",
       "title": "CertImportDto"
@@ -7357,9 +6435,7 @@
   },
   {
     "uri": "./CreateAttributeProviderDto.schema.json",
-    "fileMatch": [
-      "a://b/CreateAttributeProviderDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CreateAttributeProviderDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -7402,9 +6478,7 @@
                   "description": "Disable authentication for attribute provider calls."
                 }
               },
-              "required": [
-                "type"
-              ],
+              "required": ["type"],
               "additionalProperties": false,
               "description": "No authentication variant."
             },
@@ -7430,18 +6504,12 @@
                       "description": "API key value."
                     }
                   },
-                  "required": [
-                    "headerName",
-                    "value"
-                  ],
+                  "required": ["headerName", "value"],
                   "additionalProperties": false,
                   "description": "API key authentication settings."
                 }
               },
-              "required": [
-                "type",
-                "config"
-              ],
+              "required": ["type", "config"],
               "additionalProperties": false,
               "description": "API key authentication variant."
             }
@@ -7449,12 +6517,7 @@
           "description": "Authentication configuration for outbound provider requests."
         }
       },
-      "required": [
-        "id",
-        "name",
-        "url",
-        "auth"
-      ],
+      "required": ["id", "name", "url", "auth"],
       "additionalProperties": false,
       "$id": "./CreateAttributeProviderDto.schema.json",
       "title": "CreateAttributeProviderDto"
@@ -7462,9 +6525,7 @@
   },
   {
     "uri": "./CreateClientDto.schema.json",
-    "fileMatch": [
-      "a://b/CreateClientDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CreateClientDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -7533,10 +6594,7 @@
           ]
         }
       },
-      "required": [
-        "clientId",
-        "roles"
-      ],
+      "required": ["clientId", "roles"],
       "additionalProperties": false,
       "$id": "./CreateClientDto.schema.json",
       "title": "CreateClientDto"
@@ -7544,9 +6602,7 @@
   },
   {
     "uri": "./CreateRegistrarConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/CreateRegistrarConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CreateRegistrarConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -7597,13 +6653,7 @@
           ]
         }
       },
-      "required": [
-        "registrarUrl",
-        "oidcUrl",
-        "clientId",
-        "username",
-        "password"
-      ],
+      "required": ["registrarUrl", "oidcUrl", "clientId", "username", "password"],
       "additionalProperties": false,
       "$id": "./CreateRegistrarConfigDto.schema.json",
       "title": "CreateRegistrarConfigDto"
@@ -7611,9 +6661,7 @@
   },
   {
     "uri": "./CreateStatusListDto.schema.json",
-    "fileMatch": [
-      "a://b/CreateStatusListDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CreateStatusListDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -7663,9 +6711,7 @@
   },
   {
     "uri": "./CreateTenantDto.schema.json",
-    "fileMatch": [
-      "a://b/CreateTenantDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CreateTenantDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -7716,10 +6762,7 @@
             "cleanupMode": {
               "description": "Whether to fully delete or anonymize expired sessions.",
               "type": "string",
-              "enum": [
-                "full",
-                "anonymize"
-              ]
+              "enum": ["full", "anonymize"]
             }
           },
           "additionalProperties": false
@@ -7773,10 +6816,7 @@
           "additionalProperties": false
         }
       },
-      "required": [
-        "id",
-        "name"
-      ],
+      "required": ["id", "name"],
       "additionalProperties": false,
       "description": "Payload for creating a tenant.",
       "$id": "./CreateTenantDto.schema.json",
@@ -7785,9 +6825,7 @@
   },
   {
     "uri": "./CreateWebhookEndpointDto.schema.json",
-    "fileMatch": [
-      "a://b/CreateWebhookEndpointDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/CreateWebhookEndpointDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -7830,9 +6868,7 @@
                   "description": "Disable webhook authentication."
                 }
               },
-              "required": [
-                "type"
-              ],
+              "required": ["type"],
               "additionalProperties": false,
               "description": "No webhook authentication variant."
             },
@@ -7858,18 +6894,12 @@
                       "description": "API key value sent with webhook requests."
                     }
                   },
-                  "required": [
-                    "headerName",
-                    "value"
-                  ],
+                  "required": ["headerName", "value"],
                   "additionalProperties": false,
                   "description": "API key webhook authentication settings."
                 }
               },
-              "required": [
-                "type",
-                "config"
-              ],
+              "required": ["type", "config"],
               "additionalProperties": false,
               "description": "API key webhook authentication variant."
             }
@@ -7877,12 +6907,7 @@
           "description": "Authentication configuration applied to outgoing webhook requests."
         }
       },
-      "required": [
-        "id",
-        "name",
-        "url",
-        "auth"
-      ],
+      "required": ["id", "name", "url", "auth"],
       "additionalProperties": false,
       "$id": "./CreateWebhookEndpointDto.schema.json",
       "title": "CreateWebhookEndpointDto"
@@ -7890,9 +6915,7 @@
   },
   {
     "uri": "./CredentialConfigCreate.schema.json",
-    "fileMatch": [
-      "a://b/CredentialConfigCreate*.schema.json"
-    ],
+    "fileMatch": ["a://b/CredentialConfigCreate*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -7918,10 +6941,7 @@
           "properties": {
             "format": {
               "type": "string",
-              "enum": [
-                "mso_mdoc",
-                "dc+sd-jwt"
-              ],
+              "enum": ["mso_mdoc", "dc+sd-jwt"],
               "description": "Credential format emitted by this configuration."
             },
             "display": {
@@ -7961,9 +6981,7 @@
                         "description": "Image URI."
                       }
                     },
-                    "required": [
-                      "uri"
-                    ],
+                    "required": ["uri"],
                     "additionalProperties": false
                   },
                   "logo": {
@@ -7976,16 +6994,11 @@
                         "description": "Image URI."
                       }
                     },
-                    "required": [
-                      "uri"
-                    ],
+                    "required": ["uri"],
                     "additionalProperties": false
                   }
                 },
-                "required": [
-                  "locale",
-                  "name"
-                ],
+                "required": ["locale", "name"],
                 "additionalProperties": false
               },
               "description": "Display metadata shown by wallets."
@@ -8024,17 +7037,11 @@
               "type": "array",
               "items": {
                 "type": "string",
-                "enum": [
-                  "jwt",
-                  "attestation"
-                ]
+                "enum": ["jwt", "attestation"]
               }
             }
           },
-          "required": [
-            "format",
-            "display"
-          ],
+          "required": ["format", "display"],
           "additionalProperties": false,
           "description": "Issuer metadata-facing credential configuration."
         },
@@ -8150,10 +7157,7 @@
                         "description": "Presentation configuration id to execute."
                       }
                     },
-                    "required": [
-                      "type",
-                      "presentationConfigId"
-                    ],
+                    "required": ["type", "presentationConfigId"],
                     "additionalProperties": false
                   },
                   {
@@ -8183,10 +7187,7 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "type",
-                      "url"
-                    ],
+                    "required": ["type", "url"],
                     "additionalProperties": false
                   }
                 ],
@@ -8203,10 +7204,7 @@
           "anyOf": [
             {
               "type": "string",
-              "enum": [
-                "x5c",
-                "federation"
-              ]
+              "enum": ["x5c", "federation"]
             },
             {
               "type": "null"
@@ -8253,12 +7251,7 @@
                 },
                 "bindingType": {
                   "type": "string",
-                  "enum": [
-                    "claim",
-                    "key",
-                    "biometric",
-                    "none"
-                  ],
+                  "enum": ["claim", "key", "biometric", "none"],
                   "description": "Subject binding type."
                 },
                 "schemaURIs": {
@@ -8304,11 +7297,7 @@
                       "frameworkType": {
                         "description": "Trust framework type.",
                         "type": "string",
-                        "enum": [
-                          "aki",
-                          "etsi_tl",
-                          "openid_federation"
-                        ]
+                        "enum": ["aki", "etsi_tl", "openid_federation"]
                       },
                       "value": {
                         "description": "Framework-specific authority value.",
@@ -8334,11 +7323,7 @@
                   }
                 }
               },
-              "required": [
-                "version",
-                "attestationLoS",
-                "bindingType"
-              ],
+              "required": ["version", "attestationLoS", "bindingType"],
               "additionalProperties": false
             },
             {
@@ -8380,18 +7365,13 @@
                             "items": {}
                           }
                         },
-                        "required": [
-                          "credentials"
-                        ],
+                        "required": ["credentials"],
                         "additionalProperties": false
                       },
                       "description": "Attestation requirements used for policy enforcement."
                     }
                   },
-                  "required": [
-                    "policy",
-                    "values"
-                  ],
+                  "required": ["policy", "values"],
                   "additionalProperties": false
                 },
                 {
@@ -8403,9 +7383,7 @@
                       "description": "No disclosure policy enforcement."
                     }
                   },
-                  "required": [
-                    "policy"
-                  ],
+                  "required": ["policy"],
                   "additionalProperties": false
                 },
                 {
@@ -8424,10 +7402,7 @@
                       "description": "Allowed values for policy checks."
                     }
                   },
-                  "required": [
-                    "policy",
-                    "values"
-                  ],
+                  "required": ["policy", "values"],
                   "additionalProperties": false
                 },
                 {
@@ -8443,10 +7418,7 @@
                       "description": "Root-of-trust identifier or reference."
                     }
                   },
-                  "required": [
-                    "policy",
-                    "values"
-                  ],
+                  "required": ["policy", "values"],
                   "additionalProperties": false
                 }
               ],
@@ -8458,11 +7430,7 @@
           ]
         }
       },
-      "required": [
-        "id",
-        "config",
-        "fields"
-      ],
+      "required": ["id", "config", "fields"],
       "additionalProperties": false,
       "$defs": {
         "__schema0": {
@@ -8487,14 +7455,7 @@
             },
             "type": {
               "type": "string",
-              "enum": [
-                "string",
-                "number",
-                "integer",
-                "boolean",
-                "object",
-                "array"
-              ],
+              "enum": ["string", "number", "integer", "boolean", "object", "array"],
               "description": "Data type of the claim value."
             },
             "defaultValue": {
@@ -8533,10 +7494,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "locale",
-                  "name"
-                ],
+                "required": ["locale", "name"],
                 "additionalProperties": false
               }
             },
@@ -8556,10 +7514,7 @@
               }
             }
           },
-          "required": [
-            "path",
-            "type"
-          ],
+          "required": ["path", "type"],
           "additionalProperties": false
         }
       },
@@ -8569,9 +7524,7 @@
   },
   {
     "uri": "./DCQL.schema.json",
-    "fileMatch": [
-      "a://b/DCQL*.schema.json"
-    ],
+    "fileMatch": ["a://b/DCQL*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -8657,10 +7610,7 @@
                               "description": "Trust list references for ETSI TL verification."
                             }
                           },
-                          "required": [
-                            "type",
-                            "values"
-                          ],
+                          "required": ["type", "values"],
                           "additionalProperties": false
                         },
                         {
@@ -8679,10 +7629,7 @@
                               "description": "OpenID Federation authority identifiers."
                             }
                           },
-                          "required": [
-                            "type",
-                            "values"
-                          ],
+                          "required": ["type", "values"],
                           "additionalProperties": false
                         }
                       ]
@@ -8705,9 +7652,7 @@
                         "description": "Accepted VCT values."
                       }
                     },
-                    "required": [
-                      "vct_values"
-                    ],
+                    "required": ["vct_values"],
                     "additionalProperties": false
                   },
                   "claims": {
@@ -8742,18 +7687,12 @@
                           }
                         }
                       },
-                      "required": [
-                        "path"
-                      ],
+                      "required": ["path"],
                       "additionalProperties": false
                     }
                   }
                 },
-                "required": [
-                  "id",
-                  "format",
-                  "meta"
-                ],
+                "required": ["id", "format", "meta"],
                 "additionalProperties": false
               },
               {
@@ -8832,10 +7771,7 @@
                               "description": "Trust list references for ETSI TL verification."
                             }
                           },
-                          "required": [
-                            "type",
-                            "values"
-                          ],
+                          "required": ["type", "values"],
                           "additionalProperties": false
                         },
                         {
@@ -8854,10 +7790,7 @@
                               "description": "OpenID Federation authority identifiers."
                             }
                           },
-                          "required": [
-                            "type",
-                            "values"
-                          ],
+                          "required": ["type", "values"],
                           "additionalProperties": false
                         }
                       ]
@@ -8877,9 +7810,7 @@
                         "description": "Expected mDoc doctype value."
                       }
                     },
-                    "required": [
-                      "doctype_value"
-                    ],
+                    "required": ["doctype_value"],
                     "additionalProperties": false
                   },
                   "claims": {
@@ -8918,18 +7849,12 @@
                           "type": "boolean"
                         }
                       },
-                      "required": [
-                        "path"
-                      ],
+                      "required": ["path"],
                       "additionalProperties": false
                     }
                   }
                 },
-                "required": [
-                  "id",
-                  "format",
-                  "meta"
-                ],
+                "required": ["id", "format", "meta"],
                 "additionalProperties": false
               }
             ]
@@ -8959,16 +7884,12 @@
                 "type": "boolean"
               }
             },
-            "required": [
-              "options"
-            ],
+            "required": ["options"],
             "additionalProperties": false
           }
         }
       },
-      "required": [
-        "credentials"
-      ],
+      "required": ["credentials"],
       "additionalProperties": false,
       "$id": "./DCQL.schema.json",
       "title": "DCQL"
@@ -8976,9 +7897,7 @@
   },
   {
     "uri": "./EmbeddedDisclosurePolicy.schema.json",
-    "fileMatch": [
-      "a://b/EmbeddedDisclosurePolicy*.schema.json"
-    ],
+    "fileMatch": ["a://b/EmbeddedDisclosurePolicy*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "oneOf": [
@@ -9011,18 +7930,13 @@
                     "items": {}
                   }
                 },
-                "required": [
-                  "credentials"
-                ],
+                "required": ["credentials"],
                 "additionalProperties": false
               },
               "description": "Attestation requirements used for policy enforcement."
             }
           },
-          "required": [
-            "policy",
-            "values"
-          ],
+          "required": ["policy", "values"],
           "additionalProperties": false
         },
         {
@@ -9034,9 +7948,7 @@
               "description": "No disclosure policy enforcement."
             }
           },
-          "required": [
-            "policy"
-          ],
+          "required": ["policy"],
           "additionalProperties": false
         },
         {
@@ -9055,10 +7967,7 @@
               "description": "Allowed values for policy checks."
             }
           },
-          "required": [
-            "policy",
-            "values"
-          ],
+          "required": ["policy", "values"],
           "additionalProperties": false
         },
         {
@@ -9074,10 +7983,7 @@
               "description": "Root-of-trust identifier or reference."
             }
           },
-          "required": [
-            "policy",
-            "values"
-          ],
+          "required": ["policy", "values"],
           "additionalProperties": false
         }
       ],
@@ -9088,9 +7994,7 @@
   },
   {
     "uri": "./ImportTenantDto.schema.json",
-    "fileMatch": [
-      "a://b/ImportTenantDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/ImportTenantDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -9107,9 +8011,7 @@
           "minLength": 1
         }
       },
-      "required": [
-        "name"
-      ],
+      "required": ["name"],
       "additionalProperties": false,
       "description": "Payload used when importing tenant metadata from config files.",
       "$id": "./ImportTenantDto.schema.json",
@@ -9118,9 +8020,7 @@
   },
   {
     "uri": "./IssuanceConfig.schema.json",
-    "fileMatch": [
-      "a://b/IssuanceConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/IssuanceConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -9163,9 +8063,7 @@
                 "type": "string"
               }
             },
-            "required": [
-              "url"
-            ],
+            "required": ["url"],
             "additionalProperties": false
           }
         },
@@ -9206,11 +8104,7 @@
                     "type": "boolean"
                   }
                 },
-                "required": [
-                  "type",
-                  "id",
-                  "issuer"
-                ],
+                "required": ["type", "id", "issuer"],
                 "additionalProperties": false
               },
               {
@@ -9274,11 +8168,7 @@
                     "type": "boolean"
                   }
                 },
-                "required": [
-                  "type",
-                  "id",
-                  "presentationConfigId"
-                ],
+                "required": ["type", "id", "presentationConfigId"],
                 "additionalProperties": false
               },
               {
@@ -9321,10 +8211,7 @@
                         }
                       }
                     },
-                    "required": [
-                      "issuer",
-                      "clientId"
-                    ],
+                    "required": ["issuer", "clientId"],
                     "additionalProperties": false,
                     "description": "Upstream OIDC connection settings."
                   },
@@ -9367,11 +8254,7 @@
                     "type": "boolean"
                   }
                 },
-                "required": [
-                  "type",
-                  "id",
-                  "upstream"
-                ],
+                "required": ["type", "id", "upstream"],
                 "additionalProperties": false
               },
               {
@@ -9426,10 +8309,7 @@
                     "type": "boolean"
                   }
                 },
-                "required": [
-                  "type",
-                  "id"
-                ],
+                "required": ["type", "id"],
                 "additionalProperties": false
               }
             ],
@@ -9446,19 +8326,12 @@
                 "role": {
                   "description": "Federation role for this issuer.",
                   "type": "string",
-                  "enum": [
-                    "trust_anchor",
-                    "intermediate",
-                    "leaf"
-                  ]
+                  "enum": ["trust_anchor", "intermediate", "leaf"]
                 },
                 "mode": {
                   "description": "Federation operation mode.",
                   "type": "string",
-                  "enum": [
-                    "federation-only",
-                    "hybrid"
-                  ]
+                  "enum": ["federation-only", "hybrid"]
                 },
                 "entityId": {
                   "description": "Optional local federation entity id.",
@@ -9490,18 +8363,13 @@
                         "description": "Entity configuration URI for the trust anchor."
                       }
                     },
-                    "required": [
-                      "entityId",
-                      "entityConfigurationUri"
-                    ],
+                    "required": ["entityId", "entityConfigurationUri"],
                     "additionalProperties": false
                   },
                   "description": "Federation trust anchors."
                 }
               },
-              "required": [
-                "trustAnchors"
-              ],
+              "required": ["trustAnchors"],
               "additionalProperties": false
             },
             {
@@ -9522,10 +8390,7 @@
                 "mode": {
                   "description": "How registration certificate data is provided.",
                   "type": "string",
-                  "enum": [
-                    "import",
-                    "generate"
-                  ]
+                  "enum": ["import", "generate"]
                 },
                 "jwt": {
                   "description": "Optional registration certificate JWT when using import mode.",
@@ -9575,9 +8440,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "uri"
-                ],
+                "required": ["uri"],
                 "additionalProperties": {}
               }
             },
@@ -9606,9 +8469,7 @@
           ]
         }
       },
-      "required": [
-        "authorizationServers"
-      ],
+      "required": ["authorizationServers"],
       "additionalProperties": false,
       "$id": "./IssuanceConfig.schema.json",
       "title": "IssuanceConfig"
@@ -9616,30 +8477,19 @@
   },
   {
     "uri": "./KeyChainCreateDto.schema.json",
-    "fileMatch": [
-      "a://b/KeyChainCreateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KeyChainCreateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
       "properties": {
         "usageType": {
           "type": "string",
-          "enum": [
-            "access",
-            "attestation",
-            "trustList",
-            "statusList",
-            "encrypt"
-          ],
+          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"],
           "description": "Key usage category for the key chain."
         },
         "type": {
           "type": "string",
-          "enum": [
-            "standalone",
-            "internalChain"
-          ],
+          "enum": ["standalone", "internalChain"],
           "description": "Key chain mode."
         },
         "description": {
@@ -9671,16 +8521,11 @@
               "maximum": 3650
             }
           },
-          "required": [
-            "enabled"
-          ],
+          "required": ["enabled"],
           "additionalProperties": false
         }
       },
-      "required": [
-        "usageType",
-        "type"
-      ],
+      "required": ["usageType", "type"],
       "additionalProperties": false,
       "$id": "./KeyChainCreateDto.schema.json",
       "title": "KeyChainCreateDto"
@@ -9688,9 +8533,7 @@
   },
   {
     "uri": "./KeyChainImportDto.schema.json",
-    "fileMatch": [
-      "a://b/KeyChainImportDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KeyChainImportDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -9731,13 +8574,7 @@
               "type": "string"
             }
           },
-          "required": [
-            "kty",
-            "x",
-            "y",
-            "crv",
-            "d"
-          ],
+          "required": ["kty", "x", "y", "crv", "d"],
           "additionalProperties": false,
           "description": "Private key material in JWK format."
         },
@@ -9747,13 +8584,7 @@
         },
         "usageType": {
           "type": "string",
-          "enum": [
-            "access",
-            "attestation",
-            "trustList",
-            "statusList",
-            "encrypt"
-          ],
+          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"],
           "description": "Key usage category for the imported key chain."
         },
         "crt": {
@@ -9788,16 +8619,11 @@
               "maximum": 3650
             }
           },
-          "required": [
-            "enabled"
-          ],
+          "required": ["enabled"],
           "additionalProperties": false
         }
       },
-      "required": [
-        "key",
-        "usageType"
-      ],
+      "required": ["key", "usageType"],
       "additionalProperties": false,
       "$id": "./KeyChainImportDto.schema.json",
       "title": "KeyChainImportDto"
@@ -9805,9 +8631,7 @@
   },
   {
     "uri": "./KeyChainUpdateDto.schema.json",
-    "fileMatch": [
-      "a://b/KeyChainUpdateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KeyChainUpdateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -9851,18 +8675,14 @@
   },
   {
     "uri": "./KmsConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/KmsConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/KmsConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
       "properties": {
         "defaultProvider": {
           "description": "ID of the default KMS provider. Defaults to \"db\" if not set.",
-          "examples": [
-            "main-vault"
-          ],
+          "examples": ["main-vault"],
           "anyOf": [
             {
               "type": "string",
@@ -9893,23 +8713,17 @@
                       }
                     ],
                     "description": "Unique identifier for this provider instance. Used when generating keys to specify which provider to use.",
-                    "examples": [
-                      "main-vault"
-                    ]
+                    "examples": ["main-vault"]
                   },
                   "type": {
                     "type": "string",
                     "const": "db",
                     "description": "Type of the KMS provider.",
-                    "examples": [
-                      "db"
-                    ]
+                    "examples": ["db"]
                   },
                   "description": {
                     "description": "Human-readable description of this provider instance.",
-                    "examples": [
-                      "Production HashiCorp Vault for signing keys"
-                    ],
+                    "examples": ["Production HashiCorp Vault for signing keys"],
                     "anyOf": [
                       {
                         "type": "string",
@@ -9922,10 +8736,7 @@
                     ]
                   }
                 },
-                "required": [
-                  "id",
-                  "type"
-                ],
+                "required": ["id", "type"],
                 "additionalProperties": false
               },
               {
@@ -9943,23 +8754,17 @@
                       }
                     ],
                     "description": "Unique identifier for this provider instance. Used when generating keys to specify which provider to use.",
-                    "examples": [
-                      "main-vault"
-                    ]
+                    "examples": ["main-vault"]
                   },
                   "type": {
                     "type": "string",
                     "const": "vault",
                     "description": "Type of the KMS provider.",
-                    "examples": [
-                      "vault"
-                    ]
+                    "examples": ["vault"]
                   },
                   "description": {
                     "description": "Human-readable description of this provider instance.",
-                    "examples": [
-                      "Production HashiCorp Vault for signing keys"
-                    ],
+                    "examples": ["Production HashiCorp Vault for signing keys"],
                     "anyOf": [
                       {
                         "type": "string",
@@ -9983,9 +8788,7 @@
                       }
                     ],
                     "description": "URL of the HashiCorp Vault instance. Supports ${ENV_VAR} placeholders.",
-                    "examples": [
-                      "${VAULT_URL}"
-                    ]
+                    "examples": ["${VAULT_URL}"]
                   },
                   "vaultToken": {
                     "anyOf": [
@@ -9999,17 +8802,10 @@
                       }
                     ],
                     "description": "Authentication token for HashiCorp Vault. Supports ${ENV_VAR} placeholders.",
-                    "examples": [
-                      "${VAULT_TOKEN}"
-                    ]
+                    "examples": ["${VAULT_TOKEN}"]
                   }
                 },
-                "required": [
-                  "id",
-                  "type",
-                  "vaultUrl",
-                  "vaultToken"
-                ],
+                "required": ["id", "type", "vaultUrl", "vaultToken"],
                 "additionalProperties": false
               },
               {
@@ -10027,23 +8823,17 @@
                       }
                     ],
                     "description": "Unique identifier for this provider instance. Used when generating keys to specify which provider to use.",
-                    "examples": [
-                      "main-vault"
-                    ]
+                    "examples": ["main-vault"]
                   },
                   "type": {
                     "type": "string",
                     "const": "aws-kms",
                     "description": "Type of the KMS provider.",
-                    "examples": [
-                      "aws-kms"
-                    ]
+                    "examples": ["aws-kms"]
                   },
                   "description": {
                     "description": "Human-readable description of this provider instance.",
-                    "examples": [
-                      "Production HashiCorp Vault for signing keys"
-                    ],
+                    "examples": ["Production HashiCorp Vault for signing keys"],
                     "anyOf": [
                       {
                         "type": "string",
@@ -10067,15 +8857,11 @@
                       }
                     ],
                     "description": "AWS region for KMS. Supports ${ENV_VAR} placeholders.",
-                    "examples": [
-                      "${AWS_REGION}"
-                    ]
+                    "examples": ["${AWS_REGION}"]
                   },
                   "accessKeyId": {
                     "description": "AWS access key ID. Optional — uses SDK credential chain if not provided. Supports ${ENV_VAR} placeholders.",
-                    "examples": [
-                      "${AWS_ACCESS_KEY_ID}"
-                    ],
+                    "examples": ["${AWS_ACCESS_KEY_ID}"],
                     "anyOf": [
                       {
                         "type": "string",
@@ -10089,9 +8875,7 @@
                   },
                   "secretAccessKey": {
                     "description": "AWS secret access key. Optional — uses SDK credential chain if not provided. Supports ${ENV_VAR} placeholders.",
-                    "examples": [
-                      "${AWS_SECRET_ACCESS_KEY}"
-                    ],
+                    "examples": ["${AWS_SECRET_ACCESS_KEY}"],
                     "anyOf": [
                       {
                         "type": "string",
@@ -10104,11 +8888,7 @@
                     ]
                   }
                 },
-                "required": [
-                  "id",
-                  "type",
-                  "region"
-                ],
+                "required": ["id", "type", "region"],
                 "additionalProperties": false
               },
               {
@@ -10126,23 +8906,17 @@
                       }
                     ],
                     "description": "Unique identifier for this provider instance. Used when generating keys to specify which provider to use.",
-                    "examples": [
-                      "main-vault"
-                    ]
+                    "examples": ["main-vault"]
                   },
                   "type": {
                     "type": "string",
                     "const": "pkcs11",
                     "description": "Type of the KMS provider.",
-                    "examples": [
-                      "pkcs11"
-                    ]
+                    "examples": ["pkcs11"]
                   },
                   "description": {
                     "description": "Human-readable description of this provider instance.",
-                    "examples": [
-                      "Production HashiCorp Vault for signing keys"
-                    ],
+                    "examples": ["Production HashiCorp Vault for signing keys"],
                     "anyOf": [
                       {
                         "type": "string",
@@ -10166,9 +8940,7 @@
                       }
                     ],
                     "description": "Absolute path to the PKCS#11 module library (.so/.dll/.dylib). Supports ${ENV_VAR} placeholders.",
-                    "examples": [
-                      "${PKCS11_LIBRARY}"
-                    ]
+                    "examples": ["${PKCS11_LIBRARY}"]
                   },
                   "slot": {
                     "anyOf": [
@@ -10180,9 +8952,7 @@
                       }
                     ],
                     "description": "Slot selection. Either the numeric slot index (as a string for ENV interpolation, or a number) or the token label. Supports ${ENV_VAR} placeholders.",
-                    "examples": [
-                      "${PKCS11_SLOT}"
-                    ]
+                    "examples": ["${PKCS11_SLOT}"]
                   },
                   "pin": {
                     "anyOf": [
@@ -10196,25 +8966,15 @@
                       }
                     ],
                     "description": "User PIN used for C_Login. Supports ${ENV_VAR} placeholders.",
-                    "examples": [
-                      "${PKCS11_PIN}"
-                    ]
+                    "examples": ["${PKCS11_PIN}"]
                   },
                   "readOnly": {
                     "description": "Open the PKCS#11 session in read-only mode. Defaults to false.",
-                    "examples": [
-                      false
-                    ],
+                    "examples": [false],
                     "type": "boolean"
                   }
                 },
-                "required": [
-                  "id",
-                  "type",
-                  "library",
-                  "slot",
-                  "pin"
-                ],
+                "required": ["id", "type", "library", "slot", "pin"],
                 "additionalProperties": false
               },
               {
@@ -10232,23 +8992,17 @@
                       }
                     ],
                     "description": "Unique identifier for this provider instance. Used when generating keys to specify which provider to use.",
-                    "examples": [
-                      "main-vault"
-                    ]
+                    "examples": ["main-vault"]
                   },
                   "type": {
                     "type": "string",
                     "const": "http",
                     "description": "Type of the KMS provider.",
-                    "examples": [
-                      "http"
-                    ]
+                    "examples": ["http"]
                   },
                   "description": {
                     "description": "Human-readable description of this provider instance.",
-                    "examples": [
-                      "Production HashiCorp Vault for signing keys"
-                    ],
+                    "examples": ["Production HashiCorp Vault for signing keys"],
                     "anyOf": [
                       {
                         "type": "string",
@@ -10272,9 +9026,7 @@
                       }
                     ],
                     "description": "Base URL of the remote KMS microservice (no trailing slash). Supports ${ENV_VAR} placeholders.",
-                    "examples": [
-                      "${KMS_SERVICE_URL}"
-                    ]
+                    "examples": ["${KMS_SERVICE_URL}"]
                   },
                   "auth": {
                     "description": "Authentication method for the remote KMS service. Supports bearer token, OAuth 2.0 client credentials, and mutual TLS. Omit (or set type to \"none\") for unauthenticated services.",
@@ -10286,14 +9038,10 @@
                             "type": "string",
                             "const": "none",
                             "description": "No authentication — suitable for services on a trusted private network.",
-                            "examples": [
-                              "none"
-                            ]
+                            "examples": ["none"]
                           }
                         },
-                        "required": [
-                          "type"
-                        ],
+                        "required": ["type"],
                         "additionalProperties": false
                       },
                       {
@@ -10303,9 +9051,7 @@
                             "type": "string",
                             "const": "bearer",
                             "description": "Static Bearer token sent as Authorization: Bearer <token>.",
-                            "examples": [
-                              "bearer"
-                            ]
+                            "examples": ["bearer"]
                           },
                           "token": {
                             "anyOf": [
@@ -10319,15 +9065,10 @@
                               }
                             ],
                             "description": "Bearer token value. Supports ${ENV_VAR} placeholders.",
-                            "examples": [
-                              "${KMS_API_KEY}"
-                            ]
+                            "examples": ["${KMS_API_KEY}"]
                           }
                         },
-                        "required": [
-                          "type",
-                          "token"
-                        ],
+                        "required": ["type", "token"],
                         "additionalProperties": false
                       },
                       {
@@ -10337,9 +9078,7 @@
                             "type": "string",
                             "const": "oauth2-client-credentials",
                             "description": "OAuth 2.0 Client Credentials — EUDIPLO fetches and caches short-lived tokens.",
-                            "examples": [
-                              "oauth2-client-credentials"
-                            ]
+                            "examples": ["oauth2-client-credentials"]
                           },
                           "tokenUrl": {
                             "anyOf": [
@@ -10353,9 +9092,7 @@
                               }
                             ],
                             "description": "Token endpoint URL (e.g. Keycloak, Entra ID). Supports ${ENV_VAR} placeholders.",
-                            "examples": [
-                              "${IAM_TOKEN_URL}"
-                            ]
+                            "examples": ["${IAM_TOKEN_URL}"]
                           },
                           "clientId": {
                             "anyOf": [
@@ -10369,9 +9106,7 @@
                               }
                             ],
                             "description": "OAuth 2.0 client ID. Supports ${ENV_VAR} placeholders.",
-                            "examples": [
-                              "${KMS_CLIENT_ID}"
-                            ]
+                            "examples": ["${KMS_CLIENT_ID}"]
                           },
                           "clientSecret": {
                             "anyOf": [
@@ -10385,15 +9120,11 @@
                               }
                             ],
                             "description": "OAuth 2.0 client secret. Supports ${ENV_VAR} placeholders.",
-                            "examples": [
-                              "${KMS_CLIENT_SECRET}"
-                            ]
+                            "examples": ["${KMS_CLIENT_SECRET}"]
                           },
                           "scope": {
                             "description": "Space-separated list of OAuth 2.0 scopes to request. Optional.",
-                            "examples": [
-                              "kms:sign kms:admin"
-                            ],
+                            "examples": ["kms:sign kms:admin"],
                             "anyOf": [
                               {
                                 "type": "string",
@@ -10406,12 +9137,7 @@
                             ]
                           }
                         },
-                        "required": [
-                          "type",
-                          "tokenUrl",
-                          "clientId",
-                          "clientSecret"
-                        ],
+                        "required": ["type", "tokenUrl", "clientId", "clientSecret"],
                         "additionalProperties": false
                       },
                       {
@@ -10421,9 +9147,7 @@
                             "type": "string",
                             "const": "mtls",
                             "description": "Mutual TLS — EUDIPLO presents a client certificate on every connection.",
-                            "examples": [
-                              "mtls"
-                            ]
+                            "examples": ["mtls"]
                           },
                           "certFile": {
                             "anyOf": [
@@ -10437,9 +9161,7 @@
                               }
                             ],
                             "description": "Absolute path to the PEM-encoded client certificate file. Supports ${ENV_VAR} placeholders.",
-                            "examples": [
-                              "/etc/certs/eudiplo.crt"
-                            ]
+                            "examples": ["/etc/certs/eudiplo.crt"]
                           },
                           "keyFile": {
                             "anyOf": [
@@ -10453,15 +9175,11 @@
                               }
                             ],
                             "description": "Absolute path to the PEM-encoded private key file for the client certificate. Supports ${ENV_VAR} placeholders.",
-                            "examples": [
-                              "/etc/certs/eudiplo.key"
-                            ]
+                            "examples": ["/etc/certs/eudiplo.key"]
                           },
                           "caFile": {
                             "description": "Absolute path to the PEM-encoded CA bundle to trust for the remote server's certificate. Omit to use the system CA store.",
-                            "examples": [
-                              "/etc/certs/ca.crt"
-                            ],
+                            "examples": ["/etc/certs/ca.crt"],
                             "anyOf": [
                               {
                                 "type": "string",
@@ -10474,20 +9192,14 @@
                             ]
                           }
                         },
-                        "required": [
-                          "type",
-                          "certFile",
-                          "keyFile"
-                        ],
+                        "required": ["type", "certFile", "keyFile"],
                         "additionalProperties": false
                       }
                     ]
                   },
                   "keysPath": {
                     "description": "Path prefix for key endpoints on the remote service. Defaults to /keys.",
-                    "examples": [
-                      "/v1/keys"
-                    ],
+                    "examples": ["/v1/keys"],
                     "anyOf": [
                       {
                         "type": "string",
@@ -10501,9 +9213,7 @@
                   },
                   "healthPath": {
                     "description": "Path for the health check endpoint on the remote service. Defaults to /health.",
-                    "examples": [
-                      "/health"
-                    ],
+                    "examples": ["/health"],
                     "anyOf": [
                       {
                         "type": "string",
@@ -10517,17 +9227,11 @@
                   },
                   "canImport": {
                     "description": "Whether the remote service supports key import via POST {keysPath}/{kid}/import. Defaults to false.",
-                    "examples": [
-                      false
-                    ],
+                    "examples": [false],
                     "type": "boolean"
                   }
                 },
-                "required": [
-                  "id",
-                  "type",
-                  "baseUrl"
-                ],
+                "required": ["id", "type", "baseUrl"],
                 "additionalProperties": false
               },
               {
@@ -10545,23 +9249,17 @@
                       }
                     ],
                     "description": "Unique identifier for this provider instance. Used when generating keys to specify which provider to use.",
-                    "examples": [
-                      "main-vault"
-                    ]
+                    "examples": ["main-vault"]
                   },
                   "type": {
                     "type": "string",
                     "const": "csc",
                     "description": "Type of the KMS provider.",
-                    "examples": [
-                      "csc"
-                    ]
+                    "examples": ["csc"]
                   },
                   "description": {
                     "description": "Human-readable description of this provider instance.",
-                    "examples": [
-                      "Production HashiCorp Vault for signing keys"
-                    ],
+                    "examples": ["Production HashiCorp Vault for signing keys"],
                     "anyOf": [
                       {
                         "type": "string",
@@ -10585,9 +9283,7 @@
                       }
                     ],
                     "description": "Base URL of the CSC service (without trailing slash). Supports ${ENV_VAR} placeholders.",
-                    "examples": [
-                      "${CSC_URL}"
-                    ]
+                    "examples": ["${CSC_URL}"]
                   },
                   "tokenUrl": {
                     "anyOf": [
@@ -10601,9 +9297,7 @@
                       }
                     ],
                     "description": "OAuth2 token endpoint URL for client-credentials flow. Supports ${ENV_VAR} placeholders.",
-                    "examples": [
-                      "${CSC_TOKEN_URL}"
-                    ]
+                    "examples": ["${CSC_TOKEN_URL}"]
                   },
                   "clientId": {
                     "anyOf": [
@@ -10617,9 +9311,7 @@
                       }
                     ],
                     "description": "OAuth2 client ID. Supports ${ENV_VAR} placeholders.",
-                    "examples": [
-                      "${CSC_CLIENT_ID}"
-                    ]
+                    "examples": ["${CSC_CLIENT_ID}"]
                   },
                   "clientSecret": {
                     "anyOf": [
@@ -10633,15 +9325,11 @@
                       }
                     ],
                     "description": "OAuth2 client secret. Supports ${ENV_VAR} placeholders.",
-                    "examples": [
-                      "${CSC_CLIENT_SECRET}"
-                    ]
+                    "examples": ["${CSC_CLIENT_SECRET}"]
                   },
                   "scope": {
                     "description": "OAuth2 scope to request during token acquisition.",
-                    "examples": [
-                      "service"
-                    ],
+                    "examples": ["service"],
                     "anyOf": [
                       {
                         "type": "string",
@@ -10655,9 +9343,7 @@
                   },
                   "credentialId": {
                     "description": "Default CSC credential ID. If omitted, the adapter calls credentials/list and picks the first entry.",
-                    "examples": [
-                      "[INTESIQCSEALEC]_SEAL_351_SIGN_1781018892758"
-                    ],
+                    "examples": ["[INTESIQCSEALEC]_SEAL_351_SIGN_1781018892758"],
                     "anyOf": [
                       {
                         "type": "string",
@@ -10671,9 +9357,7 @@
                   },
                   "userId": {
                     "description": "Optional CSC user ID used in credentials/list requests.",
-                    "examples": [
-                      "eudiplo_user"
-                    ],
+                    "examples": ["eudiplo_user"],
                     "anyOf": [
                       {
                         "type": "string",
@@ -10687,9 +9371,7 @@
                   },
                   "apiPath": {
                     "description": "CSC API path prefix appended to baseUrl. Defaults to /csc/v2.",
-                    "examples": [
-                      "/csc/v2"
-                    ],
+                    "examples": ["/csc/v2"],
                     "anyOf": [
                       {
                         "type": "string",
@@ -10703,9 +9385,7 @@
                   },
                   "hashAlgorithmOid": {
                     "description": "Hash algorithm OID for signatures/signHash and credentials/authorize. Defaults to SHA-256 OID.",
-                    "examples": [
-                      "2.16.840.1.101.3.4.2.1"
-                    ],
+                    "examples": ["2.16.840.1.101.3.4.2.1"],
                     "anyOf": [
                       {
                         "type": "string",
@@ -10719,9 +9399,7 @@
                   },
                   "signAlgorithmOid": {
                     "description": "Signature algorithm OID for signatures/signHash. Defaults to ecdsa-with-SHA256 OID.",
-                    "examples": [
-                      "1.2.840.10045.4.3.2"
-                    ],
+                    "examples": ["1.2.840.10045.4.3.2"],
                     "anyOf": [
                       {
                         "type": "string",
@@ -10748,9 +9426,7 @@
                   },
                   "useAuthorizeEndpoint": {
                     "description": "When true and no static SAD is provided, the adapter calls credentials/authorize to obtain SAD before signatures/signHash.",
-                    "examples": [
-                      false
-                    ],
+                    "examples": [false],
                     "type": "boolean"
                   },
                   "authorizeAuthData": {
@@ -10771,9 +9447,7 @@
                             }
                           ],
                           "description": "Authentication factor identifier expected by the CSC provider (e.g., PIN, OTP).",
-                          "examples": [
-                            "PIN"
-                          ]
+                          "examples": ["PIN"]
                         },
                         "value": {
                           "anyOf": [
@@ -10787,27 +9461,15 @@
                             }
                           ],
                           "description": "Authentication factor value sent to CSC credentials/authorize.",
-                          "examples": [
-                            "123456"
-                          ]
+                          "examples": ["123456"]
                         }
                       },
-                      "required": [
-                        "id",
-                        "value"
-                      ],
+                      "required": ["id", "value"],
                       "additionalProperties": false
                     }
                   }
                 },
-                "required": [
-                  "id",
-                  "type",
-                  "baseUrl",
-                  "tokenUrl",
-                  "clientId",
-                  "clientSecret"
-                ],
+                "required": ["id", "type", "baseUrl", "tokenUrl", "clientId", "clientSecret"],
                 "additionalProperties": false
               }
             ]
@@ -10837,9 +9499,7 @@
           ]
         }
       },
-      "required": [
-        "providers"
-      ],
+      "required": ["providers"],
       "additionalProperties": false,
       "$id": "./KmsConfigDto.schema.json",
       "title": "KmsConfigDto"
@@ -10847,9 +9507,7 @@
   },
   {
     "uri": "./PresentationConfigCreateDto.schema.json",
-    "fileMatch": [
-      "a://b/PresentationConfigCreateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/PresentationConfigCreateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -10885,11 +9543,7 @@
         "statusCheckMode": {
           "description": "Revocation/status check mode.",
           "type": "string",
-          "enum": [
-            "strict",
-            "best_effort",
-            "disabled"
-          ]
+          "enum": ["strict", "best_effort", "disabled"]
         },
         "dcql_query": {
           "type": "object",
@@ -10975,10 +9629,7 @@
                                   "description": "Trust list references for ETSI TL verification."
                                 }
                               },
-                              "required": [
-                                "type",
-                                "values"
-                              ],
+                              "required": ["type", "values"],
                               "additionalProperties": false
                             },
                             {
@@ -10997,10 +9648,7 @@
                                   "description": "OpenID Federation authority identifiers."
                                 }
                               },
-                              "required": [
-                                "type",
-                                "values"
-                              ],
+                              "required": ["type", "values"],
                               "additionalProperties": false
                             }
                           ]
@@ -11023,9 +9671,7 @@
                             "description": "Accepted VCT values."
                           }
                         },
-                        "required": [
-                          "vct_values"
-                        ],
+                        "required": ["vct_values"],
                         "additionalProperties": false
                       },
                       "claims": {
@@ -11060,18 +9706,12 @@
                               }
                             }
                           },
-                          "required": [
-                            "path"
-                          ],
+                          "required": ["path"],
                           "additionalProperties": false
                         }
                       }
                     },
-                    "required": [
-                      "id",
-                      "format",
-                      "meta"
-                    ],
+                    "required": ["id", "format", "meta"],
                     "additionalProperties": false
                   },
                   {
@@ -11150,10 +9790,7 @@
                                   "description": "Trust list references for ETSI TL verification."
                                 }
                               },
-                              "required": [
-                                "type",
-                                "values"
-                              ],
+                              "required": ["type", "values"],
                               "additionalProperties": false
                             },
                             {
@@ -11172,10 +9809,7 @@
                                   "description": "OpenID Federation authority identifiers."
                                 }
                               },
-                              "required": [
-                                "type",
-                                "values"
-                              ],
+                              "required": ["type", "values"],
                               "additionalProperties": false
                             }
                           ]
@@ -11195,9 +9829,7 @@
                             "description": "Expected mDoc doctype value."
                           }
                         },
-                        "required": [
-                          "doctype_value"
-                        ],
+                        "required": ["doctype_value"],
                         "additionalProperties": false
                       },
                       "claims": {
@@ -11236,18 +9868,12 @@
                               "type": "boolean"
                             }
                           },
-                          "required": [
-                            "path"
-                          ],
+                          "required": ["path"],
                           "additionalProperties": false
                         }
                       }
                     },
-                    "required": [
-                      "id",
-                      "format",
-                      "meta"
-                    ],
+                    "required": ["id", "format", "meta"],
                     "additionalProperties": false
                   }
                 ]
@@ -11277,16 +9903,12 @@
                     "type": "boolean"
                   }
                 },
-                "required": [
-                  "options"
-                ],
+                "required": ["options"],
                 "additionalProperties": false
               }
             }
           },
-          "required": [
-            "credentials"
-          ],
+          "required": ["credentials"],
           "additionalProperties": false,
           "description": "DCQL query defining requested credentials and claims."
         },
@@ -11308,10 +9930,7 @@
                 "description": "Credential query ids this transaction data applies to."
               }
             },
-            "required": [
-              "type",
-              "credential_ids"
-            ],
+            "required": ["type", "credential_ids"],
             "additionalProperties": {}
           }
         },
@@ -11348,10 +9967,7 @@
                             "type": "string"
                           }
                         },
-                        "required": [
-                          "lang",
-                          "content"
-                        ],
+                        "required": ["lang", "content"],
                         "additionalProperties": false
                       }
                     },
@@ -11423,10 +10039,7 @@
                     }
                   }
                 },
-                "required": [
-                  "format",
-                  "data"
-                ],
+                "required": ["format", "data"],
                 "additionalProperties": false
               }
             },
@@ -11469,10 +10082,7 @@
           ]
         }
       },
-      "required": [
-        "id",
-        "dcql_query"
-      ],
+      "required": ["id", "dcql_query"],
       "additionalProperties": false,
       "$id": "./PresentationConfigCreateDto.schema.json",
       "title": "PresentationConfigCreateDto"
@@ -11480,9 +10090,7 @@
   },
   {
     "uri": "./RotationPolicyCreateDto.schema.json",
-    "fileMatch": [
-      "a://b/RotationPolicyCreateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/RotationPolicyCreateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -11504,9 +10112,7 @@
           "maximum": 3650
         }
       },
-      "required": [
-        "enabled"
-      ],
+      "required": ["enabled"],
       "additionalProperties": false,
       "$id": "./RotationPolicyCreateDto.schema.json",
       "title": "RotationPolicyCreateDto"
@@ -11514,9 +10120,7 @@
   },
   {
     "uri": "./RotationPolicyUpdateDto.schema.json",
-    "fileMatch": [
-      "a://b/RotationPolicyUpdateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/RotationPolicyUpdateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -11545,9 +10149,7 @@
   },
   {
     "uri": "./SessionStorageConfig.schema.json",
-    "fileMatch": [
-      "a://b/SessionStorageConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/SessionStorageConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -11561,10 +10163,7 @@
         "cleanupMode": {
           "description": "Whether to fully delete or anonymize expired sessions.",
           "type": "string",
-          "enum": [
-            "full",
-            "anonymize"
-          ]
+          "enum": ["full", "anonymize"]
         }
       },
       "additionalProperties": false,
@@ -11575,9 +10174,7 @@
   },
   {
     "uri": "./StatusListConfig.schema.json",
-    "fileMatch": [
-      "a://b/StatusListConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/StatusListConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -11632,9 +10229,7 @@
   },
   {
     "uri": "./StatusListImportDto.schema.json",
-    "fileMatch": [
-      "a://b/StatusListImportDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/StatusListImportDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -11689,9 +10284,7 @@
           ]
         }
       },
-      "required": [
-        "id"
-      ],
+      "required": ["id"],
       "additionalProperties": false,
       "$id": "./StatusListImportDto.schema.json",
       "title": "StatusListImportDto"
@@ -11699,9 +10292,7 @@
   },
   {
     "uri": "./TransactionData.schema.json",
-    "fileMatch": [
-      "a://b/TransactionData*.schema.json"
-    ],
+    "fileMatch": ["a://b/TransactionData*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -11718,10 +10309,7 @@
           "description": "Credential query ids this transaction data applies to."
         }
       },
-      "required": [
-        "type",
-        "credential_ids"
-      ],
+      "required": ["type", "credential_ids"],
       "additionalProperties": {},
       "$id": "./TransactionData.schema.json",
       "title": "TransactionData"
@@ -11729,9 +10317,7 @@
   },
   {
     "uri": "./TrustListCreateDto.schema.json",
-    "fileMatch": [
-      "a://b/TrustListCreateDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/TrustListCreateDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -11814,19 +10400,12 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "name"
-                    ],
+                    "required": ["name"],
                     "additionalProperties": false,
                     "description": "Entity metadata."
                   }
                 },
-                "required": [
-                  "type",
-                  "issuerKeyChainId",
-                  "revocationKeyChainId",
-                  "info"
-                ],
+                "required": ["type", "issuerKeyChainId", "revocationKeyChainId", "info"],
                 "additionalProperties": false
               },
               {
@@ -11888,19 +10467,12 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "name"
-                    ],
+                    "required": ["name"],
                     "additionalProperties": false,
                     "description": "Entity metadata."
                   }
                 },
-                "required": [
-                  "type",
-                  "issuerCertPem",
-                  "revocationCertPem",
-                  "info"
-                ],
+                "required": ["type", "issuerCertPem", "revocationCertPem", "info"],
                 "additionalProperties": false
               }
             ]
@@ -11916,9 +10488,7 @@
           "additionalProperties": {}
         }
       },
-      "required": [
-        "entities"
-      ],
+      "required": ["entities"],
       "additionalProperties": false,
       "$id": "./TrustListCreateDto.schema.json",
       "title": "TrustListCreateDto"
@@ -11926,9 +10496,7 @@
   },
   {
     "uri": "./UpdateAttributeProviderDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateAttributeProviderDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateAttributeProviderDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -11971,9 +10539,7 @@
                   "description": "Disable authentication for attribute provider calls."
                 }
               },
-              "required": [
-                "type"
-              ],
+              "required": ["type"],
               "additionalProperties": false,
               "description": "No authentication variant."
             },
@@ -11999,18 +10565,12 @@
                       "description": "API key value."
                     }
                   },
-                  "required": [
-                    "headerName",
-                    "value"
-                  ],
+                  "required": ["headerName", "value"],
                   "additionalProperties": false,
                   "description": "API key authentication settings."
                 }
               },
-              "required": [
-                "type",
-                "config"
-              ],
+              "required": ["type", "config"],
               "additionalProperties": false,
               "description": "API key authentication variant."
             }
@@ -12025,9 +10585,7 @@
   },
   {
     "uri": "./UpdateClientDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateClientDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateClientDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -12093,9 +10651,7 @@
   },
   {
     "uri": "./UpdateStatusListConfigDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateStatusListConfigDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateStatusListConfigDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -12184,9 +10740,7 @@
   },
   {
     "uri": "./UpdateStatusListDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateStatusListDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateStatusListDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -12223,9 +10777,7 @@
   },
   {
     "uri": "./UpdateTenantDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateTenantDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateTenantDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -12260,10 +10812,7 @@
             "cleanupMode": {
               "description": "Whether to fully delete or anonymize expired sessions.",
               "type": "string",
-              "enum": [
-                "full",
-                "anonymize"
-              ]
+              "enum": ["full", "anonymize"]
             }
           },
           "additionalProperties": false
@@ -12325,9 +10874,7 @@
   },
   {
     "uri": "./UpdateWebhookEndpointDto.schema.json",
-    "fileMatch": [
-      "a://b/UpdateWebhookEndpointDto*.schema.json"
-    ],
+    "fileMatch": ["a://b/UpdateWebhookEndpointDto*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -12370,9 +10917,7 @@
                   "description": "Disable webhook authentication."
                 }
               },
-              "required": [
-                "type"
-              ],
+              "required": ["type"],
               "additionalProperties": false,
               "description": "No webhook authentication variant."
             },
@@ -12398,18 +10943,12 @@
                       "description": "API key value sent with webhook requests."
                     }
                   },
-                  "required": [
-                    "headerName",
-                    "value"
-                  ],
+                  "required": ["headerName", "value"],
                   "additionalProperties": false,
                   "description": "API key webhook authentication settings."
                 }
               },
-              "required": [
-                "type",
-                "config"
-              ],
+              "required": ["type", "config"],
               "additionalProperties": false,
               "description": "API key webhook authentication variant."
             }
@@ -12424,9 +10963,7 @@
   },
   {
     "uri": "./VCT.schema.json",
-    "fileMatch": [
-      "a://b/VCT*.schema.json"
-    ],
+    "fileMatch": ["a://b/VCT*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -12467,9 +11004,7 @@
   },
   {
     "uri": "./WebhookConfig.schema.json",
-    "fileMatch": [
-      "a://b/WebhookConfig*.schema.json"
-    ],
+    "fileMatch": ["a://b/WebhookConfig*.schema.json"],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -12490,9 +11025,7 @@
                   "description": "Disable authentication."
                 }
               },
-              "required": [
-                "type"
-              ],
+              "required": ["type"],
               "additionalProperties": false
             },
             {
@@ -12517,18 +11050,12 @@
                       "description": "The API key value."
                     }
                   },
-                  "required": [
-                    "headerName",
-                    "value"
-                  ],
+                  "required": ["headerName", "value"],
                   "additionalProperties": false,
                   "description": "API key authentication settings."
                 }
               },
-              "required": [
-                "type",
-                "config"
-              ],
+              "required": ["type", "config"],
               "additionalProperties": false
             }
           ],
@@ -12542,10 +11069,7 @@
           }
         }
       },
-      "required": [
-        "url",
-        "auth"
-      ],
+      "required": ["url", "auth"],
       "additionalProperties": false,
       "$id": "./WebhookConfig.schema.json",
       "title": "WebhookConfig"

--- a/apps/client/src/app/utils/schemas.json
+++ b/apps/client/src/app/utils/schemas.json
@@ -1,7 +1,9 @@
 [
   {
     "uri": "./GrafanaConfigDto.schema.json",
-    "fileMatch": ["a://b/GrafanaConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/GrafanaConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./GrafanaConfigDto.schema.json",
@@ -24,13 +26,18 @@
           "example": "loki"
         }
       },
-      "required": ["tempoUid", "lokiUid"],
+      "required": [
+        "tempoUid",
+        "lokiUid"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./FrontendConfigResponseDto.schema.json",
-    "fileMatch": ["a://b/FrontendConfigResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/FrontendConfigResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./FrontendConfigResponseDto.schema.json",
@@ -46,13 +53,17 @@
           ]
         }
       },
-      "required": ["grafana"],
+      "required": [
+        "grafana"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./RoleDto.schema.json",
-    "fileMatch": ["a://b/RoleDto*.schema.json"],
+    "fileMatch": [
+      "a://b/RoleDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./RoleDto.schema.json",
@@ -75,13 +86,17 @@
           "example": "issuance:manage"
         }
       },
-      "required": ["role"],
+      "required": [
+        "role"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./ClientCredentialsDto.schema.json",
-    "fileMatch": ["a://b/ClientCredentialsDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ClientCredentialsDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./ClientCredentialsDto.schema.json",
@@ -101,13 +116,18 @@
           "minLength": 1
         }
       },
-      "required": ["client_id", "client_secret"],
+      "required": [
+        "client_id",
+        "client_secret"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./TokenResponse.schema.json",
-    "fileMatch": ["a://b/TokenResponse*.schema.json"],
+    "fileMatch": [
+      "a://b/TokenResponse*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./TokenResponse.schema.json",
@@ -130,13 +150,20 @@
           "type": "string"
         }
       },
-      "required": ["access_token", "token_type", "expires_in", "state"],
+      "required": [
+        "access_token",
+        "token_type",
+        "expires_in",
+        "state"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./TenantEntity.schema.json",
-    "fileMatch": ["a://b/TenantEntity*.schema.json"],
+    "fileMatch": [
+      "a://b/TenantEntity*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./TenantEntity.schema.json",
@@ -187,13 +214,20 @@
           }
         }
       },
-      "required": ["id", "name", "status", "clients"],
+      "required": [
+        "id",
+        "name",
+        "status",
+        "clients"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./ClientEntity.schema.json",
-    "fileMatch": ["a://b/ClientEntity*.schema.json"],
+    "fileMatch": [
+      "a://b/ClientEntity*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./ClientEntity.schema.json",
@@ -203,7 +237,10 @@
         "allowedPresentationConfigs": {
           "nullable": true,
           "description": "List of presentation config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": ["age-verification", "kyc-basic"],
+          "example": [
+            "age-verification",
+            "kyc-basic"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -212,7 +249,10 @@
         "allowedIssuanceConfigs": {
           "nullable": true,
           "description": "List of issuance config IDs this client can use. If empty/null, all configs are allowed.",
-          "example": ["pid", "mdl"],
+          "example": [
+            "pid",
+            "mdl"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -260,13 +300,18 @@
           ]
         }
       },
-      "required": ["clientId", "roles"],
+      "required": [
+        "clientId",
+        "roles"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./AuditLogResponseDto.schema.json",
-    "fileMatch": ["a://b/AuditLogResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/AuditLogResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./AuditLogResponseDto.schema.json",
@@ -303,7 +348,11 @@
           "type": "string"
         },
         "actorType": {
-          "enum": ["user", "client", "system"],
+          "enum": [
+            "user",
+            "client",
+            "system"
+          ],
           "type": "string"
         },
         "actorId": {
@@ -334,13 +383,21 @@
           "type": "string"
         }
       },
-      "required": ["id", "tenantId", "actionType", "actorType", "timestamp"],
+      "required": [
+        "id",
+        "tenantId",
+        "actionType",
+        "actorType",
+        "timestamp"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./ClientSecretResponseDto.schema.json",
-    "fileMatch": ["a://b/ClientSecretResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ClientSecretResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./ClientSecretResponseDto.schema.json",
@@ -351,13 +408,17 @@
           "type": "string"
         }
       },
-      "required": ["secret"],
+      "required": [
+        "secret"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./StatusListAggregationDto.schema.json",
-    "fileMatch": ["a://b/StatusListAggregationDto*.schema.json"],
+    "fileMatch": [
+      "a://b/StatusListAggregationDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./StatusListAggregationDto.schema.json",
@@ -376,13 +437,17 @@
           }
         }
       },
-      "required": ["status_lists"],
+      "required": [
+        "status_lists"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./StatusListResponseDto.schema.json",
-    "fileMatch": ["a://b/StatusListResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/StatusListResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./StatusListResponseDto.schema.json",
@@ -413,7 +478,12 @@
         },
         "bits": {
           "description": "Bits per status value",
-          "enum": [1, 2, 4, 8],
+          "enum": [
+            1,
+            2,
+            4,
+            8
+          ],
           "type": "number",
           "example": 1
         },
@@ -466,7 +536,9 @@
   },
   {
     "uri": "./AuthorizeQueries.schema.json",
-    "fileMatch": ["a://b/AuthorizeQueries*.schema.json"],
+    "fileMatch": [
+      "a://b/AuthorizeQueries*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./AuthorizeQueries.schema.json",
@@ -527,7 +599,9 @@
   },
   {
     "uri": "./OfferRequestDto.schema.json",
-    "fileMatch": ["a://b/OfferRequestDto*.schema.json"],
+    "fileMatch": [
+      "a://b/OfferRequestDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./OfferRequestDto.schema.json",
@@ -549,7 +623,11 @@
               "const": "iso-18013-7"
             }
           ],
-          "enum": ["uri", "dc-api", "iso-18013-7"],
+          "enum": [
+            "uri",
+            "dc-api",
+            "iso-18013-7"
+          ],
           "examples": [
             {
               "value": "qrcode"
@@ -574,14 +652,19 @@
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": ["inline"]
+                    "enum": [
+                      "inline"
+                    ]
                   },
                   "claims": {
                     "type": "object",
                     "additionalProperties": true
                   }
                 },
-                "required": ["type", "claims"],
+                "required": [
+                  "type",
+                  "claims"
+                ],
                 "additionalProperties": false
               },
               {
@@ -589,13 +672,18 @@
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": ["attributeProvider"]
+                    "enum": [
+                      "attributeProvider"
+                    ]
                   },
                   "attributeProviderId": {
                     "type": "string"
                   }
                 },
-                "required": ["type", "attributeProviderId"],
+                "required": [
+                  "type",
+                  "attributeProviderId"
+                ],
                 "additionalProperties": false
               },
               {
@@ -603,7 +691,9 @@
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": ["webhook"]
+                    "enum": [
+                      "webhook"
+                    ]
                   },
                   "webhook": {
                     "type": "object",
@@ -615,11 +705,16 @@
                         "type": "object"
                       }
                     },
-                    "required": ["url"],
+                    "required": [
+                      "url"
+                    ],
                     "additionalProperties": false
                   }
                 },
-                "required": ["type", "webhook"],
+                "required": [
+                  "type",
+                  "webhook"
+                ],
                 "additionalProperties": false
               }
             ]
@@ -647,7 +742,10 @@
             }
           ],
           "description": "The flow type for the offer request.",
-          "enum": ["authorization_code", "pre_authorized_code"]
+          "enum": [
+            "authorization_code",
+            "pre_authorized_code"
+          ]
         },
         "tx_code": {
           "type": "string",
@@ -669,13 +767,19 @@
           "description": "ID of the webhook endpoint to notify about the status of the issuance process."
         }
       },
-      "required": ["response_type", "flow", "credentialConfigurationIds"],
+      "required": [
+        "response_type",
+        "flow",
+        "credentialConfigurationIds"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./WebHookAuthConfigNone.schema.json",
-    "fileMatch": ["a://b/WebHookAuthConfigNone*.schema.json"],
+    "fileMatch": [
+      "a://b/WebHookAuthConfigNone*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./WebHookAuthConfigNone.schema.json",
@@ -689,13 +793,17 @@
           "enum": []
         }
       },
-      "required": ["type"],
+      "required": [
+        "type"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./ApiKeyConfig.schema.json",
-    "fileMatch": ["a://b/ApiKeyConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/ApiKeyConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./ApiKeyConfig.schema.json",
@@ -711,13 +819,18 @@
           "description": "The value of the API key to be sent in the header."
         }
       },
-      "required": ["headerName", "value"],
+      "required": [
+        "headerName",
+        "value"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./WebHookAuthConfigHeader.schema.json",
-    "fileMatch": ["a://b/WebHookAuthConfigHeader*.schema.json"],
+    "fileMatch": [
+      "a://b/WebHookAuthConfigHeader*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./WebHookAuthConfigHeader.schema.json",
@@ -748,13 +861,18 @@
           ]
         }
       },
-      "required": ["type", "config"],
+      "required": [
+        "type",
+        "config"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./Session.schema.json",
-    "fileMatch": ["a://b/Session*.schema.json"],
+    "fileMatch": [
+      "a://b/Session*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./Session.schema.json",
@@ -763,7 +881,13 @@
       "properties": {
         "status": {
           "description": "Status of the session.",
-          "enum": ["active", "fetched", "completed", "expired", "failed"],
+          "enum": [
+            "active",
+            "fetched",
+            "completed",
+            "expired",
+            "failed"
+          ],
           "type": "string"
         },
         "id": {
@@ -969,7 +1093,9 @@
   },
   {
     "uri": "./PaginatedSessionResponseDto.schema.json",
-    "fileMatch": ["a://b/PaginatedSessionResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/PaginatedSessionResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./PaginatedSessionResponseDto.schema.json",
@@ -1000,13 +1126,21 @@
           "description": "Total number of pages"
         }
       },
-      "required": ["items", "total", "page", "pageSize", "totalPages"],
+      "required": [
+        "items",
+        "total",
+        "page",
+        "pageSize",
+        "totalPages"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./SessionLogEntryResponseDto.schema.json",
-    "fileMatch": ["a://b/SessionLogEntryResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/SessionLogEntryResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./SessionLogEntryResponseDto.schema.json",
@@ -1029,7 +1163,11 @@
         "level": {
           "type": "string",
           "description": "Log level",
-          "enum": ["info", "warn", "error"]
+          "enum": [
+            "info",
+            "warn",
+            "error"
+          ]
         },
         "stage": {
           "type": "string",
@@ -1045,13 +1183,21 @@
           "description": "Additional structured detail"
         }
       },
-      "required": ["id", "sessionId", "timestamp", "level", "message"],
+      "required": [
+        "id",
+        "sessionId",
+        "timestamp",
+        "level",
+        "message"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./StatusUpdateDto.schema.json",
-    "fileMatch": ["a://b/StatusUpdateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/StatusUpdateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./StatusUpdateDto.schema.json",
@@ -1075,13 +1221,18 @@
           "description": "New credential status: 0 = valid, 1 = revoked, 2 = suspended."
         }
       },
-      "required": ["sessionId", "status"],
+      "required": [
+        "sessionId",
+        "status"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./UpdateSessionConfigDto.schema.json",
-    "fileMatch": ["a://b/UpdateSessionConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateSessionConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./UpdateSessionConfigDto.schema.json",
@@ -1106,7 +1257,10 @@
         },
         "cleanupMode": {
           "type": "string",
-          "enum": ["full", "anonymize"],
+          "enum": [
+            "full",
+            "anonymize"
+          ],
           "description": "Cleanup mode: 'full' deletes everything, 'anonymize' keeps metadata but removes PII.",
           "default": "full"
         }
@@ -1116,7 +1270,9 @@
   },
   {
     "uri": "./ManagedUserDto.schema.json",
-    "fileMatch": ["a://b/ManagedUserDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ManagedUserDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./ManagedUserDto.schema.json",
@@ -1165,13 +1321,20 @@
           "description": "One-time temporary password returned only on user creation."
         }
       },
-      "required": ["id", "username", "enabled", "roles"],
+      "required": [
+        "id",
+        "username",
+        "enabled",
+        "roles"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./CreateUserDto.schema.json",
-    "fileMatch": ["a://b/CreateUserDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CreateUserDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./CreateUserDto.schema.json",
@@ -1207,13 +1370,18 @@
           "type": "boolean"
         }
       },
-      "required": ["username", "roles"],
+      "required": [
+        "username",
+        "roles"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./UpdateUserDto.schema.json",
-    "fileMatch": ["a://b/UpdateUserDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateUserDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./UpdateUserDto.schema.json",
@@ -1258,7 +1426,9 @@
   },
   {
     "uri": "./AuthenticationMethodNone.schema.json",
-    "fileMatch": ["a://b/AuthenticationMethodNone*.schema.json"],
+    "fileMatch": [
+      "a://b/AuthenticationMethodNone*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./AuthenticationMethodNone.schema.json",
@@ -1270,13 +1440,17 @@
           "const": "none"
         }
       },
-      "required": ["method"],
+      "required": [
+        "method"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./AuthenticationUrlConfig.schema.json",
-    "fileMatch": ["a://b/AuthenticationUrlConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/AuthenticationUrlConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./AuthenticationUrlConfig.schema.json",
@@ -1302,7 +1476,9 @@
                       "const": "none"
                     }
                   },
-                  "required": ["type"],
+                  "required": [
+                    "type"
+                  ],
                   "additionalProperties": false
                 },
                 {
@@ -1322,11 +1498,17 @@
                           "type": "string"
                         }
                       },
-                      "required": ["headerName", "value"],
+                      "required": [
+                        "headerName",
+                        "value"
+                      ],
                       "additionalProperties": false
                     }
                   },
-                  "required": ["type", "config"],
+                  "required": [
+                    "type",
+                    "config"
+                  ],
                   "additionalProperties": false
                 }
               ]
@@ -1347,13 +1529,17 @@
           ]
         }
       },
-      "required": ["url"],
+      "required": [
+        "url"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./AuthenticationMethodAuth.schema.json",
-    "fileMatch": ["a://b/AuthenticationMethodAuth*.schema.json"],
+    "fileMatch": [
+      "a://b/AuthenticationMethodAuth*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./AuthenticationMethodAuth.schema.json",
@@ -1385,7 +1571,9 @@
                           "const": "none"
                         }
                       },
-                      "required": ["type"],
+                      "required": [
+                        "type"
+                      ],
                       "additionalProperties": false
                     },
                     {
@@ -1405,11 +1593,17 @@
                               "type": "string"
                             }
                           },
-                          "required": ["headerName", "value"],
+                          "required": [
+                            "headerName",
+                            "value"
+                          ],
                           "additionalProperties": false
                         }
                       },
-                      "required": ["type", "config"],
+                      "required": [
+                        "type",
+                        "config"
+                      ],
                       "additionalProperties": false
                     }
                   ]
@@ -1421,7 +1615,10 @@
                   }
                 }
               },
-              "required": ["url", "auth"],
+              "required": [
+                "url",
+                "auth"
+              ],
               "additionalProperties": false
             }
           },
@@ -1433,13 +1630,18 @@
           ]
         }
       },
-      "required": ["method", "config"],
+      "required": [
+        "method",
+        "config"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./PresentationDuringIssuanceConfig.schema.json",
-    "fileMatch": ["a://b/PresentationDuringIssuanceConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/PresentationDuringIssuanceConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./PresentationDuringIssuanceConfig.schema.json",
@@ -1451,13 +1653,17 @@
           "description": "Link to the presentation configuration that is relevant for the issuance process"
         }
       },
-      "required": ["type"],
+      "required": [
+        "type"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./AuthenticationMethodPresentation.schema.json",
-    "fileMatch": ["a://b/AuthenticationMethodPresentation*.schema.json"],
+    "fileMatch": [
+      "a://b/AuthenticationMethodPresentation*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./AuthenticationMethodPresentation.schema.json",
@@ -1482,13 +1688,18 @@
           ]
         }
       },
-      "required": ["method", "config"],
+      "required": [
+        "method",
+        "config"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./ManagedAuthorizationServerConfig.schema.json",
-    "fileMatch": ["a://b/ManagedAuthorizationServerConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/ManagedAuthorizationServerConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./ManagedAuthorizationServerConfig.schema.json",
@@ -1497,7 +1708,12 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["external", "oid4vp", "chained", "built-in"],
+          "enum": [
+            "external",
+            "oid4vp",
+            "chained",
+            "built-in"
+          ],
           "description": "Authorization server implementation type",
           "example": "external"
         },
@@ -1517,13 +1733,18 @@
           "default": true
         }
       },
-      "required": ["type", "id"],
+      "required": [
+        "type",
+        "id"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./ExternalAuthorizationServerConfig.schema.json",
-    "fileMatch": ["a://b/ExternalAuthorizationServerConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/ExternalAuthorizationServerConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./ExternalAuthorizationServerConfig.schema.json",
@@ -1534,7 +1755,9 @@
           "type": "string",
           "const": "external",
           "description": "Authorization server implementation type",
-          "enum": ["external"],
+          "enum": [
+            "external"
+          ],
           "example": "external"
         },
         "id": {
@@ -1554,13 +1777,19 @@
           "type": "boolean"
         }
       },
-      "required": ["type", "id", "issuer"],
+      "required": [
+        "type",
+        "id",
+        "issuer"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./ChainedAsTokenConfig.schema.json",
-    "fileMatch": ["a://b/ChainedAsTokenConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/ChainedAsTokenConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./ChainedAsTokenConfig.schema.json",
@@ -1594,7 +1823,9 @@
   },
   {
     "uri": "./Oid4VpAuthorizationServerConfig.schema.json",
-    "fileMatch": ["a://b/Oid4VpAuthorizationServerConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/Oid4VpAuthorizationServerConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./Oid4VpAuthorizationServerConfig.schema.json",
@@ -1605,7 +1836,9 @@
           "type": "string",
           "const": "oid4vp",
           "description": "Authorization server implementation type",
-          "enum": ["oid4vp"],
+          "enum": [
+            "oid4vp"
+          ],
           "example": "oid4vp"
         },
         "id": {
@@ -1660,13 +1893,19 @@
           "type": "boolean"
         }
       },
-      "required": ["type", "id", "presentationConfigId"],
+      "required": [
+        "type",
+        "id",
+        "presentationConfigId"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./UpstreamOidcConfig.schema.json",
-    "fileMatch": ["a://b/UpstreamOidcConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/UpstreamOidcConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./UpstreamOidcConfig.schema.json",
@@ -1692,17 +1931,25 @@
             "type": "string"
           },
           "description": "Scopes to request from the upstream provider",
-          "default": ["openid", "profile"],
+          "default": [
+            "openid",
+            "profile"
+          ],
           "type": "array"
         }
       },
-      "required": ["issuer", "clientId"],
+      "required": [
+        "issuer",
+        "clientId"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./ChainedAuthorizationServerConfig.schema.json",
-    "fileMatch": ["a://b/ChainedAuthorizationServerConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/ChainedAuthorizationServerConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./ChainedAuthorizationServerConfig.schema.json",
@@ -1713,7 +1960,9 @@
           "type": "string",
           "const": "chained",
           "description": "Authorization server implementation type",
-          "enum": ["chained"],
+          "enum": [
+            "chained"
+          ],
           "example": "chained"
         },
         "id": {
@@ -1784,13 +2033,19 @@
           "type": "boolean"
         }
       },
-      "required": ["type", "id", "upstream"],
+      "required": [
+        "type",
+        "id",
+        "upstream"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./BuiltInAuthorizationServerConfig.schema.json",
-    "fileMatch": ["a://b/BuiltInAuthorizationServerConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/BuiltInAuthorizationServerConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./BuiltInAuthorizationServerConfig.schema.json",
@@ -1801,7 +2056,9 @@
           "type": "string",
           "const": "built-in",
           "description": "Authorization server implementation type",
-          "enum": ["built-in"],
+          "enum": [
+            "built-in"
+          ],
           "example": "built-in"
         },
         "id": {
@@ -1846,13 +2103,18 @@
           "type": "boolean"
         }
       },
-      "required": ["type", "id"],
+      "required": [
+        "type",
+        "id"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./WalletProviderTrustListRefDto.schema.json",
-    "fileMatch": ["a://b/WalletProviderTrustListRefDto*.schema.json"],
+    "fileMatch": [
+      "a://b/WalletProviderTrustListRefDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./WalletProviderTrustListRefDto.schema.json",
@@ -1873,13 +2135,17 @@
           "description": "Base64 DER-encoded X.509 certificate used to verify the trust-list JWT signature."
         }
       },
-      "required": ["url"],
+      "required": [
+        "url"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./FederationTrustAnchorConfig.schema.json",
-    "fileMatch": ["a://b/FederationTrustAnchorConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/FederationTrustAnchorConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./FederationTrustAnchorConfig.schema.json",
@@ -1897,13 +2163,18 @@
           "example": "https://ta.example.org/.well-known/openid-federation"
         }
       },
-      "required": ["entityId", "entityConfigurationUri"],
+      "required": [
+        "entityId",
+        "entityConfigurationUri"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./FederationConfig.schema.json",
-    "fileMatch": ["a://b/FederationConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/FederationConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./FederationConfig.schema.json",
@@ -1912,13 +2183,20 @@
       "properties": {
         "role": {
           "type": "string",
-          "enum": ["trust_anchor", "intermediate", "leaf"],
+          "enum": [
+            "trust_anchor",
+            "intermediate",
+            "leaf"
+          ],
           "description": "Role this tenant plays in the OpenID Federation topology.",
           "default": "leaf"
         },
         "mode": {
           "type": "string",
-          "enum": ["federation-only", "hybrid"],
+          "enum": [
+            "federation-only",
+            "hybrid"
+          ],
           "description": "Trust decision strategy when both LoTE trust lists and OpenID Federation are configured.",
           "default": "hybrid"
         },
@@ -1948,20 +2226,27 @@
                 "type": "string"
               }
             },
-            "required": ["entityId", "entityConfigurationUri"],
+            "required": [
+              "entityId",
+              "entityConfigurationUri"
+            ],
             "additionalProperties": false
           },
           "description": "Configured federation trust anchors.",
           "type": "array"
         }
       },
-      "required": ["trustAnchors"],
+      "required": [
+        "trustAnchors"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./IssuerRegistrationCertificateConfig.schema.json",
-    "fileMatch": ["a://b/IssuerRegistrationCertificateConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/IssuerRegistrationCertificateConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./IssuerRegistrationCertificateConfig.schema.json",
@@ -1975,7 +2260,10 @@
         },
         "mode": {
           "type": "string",
-          "enum": ["import", "generate"],
+          "enum": [
+            "import",
+            "generate"
+          ],
           "description": "import: use an existing JWT, generate: create via registrar using attestation data derived from configured credential configurations.",
           "default": "generate"
         },
@@ -1999,7 +2287,9 @@
   },
   {
     "uri": "./IssuerRegistrationCertificateCache.schema.json",
-    "fileMatch": ["a://b/IssuerRegistrationCertificateCache*.schema.json"],
+    "fileMatch": [
+      "a://b/IssuerRegistrationCertificateCache*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./IssuerRegistrationCertificateCache.schema.json",
@@ -2032,7 +2322,9 @@
   },
   {
     "uri": "./DisplayLogo.schema.json",
-    "fileMatch": ["a://b/DisplayLogo*.schema.json"],
+    "fileMatch": [
+      "a://b/DisplayLogo*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./DisplayLogo.schema.json",
@@ -2046,13 +2338,17 @@
           "type": "string"
         }
       },
-      "required": ["uri"],
+      "required": [
+        "uri"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./DisplayInfo.schema.json",
-    "fileMatch": ["a://b/DisplayInfo*.schema.json"],
+    "fileMatch": [
+      "a://b/DisplayInfo*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./DisplayInfo.schema.json",
@@ -2087,7 +2383,9 @@
   },
   {
     "uri": "./UpdateIssuanceDto.schema.json",
-    "fileMatch": ["a://b/UpdateIssuanceDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateIssuanceDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./UpdateIssuanceDto.schema.json",
@@ -2136,7 +2434,12 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["external", "oid4vp", "chained", "built-in"]
+                "enum": [
+                  "external",
+                  "oid4vp",
+                  "chained",
+                  "built-in"
+                ]
               }
             }
           }
@@ -2182,6 +2485,11 @@
           "description": "Whether `credential_request_encryption` should be advertised in the credential issuer metadata.",
           "default": false
         },
+        "notificationEndpointEnabled": {
+          "type": "boolean",
+          "description": "Whether the issuer notification endpoint is enabled and advertised in metadata.",
+          "default": true
+        },
         "txCodeMaxAttempts": {
           "type": "number",
           "description": "Maximum failed tx_code attempts before the pre-authorized code is invalidated. Defaults to 5.",
@@ -2212,7 +2520,9 @@
   },
   {
     "uri": "./ClaimsQuery.schema.json",
-    "fileMatch": ["a://b/ClaimsQuery*.schema.json"],
+    "fileMatch": [
+      "a://b/ClaimsQuery*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./ClaimsQuery.schema.json",
@@ -2235,13 +2545,17 @@
           }
         }
       },
-      "required": ["path"],
+      "required": [
+        "path"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./CredentialSetQuery.schema.json",
-    "fileMatch": ["a://b/CredentialSetQuery*.schema.json"],
+    "fileMatch": [
+      "a://b/CredentialSetQuery*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./CredentialSetQuery.schema.json",
@@ -2261,13 +2575,17 @@
           "type": "boolean"
         }
       },
-      "required": ["options"],
+      "required": [
+        "options"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./PolicyCredential.schema.json",
-    "fileMatch": ["a://b/PolicyCredential*.schema.json"],
+    "fileMatch": [
+      "a://b/PolicyCredential*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./PolicyCredential.schema.json",
@@ -2287,13 +2605,17 @@
           "type": "array"
         }
       },
-      "required": ["credentials"],
+      "required": [
+        "credentials"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./AttestationBasedPolicy.schema.json",
-    "fileMatch": ["a://b/AttestationBasedPolicy*.schema.json"],
+    "fileMatch": [
+      "a://b/AttestationBasedPolicy*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./AttestationBasedPolicy.schema.json",
@@ -2321,19 +2643,26 @@
                 "items": {}
               }
             },
-            "required": ["credentials"],
+            "required": [
+              "credentials"
+            ],
             "additionalProperties": false
           },
           "type": "array"
         }
       },
-      "required": ["policy", "values"],
+      "required": [
+        "policy",
+        "values"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./NoneTrustPolicy.schema.json",
-    "fileMatch": ["a://b/NoneTrustPolicy*.schema.json"],
+    "fileMatch": [
+      "a://b/NoneTrustPolicy*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./NoneTrustPolicy.schema.json",
@@ -2344,13 +2673,17 @@
           "type": "string"
         }
       },
-      "required": ["policy"],
+      "required": [
+        "policy"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./AllowListPolicy.schema.json",
-    "fileMatch": ["a://b/AllowListPolicy*.schema.json"],
+    "fileMatch": [
+      "a://b/AllowListPolicy*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./AllowListPolicy.schema.json",
@@ -2367,13 +2700,18 @@
           }
         }
       },
-      "required": ["policy", "values"],
+      "required": [
+        "policy",
+        "values"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./RootOfTrustPolicy.schema.json",
-    "fileMatch": ["a://b/RootOfTrustPolicy*.schema.json"],
+    "fileMatch": [
+      "a://b/RootOfTrustPolicy*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./RootOfTrustPolicy.schema.json",
@@ -2387,13 +2725,18 @@
           "type": "string"
         }
       },
-      "required": ["policy", "values"],
+      "required": [
+        "policy",
+        "values"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./IaeActionOpenid4vpPresentation.schema.json",
-    "fileMatch": ["a://b/IaeActionOpenid4vpPresentation*.schema.json"],
+    "fileMatch": [
+      "a://b/IaeActionOpenid4vpPresentation*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./IaeActionOpenid4vpPresentation.schema.json",
@@ -2403,7 +2746,9 @@
         "type": {
           "type": "string",
           "const": "openid4vp_presentation",
-          "enum": ["openid4vp_presentation"],
+          "enum": [
+            "openid4vp_presentation"
+          ],
           "description": "Action type discriminator",
           "example": "openid4vp_presentation"
         },
@@ -2416,13 +2761,18 @@
           "type": "string"
         }
       },
-      "required": ["type", "presentationConfigId"],
+      "required": [
+        "type",
+        "presentationConfigId"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./IaeActionRedirectToWeb.schema.json",
-    "fileMatch": ["a://b/IaeActionRedirectToWeb*.schema.json"],
+    "fileMatch": [
+      "a://b/IaeActionRedirectToWeb*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./IaeActionRedirectToWeb.schema.json",
@@ -2432,7 +2782,9 @@
         "type": {
           "type": "string",
           "const": "redirect_to_web",
-          "enum": ["redirect_to_web"],
+          "enum": [
+            "redirect_to_web"
+          ],
           "description": "Action type discriminator",
           "example": "redirect_to_web"
         },
@@ -2457,13 +2809,18 @@
           "type": "string"
         }
       },
-      "required": ["type", "url"],
+      "required": [
+        "type",
+        "url"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./WebhookEndpointEntity.schema.json",
-    "fileMatch": ["a://b/WebhookEndpointEntity*.schema.json"],
+    "fileMatch": [
+      "a://b/WebhookEndpointEntity*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./WebhookEndpointEntity.schema.json",
@@ -2501,13 +2858,22 @@
           "type": "string"
         }
       },
-      "required": ["id", "auth", "tenantId", "tenant", "name", "url"],
+      "required": [
+        "id",
+        "auth",
+        "tenantId",
+        "tenant",
+        "name",
+        "url"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./SchemaUriEntry.schema.json",
-    "fileMatch": ["a://b/SchemaUriEntry*.schema.json"],
+    "fileMatch": [
+      "a://b/SchemaUriEntry*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./SchemaUriEntry.schema.json",
@@ -2542,7 +2908,9 @@
   },
   {
     "uri": "./TrustAuthorityEntry.schema.json",
-    "fileMatch": ["a://b/TrustAuthorityEntry*.schema.json"],
+    "fileMatch": [
+      "a://b/TrustAuthorityEntry*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./TrustAuthorityEntry.schema.json",
@@ -2555,7 +2923,11 @@
         },
         "frameworkType": {
           "type": "string",
-          "enum": ["aki", "etsi_tl", "openid_federation"],
+          "enum": [
+            "aki",
+            "etsi_tl",
+            "openid_federation"
+          ],
           "description": "Trust framework type (ignored when trustListId is set)"
         },
         "value": {
@@ -2593,7 +2965,9 @@
   },
   {
     "uri": "./SchemaMetaConfig.schema.json",
-    "fileMatch": ["a://b/SchemaMetaConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/SchemaMetaConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./SchemaMetaConfig.schema.json",
@@ -2632,7 +3006,12 @@
         },
         "bindingType": {
           "type": "string",
-          "enum": ["claim", "key", "biometric", "none"],
+          "enum": [
+            "claim",
+            "key",
+            "biometric",
+            "none"
+          ],
           "description": "Cryptographic binding type"
         },
         "schemaURIs": {
@@ -2670,7 +3049,11 @@
               },
               "frameworkType": {
                 "type": "string",
-                "enum": ["aki", "etsi_tl", "openid_federation"]
+                "enum": [
+                  "aki",
+                  "etsi_tl",
+                  "openid_federation"
+                ]
               },
               "value": {
                 "type": "string"
@@ -2701,7 +3084,9 @@
   },
   {
     "uri": "./KeyAttestationsRequired.schema.json",
-    "fileMatch": ["a://b/KeyAttestationsRequired*.schema.json"],
+    "fileMatch": [
+      "a://b/KeyAttestationsRequired*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./KeyAttestationsRequired.schema.json",
@@ -2713,7 +3098,10 @@
             "type": "string"
           },
           "description": "List of required key storage types (e.g., iso_18045_high, iso_18045_moderate)",
-          "example": ["iso_18045_high", "iso_18045_moderate"],
+          "example": [
+            "iso_18045_high",
+            "iso_18045_moderate"
+          ],
           "type": "array"
         },
         "user_authentication": {
@@ -2721,7 +3109,10 @@
             "type": "string"
           },
           "description": "List of required user authentication types (e.g., iso_18045_high, iso_18045_moderate)",
-          "example": ["iso_18045_high", "iso_18045_moderate"],
+          "example": [
+            "iso_18045_high",
+            "iso_18045_moderate"
+          ],
           "type": "array"
         }
       },
@@ -2730,7 +3121,9 @@
   },
   {
     "uri": "./DisplayImage.schema.json",
-    "fileMatch": ["a://b/DisplayImage*.schema.json"],
+    "fileMatch": [
+      "a://b/DisplayImage*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./DisplayImage.schema.json",
@@ -2741,13 +3134,17 @@
           "type": "string"
         }
       },
-      "required": ["uri"],
+      "required": [
+        "uri"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./Display.schema.json",
-    "fileMatch": ["a://b/Display*.schema.json"],
+    "fileMatch": [
+      "a://b/Display*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./Display.schema.json",
@@ -2776,13 +3173,19 @@
           "$ref": "./DisplayImage.schema.json"
         }
       },
-      "required": ["name", "description", "locale"],
+      "required": [
+        "name",
+        "description",
+        "locale"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./IssuerMetadataCredentialConfig.schema.json",
-    "fileMatch": ["a://b/IssuerMetadataCredentialConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/IssuerMetadataCredentialConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./IssuerMetadataCredentialConfig.schema.json",
@@ -2802,13 +3205,22 @@
           "type": "array",
           "items": {
             "type": "string",
-            "enum": ["jwt", "attestation"]
+            "enum": [
+              "jwt",
+              "attestation"
+            ]
           },
-          "example": ["attestation", "jwt"]
+          "example": [
+            "attestation",
+            "jwt"
+          ]
         },
         "format": {
           "type": "string",
-          "enum": ["mso_mdoc", "dc+sd-jwt"]
+          "enum": [
+            "mso_mdoc",
+            "dc+sd-jwt"
+          ]
         },
         "display": {
           "type": "array",
@@ -2824,13 +3236,18 @@
           "description": "Document type for mDOC credentials (e.g., \"org.iso.18013.5.1.mDL\").\nOnly applicable when format is \"mso_mdoc\"."
         }
       },
-      "required": ["format", "display"],
+      "required": [
+        "format",
+        "display"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./FieldDisplayDto.schema.json",
-    "fileMatch": ["a://b/FieldDisplayDto*.schema.json"],
+    "fileMatch": [
+      "a://b/FieldDisplayDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./FieldDisplayDto.schema.json",
@@ -2851,13 +3268,18 @@
           "type": "string"
         }
       },
-      "required": ["name", "locale"],
+      "required": [
+        "name",
+        "locale"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./ClaimFieldDefinitionDto.schema.json",
-    "fileMatch": ["a://b/ClaimFieldDefinitionDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ClaimFieldDefinitionDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./ClaimFieldDefinitionDto.schema.json",
@@ -2880,11 +3302,21 @@
             ]
           },
           "description": "Path to claim value. For nested child fields this can be relative to the parent path.",
-          "example": ["address", "locality"]
+          "example": [
+            "address",
+            "locality"
+          ]
         },
         "type": {
           "type": "string",
-          "enum": ["string", "number", "integer", "boolean", "object", "array"],
+          "enum": [
+            "string",
+            "number",
+            "integer",
+            "boolean",
+            "object",
+            "array"
+          ],
           "description": "Claim value type"
         },
         "defaultValue": {
@@ -2939,7 +3371,10 @@
                 "type": "string"
               }
             },
-            "required": ["locale", "name"],
+            "required": [
+              "locale",
+              "name"
+            ],
             "additionalProperties": false
           },
           "type": "array"
@@ -2960,13 +3395,18 @@
           "type": "array"
         }
       },
-      "required": ["path", "type"],
+      "required": [
+        "path",
+        "type"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./AttributeProviderEntity.schema.json",
-    "fileMatch": ["a://b/AttributeProviderEntity*.schema.json"],
+    "fileMatch": [
+      "a://b/AttributeProviderEntity*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./AttributeProviderEntity.schema.json",
@@ -3003,13 +3443,22 @@
           "type": "string"
         }
       },
-      "required": ["auth", "id", "tenantId", "tenant", "name", "url"],
+      "required": [
+        "auth",
+        "id",
+        "tenantId",
+        "tenant",
+        "name",
+        "url"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./KeyChainEntity.schema.json",
-    "fileMatch": ["a://b/KeyChainEntity*.schema.json"],
+    "fileMatch": [
+      "a://b/KeyChainEntity*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./KeyChainEntity.schema.json",
@@ -3039,12 +3488,21 @@
         "usageType": {
           "type": "string",
           "description": "The purpose/role of this key chain in the system.",
-          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"]
+          "enum": [
+            "access",
+            "attestation",
+            "trustList",
+            "statusList",
+            "encrypt"
+          ]
         },
         "usage": {
           "type": "string",
           "description": "The usage type of the keys (sign or encrypt).",
-          "enum": ["sign", "encrypt"]
+          "enum": [
+            "sign",
+            "encrypt"
+          ]
         },
         "kmsProvider": {
           "type": "string",
@@ -3128,7 +3586,9 @@
   },
   {
     "uri": "./CredentialConfig.schema.json",
-    "fileMatch": ["a://b/CredentialConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/CredentialConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./CredentialConfig.schema.json",
@@ -3255,20 +3715,30 @@
         "sdJwtTrustFormat": {
           "nullable": true,
           "description": "For SD-JWT credentials: determines whether to include certificate chain (x5c)\nor use federation-based trust (iss claim).\nDefault: \"x5c\" (federation must be explicitly selected)",
-          "enum": ["x5c", "federation"],
+          "enum": [
+            "x5c",
+            "federation"
+          ],
           "type": "string"
         },
         "lifeTime": {
           "type": "number"
         }
       },
-      "required": ["id", "tenant", "config", "fields"],
+      "required": [
+        "id",
+        "tenant",
+        "config",
+        "fields"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./CredentialConfigUpdate.schema.json",
-    "fileMatch": ["a://b/CredentialConfigUpdate*.schema.json"],
+    "fileMatch": [
+      "a://b/CredentialConfigUpdate*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./CredentialConfigUpdate.schema.json",
@@ -3378,7 +3848,10 @@
         "sdJwtTrustFormat": {
           "nullable": true,
           "description": "For SD-JWT credentials: determines whether to include certificate chain (x5c)\nor use federation-based trust (iss claim).\nDefault: \"x5c\" (federation must be explicitly selected)",
-          "enum": ["x5c", "federation"],
+          "enum": [
+            "x5c",
+            "federation"
+          ],
           "type": "string"
         },
         "lifeTime": {
@@ -3390,7 +3863,9 @@
   },
   {
     "uri": "./SignSchemaMetaConfigDto.schema.json",
-    "fileMatch": ["a://b/SignSchemaMetaConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/SignSchemaMetaConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./SignSchemaMetaConfigDto.schema.json",
@@ -3422,7 +3897,12 @@
             },
             "bindingType": {
               "type": "string",
-              "enum": ["claim", "key", "biometric", "none"]
+              "enum": [
+                "claim",
+                "key",
+                "biometric",
+                "none"
+              ]
             },
             "schemaURIs": {
               "type": "array",
@@ -3459,7 +3939,11 @@
                   },
                   "frameworkType": {
                     "type": "string",
-                    "enum": ["aki", "etsi_tl", "openid_federation"]
+                    "enum": [
+                      "aki",
+                      "etsi_tl",
+                      "openid_federation"
+                    ]
                   },
                   "value": {
                     "type": "string"
@@ -3497,18 +3981,26 @@
         },
         "pinMode": {
           "type": "string",
-          "enum": ["keep_current", "update_to_new_version", "replace_id"],
+          "enum": [
+            "keep_current",
+            "update_to_new_version",
+            "replace_id"
+          ],
           "description": "How to update credential config pinning after publish. keep_current: do not change existing pin (unless empty). update_to_new_version: update pinned version under current id. replace_id: repoint pin to a different schema id.",
           "default": "keep_current"
         }
       },
-      "required": ["config"],
+      "required": [
+        "config"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./SignVersionSchemaMetaConfigDto.schema.json",
-    "fileMatch": ["a://b/SignVersionSchemaMetaConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/SignVersionSchemaMetaConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./SignVersionSchemaMetaConfigDto.schema.json",
@@ -3540,7 +4032,12 @@
             },
             "bindingType": {
               "type": "string",
-              "enum": ["claim", "key", "biometric", "none"]
+              "enum": [
+                "claim",
+                "key",
+                "biometric",
+                "none"
+              ]
             },
             "schemaURIs": {
               "type": "array",
@@ -3577,7 +4074,11 @@
                   },
                   "frameworkType": {
                     "type": "string",
-                    "enum": ["aki", "etsi_tl", "openid_federation"]
+                    "enum": [
+                      "aki",
+                      "etsi_tl",
+                      "openid_federation"
+                    ]
                   },
                   "value": {
                     "type": "string"
@@ -3615,18 +4116,26 @@
         },
         "pinMode": {
           "type": "string",
-          "enum": ["keep_current", "update_to_new_version", "replace_id"],
+          "enum": [
+            "keep_current",
+            "update_to_new_version",
+            "replace_id"
+          ],
           "description": "How to update credential config pinning after version publish. keep_current: do not change existing pin (unless empty). update_to_new_version: update pinned version under current id. replace_id: repoint pin to config.id.",
           "default": "keep_current"
         }
       },
-      "required": ["config"],
+      "required": [
+        "config"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./VocabularyEntryDto.schema.json",
-    "fileMatch": ["a://b/VocabularyEntryDto*.schema.json"],
+    "fileMatch": [
+      "a://b/VocabularyEntryDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./VocabularyEntryDto.schema.json",
@@ -3642,7 +4151,10 @@
           "description": "Display label for UI rendering."
         },
         "status": {
-          "enum": ["active", "deprecated"],
+          "enum": [
+            "active",
+            "deprecated"
+          ],
           "type": "string",
           "description": "Vocabulary lifecycle status."
         },
@@ -3651,13 +4163,19 @@
           "description": "Replacement code when status is deprecated."
         }
       },
-      "required": ["code", "label", "status"],
+      "required": [
+        "code",
+        "label",
+        "status"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./SchemaMetadataVocabulariesDto.schema.json",
-    "fileMatch": ["a://b/SchemaMetadataVocabulariesDto*.schema.json"],
+    "fileMatch": [
+      "a://b/SchemaMetadataVocabulariesDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./SchemaMetadataVocabulariesDto.schema.json",
@@ -3683,13 +4201,19 @@
           }
         }
       },
-      "required": ["version", "categories", "tags"],
+      "required": [
+        "version",
+        "categories",
+        "tags"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./MetadataSchemaDto.schema.json",
-    "fileMatch": ["a://b/MetadataSchemaDto*.schema.json"],
+    "fileMatch": [
+      "a://b/MetadataSchemaDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./MetadataSchemaDto.schema.json",
@@ -3701,7 +4225,10 @@
           "description": "Unique identifier for this schema entry"
         },
         "formatIdentifier": {
-          "enum": ["dc+sd-jwt", "mso_mdoc"],
+          "enum": [
+            "dc+sd-jwt",
+            "mso_mdoc"
+          ],
           "type": "string",
           "description": "The credential format identifier"
         },
@@ -3719,13 +4246,18 @@
           "description": "Subresource Integrity hash for the schema"
         }
       },
-      "required": ["id", "formatIdentifier"],
+      "required": [
+        "id",
+        "formatIdentifier"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./TrustAuthorityDto.schema.json",
-    "fileMatch": ["a://b/TrustAuthorityDto*.schema.json"],
+    "fileMatch": [
+      "a://b/TrustAuthorityDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./TrustAuthorityDto.schema.json",
@@ -3739,7 +4271,9 @@
         "frameworkType": {
           "type": "string",
           "description": "Type of trust framework",
-          "enum": ["etsi_tl"]
+          "enum": [
+            "etsi_tl"
+          ]
         },
         "value": {
           "type": "string",
@@ -3751,13 +4285,19 @@
           "description": "Verification method for the trust list signature (e.g., JWK)"
         }
       },
-      "required": ["id", "frameworkType", "value"],
+      "required": [
+        "id",
+        "frameworkType",
+        "value"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./IssuerOfferEntryDto.schema.json",
-    "fileMatch": ["a://b/IssuerOfferEntryDto*.schema.json"],
+    "fileMatch": [
+      "a://b/IssuerOfferEntryDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./IssuerOfferEntryDto.schema.json",
@@ -3773,13 +4313,18 @@
           "description": "Human-readable description explaining when this issuer offer is relevant for the user."
         }
       },
-      "required": ["credentialOfferUrl", "description"],
+      "required": [
+        "credentialOfferUrl",
+        "description"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./AccessCertificateRefDto.schema.json",
-    "fileMatch": ["a://b/AccessCertificateRefDto*.schema.json"],
+    "fileMatch": [
+      "a://b/AccessCertificateRefDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./AccessCertificateRefDto.schema.json",
@@ -3802,13 +4347,21 @@
           "type": "string"
         }
       },
-      "required": ["id", "relyingPartyId", "certificate", "revoked", "createdAt"],
+      "required": [
+        "id",
+        "relyingPartyId",
+        "certificate",
+        "revoked",
+        "createdAt"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./SchemaMetadataResponseDto.schema.json",
-    "fileMatch": ["a://b/SchemaMetadataResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/SchemaMetadataResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./SchemaMetadataResponseDto.schema.json",
@@ -3842,7 +4395,12 @@
           "description": "Level of security (LoS) of this attestation"
         },
         "bindingType": {
-          "enum": ["claim", "key", "biometric", "none"],
+          "enum": [
+            "claim",
+            "key",
+            "biometric",
+            "none"
+          ],
           "type": "string",
           "description": "Required binding type between attestation and holder"
         },
@@ -3850,7 +4408,10 @@
           "type": "array",
           "items": {
             "type": "string",
-            "enum": ["dc+sd-jwt", "mso_mdoc"]
+            "enum": [
+              "dc+sd-jwt",
+              "mso_mdoc"
+            ]
           },
           "description": "Credential formats in which this attestation is available"
         },
@@ -3869,7 +4430,15 @@
           }
         },
         "category": {
-          "enum": ["identity", "health", "finance", "education", "mobility", "employment", "other"],
+          "enum": [
+            "identity",
+            "health",
+            "finance",
+            "education",
+            "mobility",
+            "employment",
+            "other"
+          ],
           "type": "string",
           "description": "Domain category for filtering"
         },
@@ -3957,7 +4526,9 @@
   },
   {
     "uri": "./UpdateIssuerOfferDto.schema.json",
-    "fileMatch": ["a://b/UpdateIssuerOfferDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateIssuerOfferDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./UpdateIssuerOfferDto.schema.json",
@@ -3978,7 +4549,9 @@
   },
   {
     "uri": "./UpdateSchemaMetadataDto.schema.json",
-    "fileMatch": ["a://b/UpdateSchemaMetadataDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateSchemaMetadataDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./UpdateSchemaMetadataDto.schema.json",
@@ -3987,7 +4560,15 @@
       "properties": {
         "category": {
           "type": "string",
-          "enum": ["identity", "health", "finance", "education", "mobility", "employment", "other"],
+          "enum": [
+            "identity",
+            "health",
+            "finance",
+            "education",
+            "mobility",
+            "employment",
+            "other"
+          ],
           "description": "Domain category for filtering"
         },
         "tags": {
@@ -4035,7 +4616,9 @@
   },
   {
     "uri": "./DeprecateSchemaMetadataDto.schema.json",
-    "fileMatch": ["a://b/DeprecateSchemaMetadataDto*.schema.json"],
+    "fileMatch": [
+      "a://b/DeprecateSchemaMetadataDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./DeprecateSchemaMetadataDto.schema.json",
@@ -4055,13 +4638,17 @@
           "description": "The version that supersedes this one"
         }
       },
-      "required": ["deprecated"],
+      "required": [
+        "deprecated"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./TrustListEntityInfo.schema.json",
-    "fileMatch": ["a://b/TrustListEntityInfo*.schema.json"],
+    "fileMatch": [
+      "a://b/TrustListEntityInfo*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./TrustListEntityInfo.schema.json",
@@ -4093,13 +4680,17 @@
           "type": "string"
         }
       },
-      "required": ["name"],
+      "required": [
+        "name"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./InternalTrustListEntity.schema.json",
-    "fileMatch": ["a://b/InternalTrustListEntity*.schema.json"],
+    "fileMatch": [
+      "a://b/InternalTrustListEntity*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./InternalTrustListEntity.schema.json",
@@ -4108,7 +4699,9 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["internal"]
+          "enum": [
+            "internal"
+          ]
         },
         "issuerKeyChainId": {
           "type": "string"
@@ -4120,13 +4713,20 @@
           "$ref": "./TrustListEntityInfo.schema.json"
         }
       },
-      "required": ["type", "issuerKeyChainId", "revocationKeyChainId", "info"],
+      "required": [
+        "type",
+        "issuerKeyChainId",
+        "revocationKeyChainId",
+        "info"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./ExternalTrustListEntity.schema.json",
-    "fileMatch": ["a://b/ExternalTrustListEntity*.schema.json"],
+    "fileMatch": [
+      "a://b/ExternalTrustListEntity*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./ExternalTrustListEntity.schema.json",
@@ -4135,7 +4735,9 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["external"]
+          "enum": [
+            "external"
+          ]
         },
         "issuerCertPem": {
           "type": "string"
@@ -4147,13 +4749,20 @@
           "$ref": "./TrustListEntityInfo.schema.json"
         }
       },
-      "required": ["type", "issuerCertPem", "revocationCertPem", "info"],
+      "required": [
+        "type",
+        "issuerCertPem",
+        "revocationCertPem",
+        "info"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./TrustList.schema.json",
-    "fileMatch": ["a://b/TrustList*.schema.json"],
+    "fileMatch": [
+      "a://b/TrustList*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./TrustList.schema.json",
@@ -4229,7 +4838,9 @@
   },
   {
     "uri": "./TrustListVersion.schema.json",
-    "fileMatch": ["a://b/TrustListVersion*.schema.json"],
+    "fileMatch": [
+      "a://b/TrustListVersion*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./TrustListVersion.schema.json",
@@ -4284,7 +4895,9 @@
   },
   {
     "uri": "./TrustListRef.schema.json",
-    "fileMatch": ["a://b/TrustListRef*.schema.json"],
+    "fileMatch": [
+      "a://b/TrustListRef*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./TrustListRef.schema.json",
@@ -4314,7 +4927,9 @@
   },
   {
     "uri": "./TrustedAuthorityQueryEtsiTl.schema.json",
-    "fileMatch": ["a://b/TrustedAuthorityQueryEtsiTl*.schema.json"],
+    "fileMatch": [
+      "a://b/TrustedAuthorityQueryEtsiTl*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./TrustedAuthorityQueryEtsiTl.schema.json",
@@ -4322,7 +4937,9 @@
       "type": "object",
       "properties": {
         "type": {
-          "enum": ["etsi_tl"],
+          "enum": [
+            "etsi_tl"
+          ],
           "type": "string",
           "default": "etsi_tl"
         },
@@ -4333,13 +4950,18 @@
           }
         }
       },
-      "required": ["type", "values"],
+      "required": [
+        "type",
+        "values"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./TrustedAuthorityQueryOpenIdFederation.schema.json",
-    "fileMatch": ["a://b/TrustedAuthorityQueryOpenIdFederation*.schema.json"],
+    "fileMatch": [
+      "a://b/TrustedAuthorityQueryOpenIdFederation*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./TrustedAuthorityQueryOpenIdFederation.schema.json",
@@ -4347,7 +4969,9 @@
       "type": "object",
       "properties": {
         "type": {
-          "enum": ["openid_federation"],
+          "enum": [
+            "openid_federation"
+          ],
           "type": "string",
           "default": "openid_federation"
         },
@@ -4358,13 +4982,18 @@
           }
         }
       },
-      "required": ["type", "values"],
+      "required": [
+        "type",
+        "values"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./DcSdJwtCredentialQueryMeta.schema.json",
-    "fileMatch": ["a://b/DcSdJwtCredentialQueryMeta*.schema.json"],
+    "fileMatch": [
+      "a://b/DcSdJwtCredentialQueryMeta*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./DcSdJwtCredentialQueryMeta.schema.json",
@@ -4379,13 +5008,17 @@
           "description": "VCT identifiers accepted for dc+sd-jwt credentials."
         }
       },
-      "required": ["vct_values"],
+      "required": [
+        "vct_values"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./MsoMdocCredentialQueryMeta.schema.json",
-    "fileMatch": ["a://b/MsoMdocCredentialQueryMeta*.schema.json"],
+    "fileMatch": [
+      "a://b/MsoMdocCredentialQueryMeta*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./MsoMdocCredentialQueryMeta.schema.json",
@@ -4397,13 +5030,17 @@
           "description": "Document type identifier accepted for mso_mdoc credentials."
         }
       },
-      "required": ["doctype_value"],
+      "required": [
+        "doctype_value"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./MsoMdocClaimsQuery.schema.json",
-    "fileMatch": ["a://b/MsoMdocClaimsQuery*.schema.json"],
+    "fileMatch": [
+      "a://b/MsoMdocClaimsQuery*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./MsoMdocClaimsQuery.schema.json",
@@ -4430,13 +5067,17 @@
           }
         }
       },
-      "required": ["path"],
+      "required": [
+        "path"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./CredentialQueryDcSdJwt.schema.json",
-    "fileMatch": ["a://b/CredentialQueryDcSdJwt*.schema.json"],
+    "fileMatch": [
+      "a://b/CredentialQueryDcSdJwt*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./CredentialQueryDcSdJwt.schema.json",
@@ -4446,7 +5087,9 @@
         "format": {
           "type": "string",
           "default": "dc+sd-jwt",
-          "enum": ["dc+sd-jwt"],
+          "enum": [
+            "dc+sd-jwt"
+          ],
           "description": "Credential format discriminator."
         },
         "claim_sets": {
@@ -4482,7 +5125,10 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["etsi_tl", "openid_federation"]
+                "enum": [
+                  "etsi_tl",
+                  "openid_federation"
+                ]
               }
             }
           }
@@ -4508,13 +5154,19 @@
           "type": "boolean"
         }
       },
-      "required": ["format", "meta", "id"],
+      "required": [
+        "format",
+        "meta",
+        "id"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./CredentialQueryMsoMdoc.schema.json",
-    "fileMatch": ["a://b/CredentialQueryMsoMdoc*.schema.json"],
+    "fileMatch": [
+      "a://b/CredentialQueryMsoMdoc*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./CredentialQueryMsoMdoc.schema.json",
@@ -4524,7 +5176,9 @@
         "format": {
           "type": "string",
           "default": "mso_mdoc",
-          "enum": ["mso_mdoc"],
+          "enum": [
+            "mso_mdoc"
+          ],
           "description": "Credential format discriminator."
         },
         "claim_sets": {
@@ -4560,7 +5214,10 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["etsi_tl", "openid_federation"]
+                "enum": [
+                  "etsi_tl",
+                  "openid_federation"
+                ]
               }
             }
           }
@@ -4586,13 +5243,19 @@
           "type": "boolean"
         }
       },
-      "required": ["format", "meta", "id"],
+      "required": [
+        "format",
+        "meta",
+        "id"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./RegistrationCertificatePurpose.schema.json",
-    "fileMatch": ["a://b/RegistrationCertificatePurpose*.schema.json"],
+    "fileMatch": [
+      "a://b/RegistrationCertificatePurpose*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./RegistrationCertificatePurpose.schema.json",
@@ -4606,13 +5269,18 @@
           "type": "string"
         }
       },
-      "required": ["lang", "content"],
+      "required": [
+        "lang",
+        "content"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./RegistrationCertificateBody.schema.json",
-    "fileMatch": ["a://b/RegistrationCertificateBody*.schema.json"],
+    "fileMatch": [
+      "a://b/RegistrationCertificateBody*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./RegistrationCertificateBody.schema.json",
@@ -4639,7 +5307,10 @@
                 "type": "string"
               }
             },
-            "required": ["lang", "content"],
+            "required": [
+              "lang",
+              "content"
+            ],
             "additionalProperties": false
           },
           "type": "array"
@@ -4670,7 +5341,9 @@
   },
   {
     "uri": "./RegistrationCertificateRequest.schema.json",
-    "fileMatch": ["a://b/RegistrationCertificateRequest*.schema.json"],
+    "fileMatch": [
+      "a://b/RegistrationCertificateRequest*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./RegistrationCertificateRequest.schema.json",
@@ -4704,7 +5377,10 @@
                     "type": "string"
                   }
                 },
-                "required": ["lang", "content"],
+                "required": [
+                  "lang",
+                  "content"
+                ],
                 "additionalProperties": false
               }
             },
@@ -4747,7 +5423,9 @@
   },
   {
     "uri": "./PresentationAttachment.schema.json",
-    "fileMatch": ["a://b/PresentationAttachment*.schema.json"],
+    "fileMatch": [
+      "a://b/PresentationAttachment*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./PresentationAttachment.schema.json",
@@ -4767,13 +5445,18 @@
           }
         }
       },
-      "required": ["format", "data"],
+      "required": [
+        "format",
+        "data"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./PresentationConfig.schema.json",
-    "fileMatch": ["a://b/PresentationConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/PresentationConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./PresentationConfig.schema.json",
@@ -4787,7 +5470,11 @@
         },
         "statusCheckMode": {
           "description": "Status list verification mode for presentations: strict (default), best_effort, or disabled.",
-          "enum": ["strict", "best_effort", "disabled"],
+          "enum": [
+            "strict",
+            "best_effort",
+            "disabled"
+          ],
           "type": "string",
           "default": "strict"
         },
@@ -4884,13 +5571,21 @@
           "description": "Enable reader authentication for the ISO 18013-7 Annex C (DC API) flow.\n\nWhen `true`, the DeviceRequest embeds a detached `readerAuth` COSE_Sign1\nsigned with the tenant's Access key chain (selected by\n{@link accessKeyChainId}), letting the wallet cryptographically\nauthenticate the verifier — the mDOC equivalent of the signed request\nobject used in the OID4VP flow. Defaults to disabled (null/false).\n\nOnly affects `response_type: \"iso-18013-7\"` offers."
         }
       },
-      "required": ["id", "tenant", "dcql_query", "createdAt", "updatedAt"],
+      "required": [
+        "id",
+        "tenant",
+        "dcql_query",
+        "createdAt",
+        "updatedAt"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./ResolveIssuerMetadataDto.schema.json",
-    "fileMatch": ["a://b/ResolveIssuerMetadataDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ResolveIssuerMetadataDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./ResolveIssuerMetadataDto.schema.json",
@@ -4904,13 +5599,17 @@
           "example": "https://issuer.example.com/issuers/tenant-a"
         }
       },
-      "required": ["issuerUrl"],
+      "required": [
+        "issuerUrl"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./ResolveSchemaMetadataDto.schema.json",
-    "fileMatch": ["a://b/ResolveSchemaMetadataDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ResolveSchemaMetadataDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./ResolveSchemaMetadataDto.schema.json",
@@ -4924,13 +5623,17 @@
           "example": "https://registrar.example.com/schema-metadata/5c0d7dbb-ef2e-448b-b84f-b8103575947b"
         }
       },
-      "required": ["schemaMetadataUrl"],
+      "required": [
+        "schemaMetadataUrl"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./ResolveSchemaMetadataJwtDto.schema.json",
-    "fileMatch": ["a://b/ResolveSchemaMetadataJwtDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ResolveSchemaMetadataJwtDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./ResolveSchemaMetadataJwtDto.schema.json",
@@ -4943,13 +5646,17 @@
           "example": "eyJ0eXAiOiJhdHRlc3RhdGlvbi1zY2hlbWErand0IiwiYWxnIjoiRVMyNTYiLCJ4NWMiOlsiTUlJQ01qQ0NBZGlnQXdJQkFnSVVDa0hwaTlPWHQ0QUJTY2NWbEl3UlJRdlE5cU1Rd0NnWUlLb1pJemowRUF3SXdLREVMTUFrR0ExVUVCaE1DUkVVeEdUQVhCZ05WQkFNTUVFZGxjbTFoYmlCU1pXZHBjM1J5WVhJd0hoY05Nall3TVRFMk1UQXdOVEE0V2hjTk1qZ3dNVEUyTVRBd05UQTRXakFvTVFzd0NRWURWUVFHRXdKRVJURVpNQmNHQTFVRUF3d1FSMlZ5YldGdUlGSmxaMmx6ZEhKaGNqQlpNQk1HQnlxR1NNNDlBZ0VHQ0NxR1NNNDlBd0VIQTBJQUJBUXQrK1dGQnJkVVJjYXkycmtyMG9pdW9zMDE2dlVLT2tsWVNJUVF4K1cvclcyOVc4bkE3SFMrNHMrNW0zWW5tUmRRcXphYWZDT3ZHYXhjSUd5UXFjQ2pnZDh3Z2R3d0hRWURWUjBPQkJZRUZQNGwyNXhUZWxBbnNEa0U2QXFlc09zd3pxWWxNQjhHQTFVZEl3UVlNQmFBRlA0bDI1eFRlbEFuc0RrRTZBcWVzT3N3enFZbE1CSUdBMVVkRXdFQi93UUlNQVlCQWY4Q0FRQXdEZ1lEVlIwUEFRSC9CQVFEQWdFR01Dd0dBMVVkRWdRbE1DT0dJV2gwZEhCek9pOHZjbVZuYVhOMGNtRnlMbVYxWkdrdGQyRnNiR1YwTG1SbGRqQklCZ05WSFI4RVFUQS9NRDJnTzZBNWhqZG9kSFJ3Y3pvdkwzSmxaMmx6ZEhKaGNpNWxkV1JwTFhkaGJHeGxkQzVrWlhZdmMzUmhkSFZ6TFcxaGJtRm5aVzFsYm5RdlkzSnNNQW9HQ0NxR1NNNDlCQU1DQTBnQU1FVUNJRFcxTXA0ZDc3a2oxWVVIWHlhVU1mMmNpbGtxTmpkL2RpdWpud3A4Ti9ISkFpRUF2WXlaK1IyUXFuUUJJUnZBL281aEVjVHJuNTNMQ2ZEQWZnWGt1OWxzZUIwPSJdIn0.eyJpZCI6Imh0dHA6Ly9sb2NhbGhvc3Q6MzAwMS9zY2hlbWEtbWV0YWRhdGEvNWMzNzFhMjEtZWIxOC00NzY3LTk4MTktMGIwMGY2NTQzY2QzIiwidmVyc2lvbiI6IjEuMC4wIn0.signature"
         }
       },
-      "required": ["signedJwt"],
+      "required": [
+        "signedJwt"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./PresentationConfigUpdateDto.schema.json",
-    "fileMatch": ["a://b/PresentationConfigUpdateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/PresentationConfigUpdateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./PresentationConfigUpdateDto.schema.json",
@@ -4963,7 +5670,11 @@
         },
         "statusCheckMode": {
           "description": "Status list verification mode for presentations: strict (default), best_effort, or disabled.",
-          "enum": ["strict", "best_effort", "disabled"],
+          "enum": [
+            "strict",
+            "best_effort",
+            "disabled"
+          ],
           "type": "string",
           "default": "strict"
         },
@@ -5039,7 +5750,9 @@
   },
   {
     "uri": "./RegistrationCertificateDefaults.schema.json",
-    "fileMatch": ["a://b/RegistrationCertificateDefaults*.schema.json"],
+    "fileMatch": [
+      "a://b/RegistrationCertificateDefaults*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./RegistrationCertificateDefaults.schema.json",
@@ -5062,7 +5775,9 @@
   },
   {
     "uri": "./RegistrarConfigResponseDto.schema.json",
-    "fileMatch": ["a://b/RegistrarConfigResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/RegistrarConfigResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./RegistrarConfigResponseDto.schema.json",
@@ -5110,13 +5825,21 @@
           "example": true
         }
       },
-      "required": ["registrarUrl", "oidcUrl", "clientId", "username", "hasPassword"],
+      "required": [
+        "registrarUrl",
+        "oidcUrl",
+        "clientId",
+        "username",
+        "hasPassword"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./DeferredCredentialRequestDto.schema.json",
-    "fileMatch": ["a://b/DeferredCredentialRequestDto*.schema.json"],
+    "fileMatch": [
+      "a://b/DeferredCredentialRequestDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./DeferredCredentialRequestDto.schema.json",
@@ -5129,13 +5852,17 @@
           "example": "8xLOxBtZp8"
         }
       },
-      "required": ["transaction_id"],
+      "required": [
+        "transaction_id"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./NotificationRequestDto.schema.json",
-    "fileMatch": ["a://b/NotificationRequestDto*.schema.json"],
+    "fileMatch": [
+      "a://b/NotificationRequestDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./NotificationRequestDto.schema.json",
@@ -5147,16 +5874,25 @@
         },
         "event": {
           "type": "string",
-          "enum": ["credential_accepted", "credential_failure", "credential_deleted"]
+          "enum": [
+            "credential_accepted",
+            "credential_failure",
+            "credential_deleted"
+          ]
         }
       },
-      "required": ["notification_id", "event"],
+      "required": [
+        "notification_id",
+        "event"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./OfferResponse.schema.json",
-    "fileMatch": ["a://b/OfferResponse*.schema.json"],
+    "fileMatch": [
+      "a://b/OfferResponse*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./OfferResponse.schema.json",
@@ -5174,13 +5910,18 @@
           "type": "string"
         }
       },
-      "required": ["uri", "session"],
+      "required": [
+        "uri",
+        "session"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./CompleteDeferredDto.schema.json",
-    "fileMatch": ["a://b/CompleteDeferredDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CompleteDeferredDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./CompleteDeferredDto.schema.json",
@@ -5201,13 +5942,17 @@
           }
         }
       },
-      "required": ["claims"],
+      "required": [
+        "claims"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./DeferredOperationResponse.schema.json",
-    "fileMatch": ["a://b/DeferredOperationResponse*.schema.json"],
+    "fileMatch": [
+      "a://b/DeferredOperationResponse*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./DeferredOperationResponse.schema.json",
@@ -5220,7 +5965,13 @@
         },
         "status": {
           "description": "The new status of the transaction",
-          "enum": ["pending", "ready", "retrieved", "expired", "failed"],
+          "enum": [
+            "pending",
+            "ready",
+            "retrieved",
+            "expired",
+            "failed"
+          ],
           "type": "string"
         },
         "message": {
@@ -5228,13 +5979,18 @@
           "description": "Optional message"
         }
       },
-      "required": ["transactionId", "status"],
+      "required": [
+        "transactionId",
+        "status"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./FailDeferredDto.schema.json",
-    "fileMatch": ["a://b/FailDeferredDto*.schema.json"],
+    "fileMatch": [
+      "a://b/FailDeferredDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./FailDeferredDto.schema.json",
@@ -5252,7 +6008,9 @@
   },
   {
     "uri": "./EC_Public.schema.json",
-    "fileMatch": ["a://b/EC_Public*.schema.json"],
+    "fileMatch": [
+      "a://b/EC_Public*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./EC_Public.schema.json",
@@ -5276,13 +6034,20 @@
           "description": "The y coordinate of the EC public key."
         }
       },
-      "required": ["kty", "crv", "x", "y"],
+      "required": [
+        "kty",
+        "crv",
+        "x",
+        "y"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./JwksResponseDto.schema.json",
-    "fileMatch": ["a://b/JwksResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/JwksResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./JwksResponseDto.schema.json",
@@ -5297,13 +6062,17 @@
           }
         }
       },
-      "required": ["keys"],
+      "required": [
+        "keys"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./AuthorizationResponse.schema.json",
-    "fileMatch": ["a://b/AuthorizationResponse*.schema.json"],
+    "fileMatch": [
+      "a://b/AuthorizationResponse*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./AuthorizationResponse.schema.json",
@@ -5339,7 +6108,9 @@
   },
   {
     "uri": "./Object.schema.json",
-    "fileMatch": ["a://b/Object*.schema.json"],
+    "fileMatch": [
+      "a://b/Object*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./Object.schema.json",
@@ -5351,7 +6122,9 @@
   },
   {
     "uri": "./ParResponseDto.schema.json",
-    "fileMatch": ["a://b/ParResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ParResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./ParResponseDto.schema.json",
@@ -5367,13 +6140,18 @@
           "description": "The expiration time for the request URI in seconds."
         }
       },
-      "required": ["request_uri", "expires_in"],
+      "required": [
+        "request_uri",
+        "expires_in"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./InteractiveAuthorizationRequestDto.schema.json",
-    "fileMatch": ["a://b/InteractiveAuthorizationRequestDto*.schema.json"],
+    "fileMatch": [
+      "a://b/InteractiveAuthorizationRequestDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./InteractiveAuthorizationRequestDto.schema.json",
@@ -5428,7 +6206,9 @@
                     "type": "string"
                   }
                 },
-                "required": ["type"],
+                "required": [
+                  "type"
+                ],
                 "additionalProperties": false
               }
             },
@@ -5472,7 +6252,9 @@
   },
   {
     "uri": "./InteractiveAuthorizationCodeResponseDto.schema.json",
-    "fileMatch": ["a://b/InteractiveAuthorizationCodeResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/InteractiveAuthorizationCodeResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./InteractiveAuthorizationCodeResponseDto.schema.json",
@@ -5490,13 +6272,18 @@
           "example": "auth-code-123"
         }
       },
-      "required": ["status", "code"],
+      "required": [
+        "status",
+        "code"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./InteractiveAuthorizationErrorResponseDto.schema.json",
-    "fileMatch": ["a://b/InteractiveAuthorizationErrorResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/InteractiveAuthorizationErrorResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./InteractiveAuthorizationErrorResponseDto.schema.json",
@@ -5514,13 +6301,17 @@
           "example": "Missing required parameter: interaction_types_supported"
         }
       },
-      "required": ["error"],
+      "required": [
+        "error"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./ChainedAsParResponseDto.schema.json",
-    "fileMatch": ["a://b/ChainedAsParResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ChainedAsParResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./ChainedAsParResponseDto.schema.json",
@@ -5538,13 +6329,18 @@
           "example": 600
         }
       },
-      "required": ["request_uri", "expires_in"],
+      "required": [
+        "request_uri",
+        "expires_in"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./ChainedAsErrorResponseDto.schema.json",
-    "fileMatch": ["a://b/ChainedAsErrorResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ChainedAsErrorResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./ChainedAsErrorResponseDto.schema.json",
@@ -5561,13 +6357,17 @@
           "description": "Human-readable error description"
         }
       },
-      "required": ["error"],
+      "required": [
+        "error"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./ChainedAsTokenRequestDto.schema.json",
-    "fileMatch": ["a://b/ChainedAsTokenRequestDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ChainedAsTokenRequestDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./ChainedAsTokenRequestDto.schema.json",
@@ -5600,13 +6400,17 @@
           "description": "PKCE code verifier"
         }
       },
-      "required": ["grant_type"],
+      "required": [
+        "grant_type"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./ChainedAsTokenResponseDto.schema.json",
-    "fileMatch": ["a://b/ChainedAsTokenResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ChainedAsTokenResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./ChainedAsTokenResponseDto.schema.json",
@@ -5651,13 +6455,19 @@
           "description": "Refresh token (issued when refresh tokens are enabled)"
         }
       },
-      "required": ["access_token", "token_type", "expires_in"],
+      "required": [
+        "access_token",
+        "token_type",
+        "expires_in"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./KmsProviderCapabilitiesDto.schema.json",
-    "fileMatch": ["a://b/KmsProviderCapabilitiesDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KmsProviderCapabilitiesDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./KmsProviderCapabilitiesDto.schema.json",
@@ -5681,7 +6491,9 @@
         },
         "supportedAlgs": {
           "description": "Signing algorithms supported by the provider.",
-          "example": ["ES256"],
+          "example": [
+            "ES256"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -5693,13 +6505,21 @@
           "example": "ES256"
         }
       },
-      "required": ["canImport", "canCreate", "canDelete", "supportedAlgs", "defaultAlg"],
+      "required": [
+        "canImport",
+        "canCreate",
+        "canDelete",
+        "supportedAlgs",
+        "defaultAlg"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./KmsProviderInfoDto.schema.json",
-    "fileMatch": ["a://b/KmsProviderInfoDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KmsProviderInfoDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./KmsProviderInfoDto.schema.json",
@@ -5730,13 +6550,19 @@
           ]
         }
       },
-      "required": ["name", "type", "capabilities"],
+      "required": [
+        "name",
+        "type",
+        "capabilities"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./KmsProvidersResponseDto.schema.json",
-    "fileMatch": ["a://b/KmsProvidersResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KmsProvidersResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./KmsProvidersResponseDto.schema.json",
@@ -5756,13 +6582,18 @@
           "example": "db"
         }
       },
-      "required": ["providers", "default"],
+      "required": [
+        "providers",
+        "default"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./KmsTenantConfigResponseDto.schema.json",
-    "fileMatch": ["a://b/KmsTenantConfigResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KmsTenantConfigResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./KmsTenantConfigResponseDto.schema.json",
@@ -5788,13 +6619,17 @@
           ]
         }
       },
-      "required": ["effectiveConfig"],
+      "required": [
+        "effectiveConfig"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./CertificateInfoDto.schema.json",
-    "fileMatch": ["a://b/CertificateInfoDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CertificateInfoDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./CertificateInfoDto.schema.json",
@@ -5828,13 +6663,17 @@
           "description": "Serial number."
         }
       },
-      "required": ["pem"],
+      "required": [
+        "pem"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./PublicKeyInfoDto.schema.json",
-    "fileMatch": ["a://b/PublicKeyInfoDto*.schema.json"],
+    "fileMatch": [
+      "a://b/PublicKeyInfoDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./PublicKeyInfoDto.schema.json",
@@ -5861,13 +6700,17 @@
           "example": "P-256"
         }
       },
-      "required": ["kty"],
+      "required": [
+        "kty"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./RotationPolicyResponseDto.schema.json",
-    "fileMatch": ["a://b/RotationPolicyResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/RotationPolicyResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./RotationPolicyResponseDto.schema.json",
@@ -5892,13 +6735,17 @@
           "description": "Next scheduled rotation date."
         }
       },
-      "required": ["enabled"],
+      "required": [
+        "enabled"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./KeyChainResponseDto.schema.json",
-    "fileMatch": ["a://b/KeyChainResponseDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KeyChainResponseDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./KeyChainResponseDto.schema.json",
@@ -5910,12 +6757,21 @@
           "description": "Unique identifier for the key chain."
         },
         "usageType": {
-          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"],
+          "enum": [
+            "access",
+            "attestation",
+            "trustList",
+            "statusList",
+            "encrypt"
+          ],
           "type": "string",
           "description": "Usage type of the key chain."
         },
         "type": {
-          "enum": ["standalone", "internalChain"],
+          "enum": [
+            "standalone",
+            "internalChain"
+          ],
           "type": "string",
           "description": "Type of key chain (standalone or internalChain)."
         },
@@ -6006,7 +6862,9 @@
   },
   {
     "uri": "./ExportEcJwk.schema.json",
-    "fileMatch": ["a://b/ExportEcJwk*.schema.json"],
+    "fileMatch": [
+      "a://b/ExportEcJwk*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./ExportEcJwk.schema.json",
@@ -6045,13 +6903,21 @@
           "description": "Key ID"
         }
       },
-      "required": ["kty", "crv", "x", "y", "d"],
+      "required": [
+        "kty",
+        "crv",
+        "x",
+        "y",
+        "d"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./ExportRotationPolicyDto.schema.json",
-    "fileMatch": ["a://b/ExportRotationPolicyDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ExportRotationPolicyDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./ExportRotationPolicyDto.schema.json",
@@ -6071,13 +6937,17 @@
           "description": "Certificate validity in days."
         }
       },
-      "required": ["enabled"],
+      "required": [
+        "enabled"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./KeyChainExportDto.schema.json",
-    "fileMatch": ["a://b/KeyChainExportDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KeyChainExportDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./KeyChainExportDto.schema.json",
@@ -6093,7 +6963,13 @@
           "description": "Human-readable description."
         },
         "usageType": {
-          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"],
+          "enum": [
+            "access",
+            "attestation",
+            "trustList",
+            "statusList",
+            "encrypt"
+          ],
           "type": "string",
           "description": "Usage type for this key chain."
         },
@@ -6125,13 +7001,19 @@
           ]
         }
       },
-      "required": ["id", "usageType", "key"],
+      "required": [
+        "id",
+        "usageType",
+        "key"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./EcJwk.schema.json",
-    "fileMatch": ["a://b/EcJwk*.schema.json"],
+    "fileMatch": [
+      "a://b/EcJwk*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./EcJwk.schema.json",
@@ -6160,13 +7042,21 @@
           "type": "string"
         }
       },
-      "required": ["kty", "x", "y", "crv", "d"],
+      "required": [
+        "kty",
+        "x",
+        "y",
+        "crv",
+        "d"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./RotationPolicyImportDto.schema.json",
-    "fileMatch": ["a://b/RotationPolicyImportDto*.schema.json"],
+    "fileMatch": [
+      "a://b/RotationPolicyImportDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./RotationPolicyImportDto.schema.json",
@@ -6193,13 +7083,17 @@
           "example": 365
         }
       },
-      "required": ["enabled"],
+      "required": [
+        "enabled"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./PresentationRequest.schema.json",
-    "fileMatch": ["a://b/PresentationRequest*.schema.json"],
+    "fileMatch": [
+      "a://b/PresentationRequest*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./PresentationRequest.schema.json",
@@ -6221,7 +7115,9 @@
                       "const": "none"
                     }
                   },
-                  "required": ["type"],
+                  "required": [
+                    "type"
+                  ],
                   "additionalProperties": false
                 },
                 {
@@ -6241,11 +7137,17 @@
                           "type": "string"
                         }
                       },
-                      "required": ["headerName", "value"],
+                      "required": [
+                        "headerName",
+                        "value"
+                      ],
                       "additionalProperties": false
                     }
                   },
-                  "required": ["type", "config"],
+                  "required": [
+                    "type",
+                    "config"
+                  ],
                   "additionalProperties": false
                 }
               ]
@@ -6281,7 +7183,11 @@
             }
           ],
           "description": "The type of response expected from the presentation request.",
-          "enum": ["uri", "dc-api", "iso-18013-7"]
+          "enum": [
+            "uri",
+            "dc-api",
+            "iso-18013-7"
+          ]
         },
         "requestId": {
           "type": "string",
@@ -6313,13 +7219,18 @@
           "description": "Optional clock skew tolerance for this presentation offer, in seconds.\nIf provided, this overrides the presentation configuration for the created session."
         }
       },
-      "required": ["response_type", "requestId"],
+      "required": [
+        "response_type",
+        "requestId"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./FileUploadDto.schema.json",
-    "fileMatch": ["a://b/FileUploadDto*.schema.json"],
+    "fileMatch": [
+      "a://b/FileUploadDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "./FileUploadDto.schema.json",
@@ -6331,13 +7242,17 @@
           "format": "binary"
         }
       },
-      "required": ["file"],
+      "required": [
+        "file"
+      ],
       "additionalProperties": false
     }
   },
   {
     "uri": "./AttributeProviderAuth.schema.json",
-    "fileMatch": ["a://b/AttributeProviderAuth*.schema.json"],
+    "fileMatch": [
+      "a://b/AttributeProviderAuth*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "oneOf": [
@@ -6350,7 +7265,9 @@
               "description": "Disable authentication for attribute provider calls."
             }
           },
-          "required": ["type"],
+          "required": [
+            "type"
+          ],
           "additionalProperties": false,
           "description": "No authentication variant."
         },
@@ -6376,12 +7293,18 @@
                   "description": "API key value."
                 }
               },
-              "required": ["headerName", "value"],
+              "required": [
+                "headerName",
+                "value"
+              ],
               "additionalProperties": false,
               "description": "API key authentication settings."
             }
           },
-          "required": ["type", "config"],
+          "required": [
+            "type",
+            "config"
+          ],
           "additionalProperties": false,
           "description": "API key authentication variant."
         }
@@ -6393,7 +7316,9 @@
   },
   {
     "uri": "./CertImportDto.schema.json",
-    "fileMatch": ["a://b/CertImportDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CertImportDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -6422,7 +7347,9 @@
           "description": "Certificate chain entries, typically PEM-encoded certificates."
         }
       },
-      "required": ["crt"],
+      "required": [
+        "crt"
+      ],
       "additionalProperties": false,
       "$id": "./CertImportDto.schema.json",
       "title": "CertImportDto"
@@ -6430,7 +7357,9 @@
   },
   {
     "uri": "./CreateAttributeProviderDto.schema.json",
-    "fileMatch": ["a://b/CreateAttributeProviderDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CreateAttributeProviderDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -6473,7 +7402,9 @@
                   "description": "Disable authentication for attribute provider calls."
                 }
               },
-              "required": ["type"],
+              "required": [
+                "type"
+              ],
               "additionalProperties": false,
               "description": "No authentication variant."
             },
@@ -6499,12 +7430,18 @@
                       "description": "API key value."
                     }
                   },
-                  "required": ["headerName", "value"],
+                  "required": [
+                    "headerName",
+                    "value"
+                  ],
                   "additionalProperties": false,
                   "description": "API key authentication settings."
                 }
               },
-              "required": ["type", "config"],
+              "required": [
+                "type",
+                "config"
+              ],
               "additionalProperties": false,
               "description": "API key authentication variant."
             }
@@ -6512,7 +7449,12 @@
           "description": "Authentication configuration for outbound provider requests."
         }
       },
-      "required": ["id", "name", "url", "auth"],
+      "required": [
+        "id",
+        "name",
+        "url",
+        "auth"
+      ],
       "additionalProperties": false,
       "$id": "./CreateAttributeProviderDto.schema.json",
       "title": "CreateAttributeProviderDto"
@@ -6520,7 +7462,9 @@
   },
   {
     "uri": "./CreateClientDto.schema.json",
-    "fileMatch": ["a://b/CreateClientDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CreateClientDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -6589,7 +7533,10 @@
           ]
         }
       },
-      "required": ["clientId", "roles"],
+      "required": [
+        "clientId",
+        "roles"
+      ],
       "additionalProperties": false,
       "$id": "./CreateClientDto.schema.json",
       "title": "CreateClientDto"
@@ -6597,7 +7544,9 @@
   },
   {
     "uri": "./CreateRegistrarConfigDto.schema.json",
-    "fileMatch": ["a://b/CreateRegistrarConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CreateRegistrarConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -6648,7 +7597,13 @@
           ]
         }
       },
-      "required": ["registrarUrl", "oidcUrl", "clientId", "username", "password"],
+      "required": [
+        "registrarUrl",
+        "oidcUrl",
+        "clientId",
+        "username",
+        "password"
+      ],
       "additionalProperties": false,
       "$id": "./CreateRegistrarConfigDto.schema.json",
       "title": "CreateRegistrarConfigDto"
@@ -6656,7 +7611,9 @@
   },
   {
     "uri": "./CreateStatusListDto.schema.json",
-    "fileMatch": ["a://b/CreateStatusListDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CreateStatusListDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -6706,7 +7663,9 @@
   },
   {
     "uri": "./CreateTenantDto.schema.json",
-    "fileMatch": ["a://b/CreateTenantDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CreateTenantDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -6757,7 +7716,10 @@
             "cleanupMode": {
               "description": "Whether to fully delete or anonymize expired sessions.",
               "type": "string",
-              "enum": ["full", "anonymize"]
+              "enum": [
+                "full",
+                "anonymize"
+              ]
             }
           },
           "additionalProperties": false
@@ -6811,7 +7773,10 @@
           "additionalProperties": false
         }
       },
-      "required": ["id", "name"],
+      "required": [
+        "id",
+        "name"
+      ],
       "additionalProperties": false,
       "description": "Payload for creating a tenant.",
       "$id": "./CreateTenantDto.schema.json",
@@ -6820,7 +7785,9 @@
   },
   {
     "uri": "./CreateWebhookEndpointDto.schema.json",
-    "fileMatch": ["a://b/CreateWebhookEndpointDto*.schema.json"],
+    "fileMatch": [
+      "a://b/CreateWebhookEndpointDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -6863,7 +7830,9 @@
                   "description": "Disable webhook authentication."
                 }
               },
-              "required": ["type"],
+              "required": [
+                "type"
+              ],
               "additionalProperties": false,
               "description": "No webhook authentication variant."
             },
@@ -6889,12 +7858,18 @@
                       "description": "API key value sent with webhook requests."
                     }
                   },
-                  "required": ["headerName", "value"],
+                  "required": [
+                    "headerName",
+                    "value"
+                  ],
                   "additionalProperties": false,
                   "description": "API key webhook authentication settings."
                 }
               },
-              "required": ["type", "config"],
+              "required": [
+                "type",
+                "config"
+              ],
               "additionalProperties": false,
               "description": "API key webhook authentication variant."
             }
@@ -6902,7 +7877,12 @@
           "description": "Authentication configuration applied to outgoing webhook requests."
         }
       },
-      "required": ["id", "name", "url", "auth"],
+      "required": [
+        "id",
+        "name",
+        "url",
+        "auth"
+      ],
       "additionalProperties": false,
       "$id": "./CreateWebhookEndpointDto.schema.json",
       "title": "CreateWebhookEndpointDto"
@@ -6910,7 +7890,9 @@
   },
   {
     "uri": "./CredentialConfigCreate.schema.json",
-    "fileMatch": ["a://b/CredentialConfigCreate*.schema.json"],
+    "fileMatch": [
+      "a://b/CredentialConfigCreate*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -6936,7 +7918,10 @@
           "properties": {
             "format": {
               "type": "string",
-              "enum": ["mso_mdoc", "dc+sd-jwt"],
+              "enum": [
+                "mso_mdoc",
+                "dc+sd-jwt"
+              ],
               "description": "Credential format emitted by this configuration."
             },
             "display": {
@@ -6976,7 +7961,9 @@
                         "description": "Image URI."
                       }
                     },
-                    "required": ["uri"],
+                    "required": [
+                      "uri"
+                    ],
                     "additionalProperties": false
                   },
                   "logo": {
@@ -6989,11 +7976,16 @@
                         "description": "Image URI."
                       }
                     },
-                    "required": ["uri"],
+                    "required": [
+                      "uri"
+                    ],
                     "additionalProperties": false
                   }
                 },
-                "required": ["locale", "name"],
+                "required": [
+                  "locale",
+                  "name"
+                ],
                 "additionalProperties": false
               },
               "description": "Display metadata shown by wallets."
@@ -7032,11 +8024,17 @@
               "type": "array",
               "items": {
                 "type": "string",
-                "enum": ["jwt", "attestation"]
+                "enum": [
+                  "jwt",
+                  "attestation"
+                ]
               }
             }
           },
-          "required": ["format", "display"],
+          "required": [
+            "format",
+            "display"
+          ],
           "additionalProperties": false,
           "description": "Issuer metadata-facing credential configuration."
         },
@@ -7152,7 +8150,10 @@
                         "description": "Presentation configuration id to execute."
                       }
                     },
-                    "required": ["type", "presentationConfigId"],
+                    "required": [
+                      "type",
+                      "presentationConfigId"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -7182,7 +8183,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["type", "url"],
+                    "required": [
+                      "type",
+                      "url"
+                    ],
                     "additionalProperties": false
                   }
                 ],
@@ -7199,7 +8203,10 @@
           "anyOf": [
             {
               "type": "string",
-              "enum": ["x5c", "federation"]
+              "enum": [
+                "x5c",
+                "federation"
+              ]
             },
             {
               "type": "null"
@@ -7246,7 +8253,12 @@
                 },
                 "bindingType": {
                   "type": "string",
-                  "enum": ["claim", "key", "biometric", "none"],
+                  "enum": [
+                    "claim",
+                    "key",
+                    "biometric",
+                    "none"
+                  ],
                   "description": "Subject binding type."
                 },
                 "schemaURIs": {
@@ -7292,7 +8304,11 @@
                       "frameworkType": {
                         "description": "Trust framework type.",
                         "type": "string",
-                        "enum": ["aki", "etsi_tl", "openid_federation"]
+                        "enum": [
+                          "aki",
+                          "etsi_tl",
+                          "openid_federation"
+                        ]
                       },
                       "value": {
                         "description": "Framework-specific authority value.",
@@ -7318,7 +8334,11 @@
                   }
                 }
               },
-              "required": ["version", "attestationLoS", "bindingType"],
+              "required": [
+                "version",
+                "attestationLoS",
+                "bindingType"
+              ],
               "additionalProperties": false
             },
             {
@@ -7360,13 +8380,18 @@
                             "items": {}
                           }
                         },
-                        "required": ["credentials"],
+                        "required": [
+                          "credentials"
+                        ],
                         "additionalProperties": false
                       },
                       "description": "Attestation requirements used for policy enforcement."
                     }
                   },
-                  "required": ["policy", "values"],
+                  "required": [
+                    "policy",
+                    "values"
+                  ],
                   "additionalProperties": false
                 },
                 {
@@ -7378,7 +8403,9 @@
                       "description": "No disclosure policy enforcement."
                     }
                   },
-                  "required": ["policy"],
+                  "required": [
+                    "policy"
+                  ],
                   "additionalProperties": false
                 },
                 {
@@ -7397,7 +8424,10 @@
                       "description": "Allowed values for policy checks."
                     }
                   },
-                  "required": ["policy", "values"],
+                  "required": [
+                    "policy",
+                    "values"
+                  ],
                   "additionalProperties": false
                 },
                 {
@@ -7413,7 +8443,10 @@
                       "description": "Root-of-trust identifier or reference."
                     }
                   },
-                  "required": ["policy", "values"],
+                  "required": [
+                    "policy",
+                    "values"
+                  ],
                   "additionalProperties": false
                 }
               ],
@@ -7425,7 +8458,11 @@
           ]
         }
       },
-      "required": ["id", "config", "fields"],
+      "required": [
+        "id",
+        "config",
+        "fields"
+      ],
       "additionalProperties": false,
       "$defs": {
         "__schema0": {
@@ -7450,7 +8487,14 @@
             },
             "type": {
               "type": "string",
-              "enum": ["string", "number", "integer", "boolean", "object", "array"],
+              "enum": [
+                "string",
+                "number",
+                "integer",
+                "boolean",
+                "object",
+                "array"
+              ],
               "description": "Data type of the claim value."
             },
             "defaultValue": {
@@ -7489,7 +8533,10 @@
                     "type": "string"
                   }
                 },
-                "required": ["locale", "name"],
+                "required": [
+                  "locale",
+                  "name"
+                ],
                 "additionalProperties": false
               }
             },
@@ -7509,7 +8556,10 @@
               }
             }
           },
-          "required": ["path", "type"],
+          "required": [
+            "path",
+            "type"
+          ],
           "additionalProperties": false
         }
       },
@@ -7519,7 +8569,9 @@
   },
   {
     "uri": "./DCQL.schema.json",
-    "fileMatch": ["a://b/DCQL*.schema.json"],
+    "fileMatch": [
+      "a://b/DCQL*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -7605,7 +8657,10 @@
                               "description": "Trust list references for ETSI TL verification."
                             }
                           },
-                          "required": ["type", "values"],
+                          "required": [
+                            "type",
+                            "values"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -7624,7 +8679,10 @@
                               "description": "OpenID Federation authority identifiers."
                             }
                           },
-                          "required": ["type", "values"],
+                          "required": [
+                            "type",
+                            "values"
+                          ],
                           "additionalProperties": false
                         }
                       ]
@@ -7647,7 +8705,9 @@
                         "description": "Accepted VCT values."
                       }
                     },
-                    "required": ["vct_values"],
+                    "required": [
+                      "vct_values"
+                    ],
                     "additionalProperties": false
                   },
                   "claims": {
@@ -7682,12 +8742,18 @@
                           }
                         }
                       },
-                      "required": ["path"],
+                      "required": [
+                        "path"
+                      ],
                       "additionalProperties": false
                     }
                   }
                 },
-                "required": ["id", "format", "meta"],
+                "required": [
+                  "id",
+                  "format",
+                  "meta"
+                ],
                 "additionalProperties": false
               },
               {
@@ -7766,7 +8832,10 @@
                               "description": "Trust list references for ETSI TL verification."
                             }
                           },
-                          "required": ["type", "values"],
+                          "required": [
+                            "type",
+                            "values"
+                          ],
                           "additionalProperties": false
                         },
                         {
@@ -7785,7 +8854,10 @@
                               "description": "OpenID Federation authority identifiers."
                             }
                           },
-                          "required": ["type", "values"],
+                          "required": [
+                            "type",
+                            "values"
+                          ],
                           "additionalProperties": false
                         }
                       ]
@@ -7805,7 +8877,9 @@
                         "description": "Expected mDoc doctype value."
                       }
                     },
-                    "required": ["doctype_value"],
+                    "required": [
+                      "doctype_value"
+                    ],
                     "additionalProperties": false
                   },
                   "claims": {
@@ -7844,12 +8918,18 @@
                           "type": "boolean"
                         }
                       },
-                      "required": ["path"],
+                      "required": [
+                        "path"
+                      ],
                       "additionalProperties": false
                     }
                   }
                 },
-                "required": ["id", "format", "meta"],
+                "required": [
+                  "id",
+                  "format",
+                  "meta"
+                ],
                 "additionalProperties": false
               }
             ]
@@ -7879,12 +8959,16 @@
                 "type": "boolean"
               }
             },
-            "required": ["options"],
+            "required": [
+              "options"
+            ],
             "additionalProperties": false
           }
         }
       },
-      "required": ["credentials"],
+      "required": [
+        "credentials"
+      ],
       "additionalProperties": false,
       "$id": "./DCQL.schema.json",
       "title": "DCQL"
@@ -7892,7 +8976,9 @@
   },
   {
     "uri": "./EmbeddedDisclosurePolicy.schema.json",
-    "fileMatch": ["a://b/EmbeddedDisclosurePolicy*.schema.json"],
+    "fileMatch": [
+      "a://b/EmbeddedDisclosurePolicy*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "oneOf": [
@@ -7925,13 +9011,18 @@
                     "items": {}
                   }
                 },
-                "required": ["credentials"],
+                "required": [
+                  "credentials"
+                ],
                 "additionalProperties": false
               },
               "description": "Attestation requirements used for policy enforcement."
             }
           },
-          "required": ["policy", "values"],
+          "required": [
+            "policy",
+            "values"
+          ],
           "additionalProperties": false
         },
         {
@@ -7943,7 +9034,9 @@
               "description": "No disclosure policy enforcement."
             }
           },
-          "required": ["policy"],
+          "required": [
+            "policy"
+          ],
           "additionalProperties": false
         },
         {
@@ -7962,7 +9055,10 @@
               "description": "Allowed values for policy checks."
             }
           },
-          "required": ["policy", "values"],
+          "required": [
+            "policy",
+            "values"
+          ],
           "additionalProperties": false
         },
         {
@@ -7978,7 +9074,10 @@
               "description": "Root-of-trust identifier or reference."
             }
           },
-          "required": ["policy", "values"],
+          "required": [
+            "policy",
+            "values"
+          ],
           "additionalProperties": false
         }
       ],
@@ -7989,7 +9088,9 @@
   },
   {
     "uri": "./ImportTenantDto.schema.json",
-    "fileMatch": ["a://b/ImportTenantDto*.schema.json"],
+    "fileMatch": [
+      "a://b/ImportTenantDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -8006,7 +9107,9 @@
           "minLength": 1
         }
       },
-      "required": ["name"],
+      "required": [
+        "name"
+      ],
       "additionalProperties": false,
       "description": "Payload used when importing tenant metadata from config files.",
       "$id": "./ImportTenantDto.schema.json",
@@ -8015,7 +9118,9 @@
   },
   {
     "uri": "./IssuanceConfig.schema.json",
-    "fileMatch": ["a://b/IssuanceConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/IssuanceConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -8058,7 +9163,9 @@
                 "type": "string"
               }
             },
-            "required": ["url"],
+            "required": [
+              "url"
+            ],
             "additionalProperties": false
           }
         },
@@ -8099,7 +9206,11 @@
                     "type": "boolean"
                   }
                 },
-                "required": ["type", "id", "issuer"],
+                "required": [
+                  "type",
+                  "id",
+                  "issuer"
+                ],
                 "additionalProperties": false
               },
               {
@@ -8163,7 +9274,11 @@
                     "type": "boolean"
                   }
                 },
-                "required": ["type", "id", "presentationConfigId"],
+                "required": [
+                  "type",
+                  "id",
+                  "presentationConfigId"
+                ],
                 "additionalProperties": false
               },
               {
@@ -8206,7 +9321,10 @@
                         }
                       }
                     },
-                    "required": ["issuer", "clientId"],
+                    "required": [
+                      "issuer",
+                      "clientId"
+                    ],
                     "additionalProperties": false,
                     "description": "Upstream OIDC connection settings."
                   },
@@ -8249,7 +9367,11 @@
                     "type": "boolean"
                   }
                 },
-                "required": ["type", "id", "upstream"],
+                "required": [
+                  "type",
+                  "id",
+                  "upstream"
+                ],
                 "additionalProperties": false
               },
               {
@@ -8304,7 +9426,10 @@
                     "type": "boolean"
                   }
                 },
-                "required": ["type", "id"],
+                "required": [
+                  "type",
+                  "id"
+                ],
                 "additionalProperties": false
               }
             ],
@@ -8321,12 +9446,19 @@
                 "role": {
                   "description": "Federation role for this issuer.",
                   "type": "string",
-                  "enum": ["trust_anchor", "intermediate", "leaf"]
+                  "enum": [
+                    "trust_anchor",
+                    "intermediate",
+                    "leaf"
+                  ]
                 },
                 "mode": {
                   "description": "Federation operation mode.",
                   "type": "string",
-                  "enum": ["federation-only", "hybrid"]
+                  "enum": [
+                    "federation-only",
+                    "hybrid"
+                  ]
                 },
                 "entityId": {
                   "description": "Optional local federation entity id.",
@@ -8358,13 +9490,18 @@
                         "description": "Entity configuration URI for the trust anchor."
                       }
                     },
-                    "required": ["entityId", "entityConfigurationUri"],
+                    "required": [
+                      "entityId",
+                      "entityConfigurationUri"
+                    ],
                     "additionalProperties": false
                   },
                   "description": "Federation trust anchors."
                 }
               },
-              "required": ["trustAnchors"],
+              "required": [
+                "trustAnchors"
+              ],
               "additionalProperties": false
             },
             {
@@ -8385,7 +9522,10 @@
                 "mode": {
                   "description": "How registration certificate data is provided.",
                   "type": "string",
-                  "enum": ["import", "generate"]
+                  "enum": [
+                    "import",
+                    "generate"
+                  ]
                 },
                 "jwt": {
                   "description": "Optional registration certificate JWT when using import mode.",
@@ -8435,7 +9575,9 @@
                     "type": "string"
                   }
                 },
-                "required": ["uri"],
+                "required": [
+                  "uri"
+                ],
                 "additionalProperties": {}
               }
             },
@@ -8464,7 +9606,9 @@
           ]
         }
       },
-      "required": ["authorizationServers"],
+      "required": [
+        "authorizationServers"
+      ],
       "additionalProperties": false,
       "$id": "./IssuanceConfig.schema.json",
       "title": "IssuanceConfig"
@@ -8472,19 +9616,30 @@
   },
   {
     "uri": "./KeyChainCreateDto.schema.json",
-    "fileMatch": ["a://b/KeyChainCreateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KeyChainCreateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
       "properties": {
         "usageType": {
           "type": "string",
-          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"],
+          "enum": [
+            "access",
+            "attestation",
+            "trustList",
+            "statusList",
+            "encrypt"
+          ],
           "description": "Key usage category for the key chain."
         },
         "type": {
           "type": "string",
-          "enum": ["standalone", "internalChain"],
+          "enum": [
+            "standalone",
+            "internalChain"
+          ],
           "description": "Key chain mode."
         },
         "description": {
@@ -8516,11 +9671,16 @@
               "maximum": 3650
             }
           },
-          "required": ["enabled"],
+          "required": [
+            "enabled"
+          ],
           "additionalProperties": false
         }
       },
-      "required": ["usageType", "type"],
+      "required": [
+        "usageType",
+        "type"
+      ],
       "additionalProperties": false,
       "$id": "./KeyChainCreateDto.schema.json",
       "title": "KeyChainCreateDto"
@@ -8528,7 +9688,9 @@
   },
   {
     "uri": "./KeyChainImportDto.schema.json",
-    "fileMatch": ["a://b/KeyChainImportDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KeyChainImportDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -8569,7 +9731,13 @@
               "type": "string"
             }
           },
-          "required": ["kty", "x", "y", "crv", "d"],
+          "required": [
+            "kty",
+            "x",
+            "y",
+            "crv",
+            "d"
+          ],
           "additionalProperties": false,
           "description": "Private key material in JWK format."
         },
@@ -8579,7 +9747,13 @@
         },
         "usageType": {
           "type": "string",
-          "enum": ["access", "attestation", "trustList", "statusList", "encrypt"],
+          "enum": [
+            "access",
+            "attestation",
+            "trustList",
+            "statusList",
+            "encrypt"
+          ],
           "description": "Key usage category for the imported key chain."
         },
         "crt": {
@@ -8614,11 +9788,16 @@
               "maximum": 3650
             }
           },
-          "required": ["enabled"],
+          "required": [
+            "enabled"
+          ],
           "additionalProperties": false
         }
       },
-      "required": ["key", "usageType"],
+      "required": [
+        "key",
+        "usageType"
+      ],
       "additionalProperties": false,
       "$id": "./KeyChainImportDto.schema.json",
       "title": "KeyChainImportDto"
@@ -8626,7 +9805,9 @@
   },
   {
     "uri": "./KeyChainUpdateDto.schema.json",
-    "fileMatch": ["a://b/KeyChainUpdateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KeyChainUpdateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -8670,14 +9851,18 @@
   },
   {
     "uri": "./KmsConfigDto.schema.json",
-    "fileMatch": ["a://b/KmsConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/KmsConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
       "properties": {
         "defaultProvider": {
           "description": "ID of the default KMS provider. Defaults to \"db\" if not set.",
-          "examples": ["main-vault"],
+          "examples": [
+            "main-vault"
+          ],
           "anyOf": [
             {
               "type": "string",
@@ -8708,17 +9893,23 @@
                       }
                     ],
                     "description": "Unique identifier for this provider instance. Used when generating keys to specify which provider to use.",
-                    "examples": ["main-vault"]
+                    "examples": [
+                      "main-vault"
+                    ]
                   },
                   "type": {
                     "type": "string",
                     "const": "db",
                     "description": "Type of the KMS provider.",
-                    "examples": ["db"]
+                    "examples": [
+                      "db"
+                    ]
                   },
                   "description": {
                     "description": "Human-readable description of this provider instance.",
-                    "examples": ["Production HashiCorp Vault for signing keys"],
+                    "examples": [
+                      "Production HashiCorp Vault for signing keys"
+                    ],
                     "anyOf": [
                       {
                         "type": "string",
@@ -8731,7 +9922,10 @@
                     ]
                   }
                 },
-                "required": ["id", "type"],
+                "required": [
+                  "id",
+                  "type"
+                ],
                 "additionalProperties": false
               },
               {
@@ -8749,17 +9943,23 @@
                       }
                     ],
                     "description": "Unique identifier for this provider instance. Used when generating keys to specify which provider to use.",
-                    "examples": ["main-vault"]
+                    "examples": [
+                      "main-vault"
+                    ]
                   },
                   "type": {
                     "type": "string",
                     "const": "vault",
                     "description": "Type of the KMS provider.",
-                    "examples": ["vault"]
+                    "examples": [
+                      "vault"
+                    ]
                   },
                   "description": {
                     "description": "Human-readable description of this provider instance.",
-                    "examples": ["Production HashiCorp Vault for signing keys"],
+                    "examples": [
+                      "Production HashiCorp Vault for signing keys"
+                    ],
                     "anyOf": [
                       {
                         "type": "string",
@@ -8783,7 +9983,9 @@
                       }
                     ],
                     "description": "URL of the HashiCorp Vault instance. Supports ${ENV_VAR} placeholders.",
-                    "examples": ["${VAULT_URL}"]
+                    "examples": [
+                      "${VAULT_URL}"
+                    ]
                   },
                   "vaultToken": {
                     "anyOf": [
@@ -8797,10 +9999,17 @@
                       }
                     ],
                     "description": "Authentication token for HashiCorp Vault. Supports ${ENV_VAR} placeholders.",
-                    "examples": ["${VAULT_TOKEN}"]
+                    "examples": [
+                      "${VAULT_TOKEN}"
+                    ]
                   }
                 },
-                "required": ["id", "type", "vaultUrl", "vaultToken"],
+                "required": [
+                  "id",
+                  "type",
+                  "vaultUrl",
+                  "vaultToken"
+                ],
                 "additionalProperties": false
               },
               {
@@ -8818,17 +10027,23 @@
                       }
                     ],
                     "description": "Unique identifier for this provider instance. Used when generating keys to specify which provider to use.",
-                    "examples": ["main-vault"]
+                    "examples": [
+                      "main-vault"
+                    ]
                   },
                   "type": {
                     "type": "string",
                     "const": "aws-kms",
                     "description": "Type of the KMS provider.",
-                    "examples": ["aws-kms"]
+                    "examples": [
+                      "aws-kms"
+                    ]
                   },
                   "description": {
                     "description": "Human-readable description of this provider instance.",
-                    "examples": ["Production HashiCorp Vault for signing keys"],
+                    "examples": [
+                      "Production HashiCorp Vault for signing keys"
+                    ],
                     "anyOf": [
                       {
                         "type": "string",
@@ -8852,11 +10067,15 @@
                       }
                     ],
                     "description": "AWS region for KMS. Supports ${ENV_VAR} placeholders.",
-                    "examples": ["${AWS_REGION}"]
+                    "examples": [
+                      "${AWS_REGION}"
+                    ]
                   },
                   "accessKeyId": {
                     "description": "AWS access key ID. Optional — uses SDK credential chain if not provided. Supports ${ENV_VAR} placeholders.",
-                    "examples": ["${AWS_ACCESS_KEY_ID}"],
+                    "examples": [
+                      "${AWS_ACCESS_KEY_ID}"
+                    ],
                     "anyOf": [
                       {
                         "type": "string",
@@ -8870,7 +10089,9 @@
                   },
                   "secretAccessKey": {
                     "description": "AWS secret access key. Optional — uses SDK credential chain if not provided. Supports ${ENV_VAR} placeholders.",
-                    "examples": ["${AWS_SECRET_ACCESS_KEY}"],
+                    "examples": [
+                      "${AWS_SECRET_ACCESS_KEY}"
+                    ],
                     "anyOf": [
                       {
                         "type": "string",
@@ -8883,7 +10104,11 @@
                     ]
                   }
                 },
-                "required": ["id", "type", "region"],
+                "required": [
+                  "id",
+                  "type",
+                  "region"
+                ],
                 "additionalProperties": false
               },
               {
@@ -8901,17 +10126,23 @@
                       }
                     ],
                     "description": "Unique identifier for this provider instance. Used when generating keys to specify which provider to use.",
-                    "examples": ["main-vault"]
+                    "examples": [
+                      "main-vault"
+                    ]
                   },
                   "type": {
                     "type": "string",
                     "const": "pkcs11",
                     "description": "Type of the KMS provider.",
-                    "examples": ["pkcs11"]
+                    "examples": [
+                      "pkcs11"
+                    ]
                   },
                   "description": {
                     "description": "Human-readable description of this provider instance.",
-                    "examples": ["Production HashiCorp Vault for signing keys"],
+                    "examples": [
+                      "Production HashiCorp Vault for signing keys"
+                    ],
                     "anyOf": [
                       {
                         "type": "string",
@@ -8935,7 +10166,9 @@
                       }
                     ],
                     "description": "Absolute path to the PKCS#11 module library (.so/.dll/.dylib). Supports ${ENV_VAR} placeholders.",
-                    "examples": ["${PKCS11_LIBRARY}"]
+                    "examples": [
+                      "${PKCS11_LIBRARY}"
+                    ]
                   },
                   "slot": {
                     "anyOf": [
@@ -8947,7 +10180,9 @@
                       }
                     ],
                     "description": "Slot selection. Either the numeric slot index (as a string for ENV interpolation, or a number) or the token label. Supports ${ENV_VAR} placeholders.",
-                    "examples": ["${PKCS11_SLOT}"]
+                    "examples": [
+                      "${PKCS11_SLOT}"
+                    ]
                   },
                   "pin": {
                     "anyOf": [
@@ -8961,15 +10196,25 @@
                       }
                     ],
                     "description": "User PIN used for C_Login. Supports ${ENV_VAR} placeholders.",
-                    "examples": ["${PKCS11_PIN}"]
+                    "examples": [
+                      "${PKCS11_PIN}"
+                    ]
                   },
                   "readOnly": {
                     "description": "Open the PKCS#11 session in read-only mode. Defaults to false.",
-                    "examples": [false],
+                    "examples": [
+                      false
+                    ],
                     "type": "boolean"
                   }
                 },
-                "required": ["id", "type", "library", "slot", "pin"],
+                "required": [
+                  "id",
+                  "type",
+                  "library",
+                  "slot",
+                  "pin"
+                ],
                 "additionalProperties": false
               },
               {
@@ -8987,17 +10232,23 @@
                       }
                     ],
                     "description": "Unique identifier for this provider instance. Used when generating keys to specify which provider to use.",
-                    "examples": ["main-vault"]
+                    "examples": [
+                      "main-vault"
+                    ]
                   },
                   "type": {
                     "type": "string",
                     "const": "http",
                     "description": "Type of the KMS provider.",
-                    "examples": ["http"]
+                    "examples": [
+                      "http"
+                    ]
                   },
                   "description": {
                     "description": "Human-readable description of this provider instance.",
-                    "examples": ["Production HashiCorp Vault for signing keys"],
+                    "examples": [
+                      "Production HashiCorp Vault for signing keys"
+                    ],
                     "anyOf": [
                       {
                         "type": "string",
@@ -9021,7 +10272,9 @@
                       }
                     ],
                     "description": "Base URL of the remote KMS microservice (no trailing slash). Supports ${ENV_VAR} placeholders.",
-                    "examples": ["${KMS_SERVICE_URL}"]
+                    "examples": [
+                      "${KMS_SERVICE_URL}"
+                    ]
                   },
                   "auth": {
                     "description": "Authentication method for the remote KMS service. Supports bearer token, OAuth 2.0 client credentials, and mutual TLS. Omit (or set type to \"none\") for unauthenticated services.",
@@ -9033,10 +10286,14 @@
                             "type": "string",
                             "const": "none",
                             "description": "No authentication — suitable for services on a trusted private network.",
-                            "examples": ["none"]
+                            "examples": [
+                              "none"
+                            ]
                           }
                         },
-                        "required": ["type"],
+                        "required": [
+                          "type"
+                        ],
                         "additionalProperties": false
                       },
                       {
@@ -9046,7 +10303,9 @@
                             "type": "string",
                             "const": "bearer",
                             "description": "Static Bearer token sent as Authorization: Bearer <token>.",
-                            "examples": ["bearer"]
+                            "examples": [
+                              "bearer"
+                            ]
                           },
                           "token": {
                             "anyOf": [
@@ -9060,10 +10319,15 @@
                               }
                             ],
                             "description": "Bearer token value. Supports ${ENV_VAR} placeholders.",
-                            "examples": ["${KMS_API_KEY}"]
+                            "examples": [
+                              "${KMS_API_KEY}"
+                            ]
                           }
                         },
-                        "required": ["type", "token"],
+                        "required": [
+                          "type",
+                          "token"
+                        ],
                         "additionalProperties": false
                       },
                       {
@@ -9073,7 +10337,9 @@
                             "type": "string",
                             "const": "oauth2-client-credentials",
                             "description": "OAuth 2.0 Client Credentials — EUDIPLO fetches and caches short-lived tokens.",
-                            "examples": ["oauth2-client-credentials"]
+                            "examples": [
+                              "oauth2-client-credentials"
+                            ]
                           },
                           "tokenUrl": {
                             "anyOf": [
@@ -9087,7 +10353,9 @@
                               }
                             ],
                             "description": "Token endpoint URL (e.g. Keycloak, Entra ID). Supports ${ENV_VAR} placeholders.",
-                            "examples": ["${IAM_TOKEN_URL}"]
+                            "examples": [
+                              "${IAM_TOKEN_URL}"
+                            ]
                           },
                           "clientId": {
                             "anyOf": [
@@ -9101,7 +10369,9 @@
                               }
                             ],
                             "description": "OAuth 2.0 client ID. Supports ${ENV_VAR} placeholders.",
-                            "examples": ["${KMS_CLIENT_ID}"]
+                            "examples": [
+                              "${KMS_CLIENT_ID}"
+                            ]
                           },
                           "clientSecret": {
                             "anyOf": [
@@ -9115,11 +10385,15 @@
                               }
                             ],
                             "description": "OAuth 2.0 client secret. Supports ${ENV_VAR} placeholders.",
-                            "examples": ["${KMS_CLIENT_SECRET}"]
+                            "examples": [
+                              "${KMS_CLIENT_SECRET}"
+                            ]
                           },
                           "scope": {
                             "description": "Space-separated list of OAuth 2.0 scopes to request. Optional.",
-                            "examples": ["kms:sign kms:admin"],
+                            "examples": [
+                              "kms:sign kms:admin"
+                            ],
                             "anyOf": [
                               {
                                 "type": "string",
@@ -9132,7 +10406,12 @@
                             ]
                           }
                         },
-                        "required": ["type", "tokenUrl", "clientId", "clientSecret"],
+                        "required": [
+                          "type",
+                          "tokenUrl",
+                          "clientId",
+                          "clientSecret"
+                        ],
                         "additionalProperties": false
                       },
                       {
@@ -9142,7 +10421,9 @@
                             "type": "string",
                             "const": "mtls",
                             "description": "Mutual TLS — EUDIPLO presents a client certificate on every connection.",
-                            "examples": ["mtls"]
+                            "examples": [
+                              "mtls"
+                            ]
                           },
                           "certFile": {
                             "anyOf": [
@@ -9156,7 +10437,9 @@
                               }
                             ],
                             "description": "Absolute path to the PEM-encoded client certificate file. Supports ${ENV_VAR} placeholders.",
-                            "examples": ["/etc/certs/eudiplo.crt"]
+                            "examples": [
+                              "/etc/certs/eudiplo.crt"
+                            ]
                           },
                           "keyFile": {
                             "anyOf": [
@@ -9170,11 +10453,15 @@
                               }
                             ],
                             "description": "Absolute path to the PEM-encoded private key file for the client certificate. Supports ${ENV_VAR} placeholders.",
-                            "examples": ["/etc/certs/eudiplo.key"]
+                            "examples": [
+                              "/etc/certs/eudiplo.key"
+                            ]
                           },
                           "caFile": {
                             "description": "Absolute path to the PEM-encoded CA bundle to trust for the remote server's certificate. Omit to use the system CA store.",
-                            "examples": ["/etc/certs/ca.crt"],
+                            "examples": [
+                              "/etc/certs/ca.crt"
+                            ],
                             "anyOf": [
                               {
                                 "type": "string",
@@ -9187,14 +10474,20 @@
                             ]
                           }
                         },
-                        "required": ["type", "certFile", "keyFile"],
+                        "required": [
+                          "type",
+                          "certFile",
+                          "keyFile"
+                        ],
                         "additionalProperties": false
                       }
                     ]
                   },
                   "keysPath": {
                     "description": "Path prefix for key endpoints on the remote service. Defaults to /keys.",
-                    "examples": ["/v1/keys"],
+                    "examples": [
+                      "/v1/keys"
+                    ],
                     "anyOf": [
                       {
                         "type": "string",
@@ -9208,7 +10501,9 @@
                   },
                   "healthPath": {
                     "description": "Path for the health check endpoint on the remote service. Defaults to /health.",
-                    "examples": ["/health"],
+                    "examples": [
+                      "/health"
+                    ],
                     "anyOf": [
                       {
                         "type": "string",
@@ -9222,11 +10517,17 @@
                   },
                   "canImport": {
                     "description": "Whether the remote service supports key import via POST {keysPath}/{kid}/import. Defaults to false.",
-                    "examples": [false],
+                    "examples": [
+                      false
+                    ],
                     "type": "boolean"
                   }
                 },
-                "required": ["id", "type", "baseUrl"],
+                "required": [
+                  "id",
+                  "type",
+                  "baseUrl"
+                ],
                 "additionalProperties": false
               },
               {
@@ -9244,17 +10545,23 @@
                       }
                     ],
                     "description": "Unique identifier for this provider instance. Used when generating keys to specify which provider to use.",
-                    "examples": ["main-vault"]
+                    "examples": [
+                      "main-vault"
+                    ]
                   },
                   "type": {
                     "type": "string",
                     "const": "csc",
                     "description": "Type of the KMS provider.",
-                    "examples": ["csc"]
+                    "examples": [
+                      "csc"
+                    ]
                   },
                   "description": {
                     "description": "Human-readable description of this provider instance.",
-                    "examples": ["Production HashiCorp Vault for signing keys"],
+                    "examples": [
+                      "Production HashiCorp Vault for signing keys"
+                    ],
                     "anyOf": [
                       {
                         "type": "string",
@@ -9278,7 +10585,9 @@
                       }
                     ],
                     "description": "Base URL of the CSC service (without trailing slash). Supports ${ENV_VAR} placeholders.",
-                    "examples": ["${CSC_URL}"]
+                    "examples": [
+                      "${CSC_URL}"
+                    ]
                   },
                   "tokenUrl": {
                     "anyOf": [
@@ -9292,7 +10601,9 @@
                       }
                     ],
                     "description": "OAuth2 token endpoint URL for client-credentials flow. Supports ${ENV_VAR} placeholders.",
-                    "examples": ["${CSC_TOKEN_URL}"]
+                    "examples": [
+                      "${CSC_TOKEN_URL}"
+                    ]
                   },
                   "clientId": {
                     "anyOf": [
@@ -9306,7 +10617,9 @@
                       }
                     ],
                     "description": "OAuth2 client ID. Supports ${ENV_VAR} placeholders.",
-                    "examples": ["${CSC_CLIENT_ID}"]
+                    "examples": [
+                      "${CSC_CLIENT_ID}"
+                    ]
                   },
                   "clientSecret": {
                     "anyOf": [
@@ -9320,11 +10633,15 @@
                       }
                     ],
                     "description": "OAuth2 client secret. Supports ${ENV_VAR} placeholders.",
-                    "examples": ["${CSC_CLIENT_SECRET}"]
+                    "examples": [
+                      "${CSC_CLIENT_SECRET}"
+                    ]
                   },
                   "scope": {
                     "description": "OAuth2 scope to request during token acquisition.",
-                    "examples": ["service"],
+                    "examples": [
+                      "service"
+                    ],
                     "anyOf": [
                       {
                         "type": "string",
@@ -9338,7 +10655,9 @@
                   },
                   "credentialId": {
                     "description": "Default CSC credential ID. If omitted, the adapter calls credentials/list and picks the first entry.",
-                    "examples": ["[INTESIQCSEALEC]_SEAL_351_SIGN_1781018892758"],
+                    "examples": [
+                      "[INTESIQCSEALEC]_SEAL_351_SIGN_1781018892758"
+                    ],
                     "anyOf": [
                       {
                         "type": "string",
@@ -9352,7 +10671,9 @@
                   },
                   "userId": {
                     "description": "Optional CSC user ID used in credentials/list requests.",
-                    "examples": ["eudiplo_user"],
+                    "examples": [
+                      "eudiplo_user"
+                    ],
                     "anyOf": [
                       {
                         "type": "string",
@@ -9366,7 +10687,9 @@
                   },
                   "apiPath": {
                     "description": "CSC API path prefix appended to baseUrl. Defaults to /csc/v2.",
-                    "examples": ["/csc/v2"],
+                    "examples": [
+                      "/csc/v2"
+                    ],
                     "anyOf": [
                       {
                         "type": "string",
@@ -9380,7 +10703,9 @@
                   },
                   "hashAlgorithmOid": {
                     "description": "Hash algorithm OID for signatures/signHash and credentials/authorize. Defaults to SHA-256 OID.",
-                    "examples": ["2.16.840.1.101.3.4.2.1"],
+                    "examples": [
+                      "2.16.840.1.101.3.4.2.1"
+                    ],
                     "anyOf": [
                       {
                         "type": "string",
@@ -9394,7 +10719,9 @@
                   },
                   "signAlgorithmOid": {
                     "description": "Signature algorithm OID for signatures/signHash. Defaults to ecdsa-with-SHA256 OID.",
-                    "examples": ["1.2.840.10045.4.3.2"],
+                    "examples": [
+                      "1.2.840.10045.4.3.2"
+                    ],
                     "anyOf": [
                       {
                         "type": "string",
@@ -9421,7 +10748,9 @@
                   },
                   "useAuthorizeEndpoint": {
                     "description": "When true and no static SAD is provided, the adapter calls credentials/authorize to obtain SAD before signatures/signHash.",
-                    "examples": [false],
+                    "examples": [
+                      false
+                    ],
                     "type": "boolean"
                   },
                   "authorizeAuthData": {
@@ -9442,7 +10771,9 @@
                             }
                           ],
                           "description": "Authentication factor identifier expected by the CSC provider (e.g., PIN, OTP).",
-                          "examples": ["PIN"]
+                          "examples": [
+                            "PIN"
+                          ]
                         },
                         "value": {
                           "anyOf": [
@@ -9456,15 +10787,27 @@
                             }
                           ],
                           "description": "Authentication factor value sent to CSC credentials/authorize.",
-                          "examples": ["123456"]
+                          "examples": [
+                            "123456"
+                          ]
                         }
                       },
-                      "required": ["id", "value"],
+                      "required": [
+                        "id",
+                        "value"
+                      ],
                       "additionalProperties": false
                     }
                   }
                 },
-                "required": ["id", "type", "baseUrl", "tokenUrl", "clientId", "clientSecret"],
+                "required": [
+                  "id",
+                  "type",
+                  "baseUrl",
+                  "tokenUrl",
+                  "clientId",
+                  "clientSecret"
+                ],
                 "additionalProperties": false
               }
             ]
@@ -9494,7 +10837,9 @@
           ]
         }
       },
-      "required": ["providers"],
+      "required": [
+        "providers"
+      ],
       "additionalProperties": false,
       "$id": "./KmsConfigDto.schema.json",
       "title": "KmsConfigDto"
@@ -9502,7 +10847,9 @@
   },
   {
     "uri": "./PresentationConfigCreateDto.schema.json",
-    "fileMatch": ["a://b/PresentationConfigCreateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/PresentationConfigCreateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -9538,7 +10885,11 @@
         "statusCheckMode": {
           "description": "Revocation/status check mode.",
           "type": "string",
-          "enum": ["strict", "best_effort", "disabled"]
+          "enum": [
+            "strict",
+            "best_effort",
+            "disabled"
+          ]
         },
         "dcql_query": {
           "type": "object",
@@ -9624,7 +10975,10 @@
                                   "description": "Trust list references for ETSI TL verification."
                                 }
                               },
-                              "required": ["type", "values"],
+                              "required": [
+                                "type",
+                                "values"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -9643,7 +10997,10 @@
                                   "description": "OpenID Federation authority identifiers."
                                 }
                               },
-                              "required": ["type", "values"],
+                              "required": [
+                                "type",
+                                "values"
+                              ],
                               "additionalProperties": false
                             }
                           ]
@@ -9666,7 +11023,9 @@
                             "description": "Accepted VCT values."
                           }
                         },
-                        "required": ["vct_values"],
+                        "required": [
+                          "vct_values"
+                        ],
                         "additionalProperties": false
                       },
                       "claims": {
@@ -9701,12 +11060,18 @@
                               }
                             }
                           },
-                          "required": ["path"],
+                          "required": [
+                            "path"
+                          ],
                           "additionalProperties": false
                         }
                       }
                     },
-                    "required": ["id", "format", "meta"],
+                    "required": [
+                      "id",
+                      "format",
+                      "meta"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -9785,7 +11150,10 @@
                                   "description": "Trust list references for ETSI TL verification."
                                 }
                               },
-                              "required": ["type", "values"],
+                              "required": [
+                                "type",
+                                "values"
+                              ],
                               "additionalProperties": false
                             },
                             {
@@ -9804,7 +11172,10 @@
                                   "description": "OpenID Federation authority identifiers."
                                 }
                               },
-                              "required": ["type", "values"],
+                              "required": [
+                                "type",
+                                "values"
+                              ],
                               "additionalProperties": false
                             }
                           ]
@@ -9824,7 +11195,9 @@
                             "description": "Expected mDoc doctype value."
                           }
                         },
-                        "required": ["doctype_value"],
+                        "required": [
+                          "doctype_value"
+                        ],
                         "additionalProperties": false
                       },
                       "claims": {
@@ -9863,12 +11236,18 @@
                               "type": "boolean"
                             }
                           },
-                          "required": ["path"],
+                          "required": [
+                            "path"
+                          ],
                           "additionalProperties": false
                         }
                       }
                     },
-                    "required": ["id", "format", "meta"],
+                    "required": [
+                      "id",
+                      "format",
+                      "meta"
+                    ],
                     "additionalProperties": false
                   }
                 ]
@@ -9898,12 +11277,16 @@
                     "type": "boolean"
                   }
                 },
-                "required": ["options"],
+                "required": [
+                  "options"
+                ],
                 "additionalProperties": false
               }
             }
           },
-          "required": ["credentials"],
+          "required": [
+            "credentials"
+          ],
           "additionalProperties": false,
           "description": "DCQL query defining requested credentials and claims."
         },
@@ -9925,7 +11308,10 @@
                 "description": "Credential query ids this transaction data applies to."
               }
             },
-            "required": ["type", "credential_ids"],
+            "required": [
+              "type",
+              "credential_ids"
+            ],
             "additionalProperties": {}
           }
         },
@@ -9962,7 +11348,10 @@
                             "type": "string"
                           }
                         },
-                        "required": ["lang", "content"],
+                        "required": [
+                          "lang",
+                          "content"
+                        ],
                         "additionalProperties": false
                       }
                     },
@@ -10034,7 +11423,10 @@
                     }
                   }
                 },
-                "required": ["format", "data"],
+                "required": [
+                  "format",
+                  "data"
+                ],
                 "additionalProperties": false
               }
             },
@@ -10077,7 +11469,10 @@
           ]
         }
       },
-      "required": ["id", "dcql_query"],
+      "required": [
+        "id",
+        "dcql_query"
+      ],
       "additionalProperties": false,
       "$id": "./PresentationConfigCreateDto.schema.json",
       "title": "PresentationConfigCreateDto"
@@ -10085,7 +11480,9 @@
   },
   {
     "uri": "./RotationPolicyCreateDto.schema.json",
-    "fileMatch": ["a://b/RotationPolicyCreateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/RotationPolicyCreateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -10107,7 +11504,9 @@
           "maximum": 3650
         }
       },
-      "required": ["enabled"],
+      "required": [
+        "enabled"
+      ],
       "additionalProperties": false,
       "$id": "./RotationPolicyCreateDto.schema.json",
       "title": "RotationPolicyCreateDto"
@@ -10115,7 +11514,9 @@
   },
   {
     "uri": "./RotationPolicyUpdateDto.schema.json",
-    "fileMatch": ["a://b/RotationPolicyUpdateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/RotationPolicyUpdateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -10144,7 +11545,9 @@
   },
   {
     "uri": "./SessionStorageConfig.schema.json",
-    "fileMatch": ["a://b/SessionStorageConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/SessionStorageConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -10158,7 +11561,10 @@
         "cleanupMode": {
           "description": "Whether to fully delete or anonymize expired sessions.",
           "type": "string",
-          "enum": ["full", "anonymize"]
+          "enum": [
+            "full",
+            "anonymize"
+          ]
         }
       },
       "additionalProperties": false,
@@ -10169,7 +11575,9 @@
   },
   {
     "uri": "./StatusListConfig.schema.json",
-    "fileMatch": ["a://b/StatusListConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/StatusListConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -10224,7 +11632,9 @@
   },
   {
     "uri": "./StatusListImportDto.schema.json",
-    "fileMatch": ["a://b/StatusListImportDto*.schema.json"],
+    "fileMatch": [
+      "a://b/StatusListImportDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -10279,7 +11689,9 @@
           ]
         }
       },
-      "required": ["id"],
+      "required": [
+        "id"
+      ],
       "additionalProperties": false,
       "$id": "./StatusListImportDto.schema.json",
       "title": "StatusListImportDto"
@@ -10287,7 +11699,9 @@
   },
   {
     "uri": "./TransactionData.schema.json",
-    "fileMatch": ["a://b/TransactionData*.schema.json"],
+    "fileMatch": [
+      "a://b/TransactionData*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -10304,7 +11718,10 @@
           "description": "Credential query ids this transaction data applies to."
         }
       },
-      "required": ["type", "credential_ids"],
+      "required": [
+        "type",
+        "credential_ids"
+      ],
       "additionalProperties": {},
       "$id": "./TransactionData.schema.json",
       "title": "TransactionData"
@@ -10312,7 +11729,9 @@
   },
   {
     "uri": "./TrustListCreateDto.schema.json",
-    "fileMatch": ["a://b/TrustListCreateDto*.schema.json"],
+    "fileMatch": [
+      "a://b/TrustListCreateDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -10395,12 +11814,19 @@
                         "type": "string"
                       }
                     },
-                    "required": ["name"],
+                    "required": [
+                      "name"
+                    ],
                     "additionalProperties": false,
                     "description": "Entity metadata."
                   }
                 },
-                "required": ["type", "issuerKeyChainId", "revocationKeyChainId", "info"],
+                "required": [
+                  "type",
+                  "issuerKeyChainId",
+                  "revocationKeyChainId",
+                  "info"
+                ],
                 "additionalProperties": false
               },
               {
@@ -10462,12 +11888,19 @@
                         "type": "string"
                       }
                     },
-                    "required": ["name"],
+                    "required": [
+                      "name"
+                    ],
                     "additionalProperties": false,
                     "description": "Entity metadata."
                   }
                 },
-                "required": ["type", "issuerCertPem", "revocationCertPem", "info"],
+                "required": [
+                  "type",
+                  "issuerCertPem",
+                  "revocationCertPem",
+                  "info"
+                ],
                 "additionalProperties": false
               }
             ]
@@ -10483,7 +11916,9 @@
           "additionalProperties": {}
         }
       },
-      "required": ["entities"],
+      "required": [
+        "entities"
+      ],
       "additionalProperties": false,
       "$id": "./TrustListCreateDto.schema.json",
       "title": "TrustListCreateDto"
@@ -10491,7 +11926,9 @@
   },
   {
     "uri": "./UpdateAttributeProviderDto.schema.json",
-    "fileMatch": ["a://b/UpdateAttributeProviderDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateAttributeProviderDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -10534,7 +11971,9 @@
                   "description": "Disable authentication for attribute provider calls."
                 }
               },
-              "required": ["type"],
+              "required": [
+                "type"
+              ],
               "additionalProperties": false,
               "description": "No authentication variant."
             },
@@ -10560,12 +11999,18 @@
                       "description": "API key value."
                     }
                   },
-                  "required": ["headerName", "value"],
+                  "required": [
+                    "headerName",
+                    "value"
+                  ],
                   "additionalProperties": false,
                   "description": "API key authentication settings."
                 }
               },
-              "required": ["type", "config"],
+              "required": [
+                "type",
+                "config"
+              ],
               "additionalProperties": false,
               "description": "API key authentication variant."
             }
@@ -10580,7 +12025,9 @@
   },
   {
     "uri": "./UpdateClientDto.schema.json",
-    "fileMatch": ["a://b/UpdateClientDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateClientDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -10646,7 +12093,9 @@
   },
   {
     "uri": "./UpdateStatusListConfigDto.schema.json",
-    "fileMatch": ["a://b/UpdateStatusListConfigDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateStatusListConfigDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -10735,7 +12184,9 @@
   },
   {
     "uri": "./UpdateStatusListDto.schema.json",
-    "fileMatch": ["a://b/UpdateStatusListDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateStatusListDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -10772,7 +12223,9 @@
   },
   {
     "uri": "./UpdateTenantDto.schema.json",
-    "fileMatch": ["a://b/UpdateTenantDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateTenantDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -10807,7 +12260,10 @@
             "cleanupMode": {
               "description": "Whether to fully delete or anonymize expired sessions.",
               "type": "string",
-              "enum": ["full", "anonymize"]
+              "enum": [
+                "full",
+                "anonymize"
+              ]
             }
           },
           "additionalProperties": false
@@ -10869,7 +12325,9 @@
   },
   {
     "uri": "./UpdateWebhookEndpointDto.schema.json",
-    "fileMatch": ["a://b/UpdateWebhookEndpointDto*.schema.json"],
+    "fileMatch": [
+      "a://b/UpdateWebhookEndpointDto*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -10912,7 +12370,9 @@
                   "description": "Disable webhook authentication."
                 }
               },
-              "required": ["type"],
+              "required": [
+                "type"
+              ],
               "additionalProperties": false,
               "description": "No webhook authentication variant."
             },
@@ -10938,12 +12398,18 @@
                       "description": "API key value sent with webhook requests."
                     }
                   },
-                  "required": ["headerName", "value"],
+                  "required": [
+                    "headerName",
+                    "value"
+                  ],
                   "additionalProperties": false,
                   "description": "API key webhook authentication settings."
                 }
               },
-              "required": ["type", "config"],
+              "required": [
+                "type",
+                "config"
+              ],
               "additionalProperties": false,
               "description": "API key webhook authentication variant."
             }
@@ -10958,7 +12424,9 @@
   },
   {
     "uri": "./VCT.schema.json",
-    "fileMatch": ["a://b/VCT*.schema.json"],
+    "fileMatch": [
+      "a://b/VCT*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -10999,7 +12467,9 @@
   },
   {
     "uri": "./WebhookConfig.schema.json",
-    "fileMatch": ["a://b/WebhookConfig*.schema.json"],
+    "fileMatch": [
+      "a://b/WebhookConfig*.schema.json"
+    ],
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -11020,7 +12490,9 @@
                   "description": "Disable authentication."
                 }
               },
-              "required": ["type"],
+              "required": [
+                "type"
+              ],
               "additionalProperties": false
             },
             {
@@ -11045,12 +12517,18 @@
                       "description": "The API key value."
                     }
                   },
-                  "required": ["headerName", "value"],
+                  "required": [
+                    "headerName",
+                    "value"
+                  ],
                   "additionalProperties": false,
                   "description": "API key authentication settings."
                 }
               },
-              "required": ["type", "config"],
+              "required": [
+                "type",
+                "config"
+              ],
               "additionalProperties": false
             }
           ],
@@ -11064,7 +12542,10 @@
           }
         }
       },
-      "required": ["url", "auth"],
+      "required": [
+        "url",
+        "auth"
+      ],
       "additionalProperties": false,
       "$id": "./WebhookConfig.schema.json",
       "title": "WebhookConfig"

--- a/packages/eudiplo-sdk-core/src/api/types.gen.ts
+++ b/packages/eudiplo-sdk-core/src/api/types.gen.ts
@@ -1178,6 +1178,10 @@ export type IssuanceConfig = {
      */
     credentialRequestEncryption?: boolean;
     /**
+     * Whether the issuer notification endpoint is enabled and advertised in metadata.
+     */
+    notificationEndpointEnabled?: boolean;
+    /**
      * Maximum failed tx_code attempts before the pre-authorized code is invalidated. Defaults to 5.
      */
     txCodeMaxAttempts?: number;
@@ -1247,6 +1251,10 @@ export type UpdateIssuanceDto = {
      * Whether `credential_request_encryption` should be advertised in the credential issuer metadata.
      */
     credentialRequestEncryption?: boolean;
+    /**
+     * Whether the issuer notification endpoint is enabled and advertised in metadata.
+     */
+    notificationEndpointEnabled?: boolean;
     /**
      * Maximum failed tx_code attempts before the pre-authorized code is invalidated. Defaults to 5.
      */
@@ -3748,6 +3756,10 @@ export type IssuanceConfigWritable = {
      */
     credentialRequestEncryption?: boolean;
     /**
+     * Whether the issuer notification endpoint is enabled and advertised in metadata.
+     */
+    notificationEndpointEnabled?: boolean;
+    /**
      * Maximum failed tx_code attempts before the pre-authorized code is invalidated. Defaults to 5.
      */
     txCodeMaxAttempts?: number;
@@ -3813,6 +3825,10 @@ export type UpdateIssuanceDtoWritable = {
      * Whether `credential_request_encryption` should be advertised in the credential issuer metadata.
      */
     credentialRequestEncryption?: boolean;
+    /**
+     * Whether the issuer notification endpoint is enabled and advertised in metadata.
+     */
+    notificationEndpointEnabled?: boolean;
     /**
      * Maximum failed tx_code attempts before the pre-authorized code is invalidated. Defaults to 5.
      */

--- a/schemas/IssuanceConfig.schema.json
+++ b/schemas/IssuanceConfig.schema.json
@@ -469,6 +469,11 @@
       "description": "Require encrypted credential requests.",
       "type": "boolean"
     },
+    "notificationEndpointEnabled": {
+      "description": "Whether the issuer notification endpoint is enabled and advertised in metadata.",
+      "type": "boolean",
+      "default": true
+    },
     "txCodeMaxAttempts": {
       "description": "Maximum verification attempts for transaction codes. Null resets to defaults.",
       "anyOf": [


### PR DESCRIPTION
## 📝 Description

Adds a per-issuance configuration flag to enable or disable the OpenID4VCI notification endpoint. The setting defaults to enabled for backward compatibility and is now configurable from the Angular client.

Fixes #919

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [x] 🧪 Test improvements
- [ ] 🏗️ Build/CI changes

## 💥 Breaking Changes (if applicable)

None. Existing configurations retain the notification endpoint because the new setting defaults to enabled.

## 🧪 Testing

- [x] Integration tests pass
- [x] Manual build verification performed

**Test Configuration**:

- Node.js version: workspace default
- OS: macOS
- Test environment: local

Validation performed:
- Targeted backend issuance metadata regression tests passed.
- `pnpm --filter @eudiplo/client exec ng build --configuration development` passed.
- Commit hooks passed formatting and linting.

## 📸 Screenshots (if applicable)

Not included; the change is a small configuration toggle.

## ✔️ Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing relevant checks pass locally

## 📋 Additional Notes

The backend omits `notification_endpoint` from issuer metadata and rejects notification callbacks when the setting is disabled. The client form and read-only view expose the setting.