### PR TITLE
feat(issuance): add credential reuse policy

### DIFF
--- a/apps/backend/src/issuer/configuration/credentials/credentials.service.ts
+++ b/apps/backend/src/issuer/configuration/credentials/credentials.service.ts
@@ -180,6 +180,23 @@ export class CredentialsService {
         );
     }
 
+    private buildCredentialMetadata(
+        entity: CredentialConfig,
+    ): Record<string, unknown> | undefined {
+        const metadata: Record<string, unknown> = {};
+        if (entity.config.display) {
+            metadata.display = entity.config.display;
+        }
+        if (entity.fields.length > 0) {
+            metadata.claims = buildClaimsMetadata(entity.fields as any);
+        }
+        if (entity.config.credentialReusePolicy) {
+            metadata.credential_reuse_policy =
+                entity.config.credentialReusePolicy;
+        }
+        return Object.keys(metadata).length > 0 ? metadata : undefined;
+    }
+
     async getSupportedProofTypesForCredentialConfig(
         tenantId: string,
         credentialConfigurationId: string,
@@ -213,16 +230,7 @@ export class CredentialsService {
         }
 
         // Build credential_metadata with display and claims
-        const credentialMetadata = entity.config.display
-            ? {
-                  display: entity.config.display,
-                  ...(entity.fields.length > 0 && {
-                      claims: buildClaimsMetadata(entity.fields as any),
-                  }),
-              }
-            : entity.fields.length > 0
-              ? { claims: buildClaimsMetadata(entity.fields as any) }
-              : undefined;
+        const credentialMetadata = this.buildCredentialMetadata(entity);
 
         // Build proof_types_supported with optional key_attestations_required
         const keyAttestationsRequired = entity.config.keyAttestationsRequired;
@@ -298,16 +306,7 @@ export class CredentialsService {
         }
 
         // Build credential_metadata with display and claims
-        const credentialMetadata = entity.config.display
-            ? {
-                  display: entity.config.display,
-                  ...(entity.fields.length > 0 && {
-                      claims: buildClaimsMetadata(entity.fields as any),
-                  }),
-              }
-            : entity.fields.length > 0
-              ? { claims: buildClaimsMetadata(entity.fields as any) }
-              : undefined;
+        const credentialMetadata = this.buildCredentialMetadata(entity);
 
         // Build proof_types_supported with optional key_attestations_required
         const keyAttestationsRequired = entity.config.keyAttestationsRequired;

--- a/apps/backend/src/issuer/configuration/credentials/dto/credential-reuse-policy.dto.ts
+++ b/apps/backend/src/issuer/configuration/credentials/dto/credential-reuse-policy.dto.ts
@@ -1,0 +1,6 @@
+import { createZodDto } from "nestjs-zod";
+import { CredentialReusePolicySchema } from "../schemas/credential-config.schema";
+
+export class CredentialReusePolicy extends createZodDto(
+    CredentialReusePolicySchema,
+) {}

--- a/apps/backend/src/issuer/configuration/credentials/entities/credential.entity.ts
+++ b/apps/backend/src/issuer/configuration/credentials/entities/credential.entity.ts
@@ -13,6 +13,7 @@ import { AttributeProviderEntity } from "../../attribute-provider/entities/attri
 import { KeyAttestationsRequired } from "../../issuance/dto/key-attestations-required.dto";
 import { WebhookEndpointEntity } from "../../webhook-endpoint/entities/webhook-endpoint.entity";
 import { ClaimFieldDefinitionDto } from "../dto/claim-field-definition.dto";
+import { CredentialReusePolicy } from "../dto/credential-reuse-policy.dto";
 import { SchemaMetaConfig } from "../dto/schema-meta-config.dto";
 import {
     IaeAction,
@@ -94,6 +95,9 @@ export class IssuerMetadataCredentialConfig {
         example: [CredentialProofType.ATTESTATION, CredentialProofType.JWT],
     })
     proofTypesSupported?: CredentialProofType[];
+
+    @ApiPropertyOptional({ type: () => CredentialReusePolicy })
+    credentialReusePolicy?: CredentialReusePolicy;
 }
 
 @ApiExtraModels(

--- a/apps/backend/src/issuer/configuration/credentials/schemas/credential-config.schema.ts
+++ b/apps/backend/src/issuer/configuration/credentials/schemas/credential-config.schema.ts
@@ -300,6 +300,88 @@ const CredentialDisplaySchema = FieldDisplaySchema.extend({
     logo: DisplayImageSchema.optional().describe("Optional logo image."),
 }).strict();
 
+const CredentialReusePolicyOptionSchema = z
+    .object({
+        details: z
+            .array(
+                z.enum([
+                    "once_only",
+                    "limited_time",
+                    "limited-time",
+                    "rotating-batch",
+                    "per-relying-party",
+                ]),
+            )
+            .min(1),
+        batch_size: z.number().int().min(2).optional(),
+        reissue_trigger_unused: z.number().int().min(0).optional(),
+        reissue_trigger_lifetime_left: z.number().int().min(0).optional(),
+    })
+    .strict()
+    .superRefine((option, context) => {
+        const details = new Set(option.details);
+        if (
+            (details.has("once_only") ||
+                details.has("rotating-batch") ||
+                details.has("per-relying-party")) &&
+            option.batch_size === undefined
+        ) {
+            context.addIssue({
+                code: z.ZodIssueCode.custom,
+                path: ["batch_size"],
+                message: "batch_size is required for this reuse policy",
+            });
+        }
+        if (details.has("once_only")) {
+            if (option.reissue_trigger_unused === undefined) {
+                context.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    path: ["reissue_trigger_unused"],
+                    message: "reissue_trigger_unused is required for once_only",
+                });
+            } else if (
+                option.batch_size !== undefined &&
+                option.reissue_trigger_unused >= option.batch_size
+            ) {
+                context.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    path: ["reissue_trigger_unused"],
+                    message: "must be lower than batch_size",
+                });
+            }
+        }
+        if (
+            (details.has("limited_time") ||
+                details.has("limited-time") ||
+                details.has("rotating-batch") ||
+                details.has("per-relying-party")) &&
+            option.reissue_trigger_lifetime_left === undefined
+        ) {
+            context.addIssue({
+                code: z.ZodIssueCode.custom,
+                path: ["reissue_trigger_lifetime_left"],
+                message:
+                    "reissue_trigger_lifetime_left is required for this reuse policy",
+            });
+        }
+    });
+
+export const CredentialReusePolicySchema = z
+    .object({
+        id: z.string().min(1),
+        options: z.array(CredentialReusePolicyOptionSchema).optional(),
+    })
+    .strict()
+    .superRefine((policy, context) => {
+        if (policy.id === "arf_annex_ii" && !policy.options) {
+            context.addIssue({
+                code: z.ZodIssueCode.custom,
+                path: ["options"],
+                message: "options is required for arf_annex_ii",
+            });
+        }
+    });
+
 const IssuerMetadataCredentialConfigSchema = z
     .object({
         format: z
@@ -323,6 +405,9 @@ const IssuerMetadataCredentialConfigSchema = z
             .array(z.enum(["jwt", "attestation"]))
             .optional()
             .describe("Supported proof types for issuance requests."),
+        credentialReusePolicy: CredentialReusePolicySchema.optional().describe(
+            "Optional PID/EAA reuse policy published in credential metadata.",
+        ),
     })
     .describe("Credential metadata configuration exposed by issuer metadata.")
     .strict();

--- a/apps/client/src/app/issuance/credential-config/credential-config-create/credential-config-create.component.html
+++ b/apps/client/src/app/issuance/credential-config/credential-config-create/credential-config-create.component.html
@@ -402,6 +402,75 @@
             </mat-card-content>
           </mat-card>
 
+          <mat-card>
+            <mat-card-header>
+              <mat-card-title>
+                <mat-icon>autorenew</mat-icon>
+                Credential Reuse Policy
+              </mat-card-title>
+              <mat-card-subtitle>
+                Optional PID/EAA reuse guidance published in credential metadata
+              </mat-card-subtitle>
+            </mat-card-header>
+            <mat-card-content>
+              <mat-slide-toggle formControlName="credentialReusePolicyEnabled">
+                Publish ARF Annex II reuse policy
+              </mat-slide-toggle>
+              @if (form.get('credentialReusePolicyEnabled')?.value) {
+                <div fxLayout="row" fxLayoutGap="16px" fxLayout.lt-md="column">
+                  <mat-form-field fxFlex>
+                    <mat-label>Wallet reuse methods</mat-label>
+                    <mat-select formControlName="credentialReusePolicyDetails" multiple>
+                      <mat-option value="once_only">Once only</mat-option>
+                      <mat-option value="limited_time">Limited time</mat-option>
+                      <mat-option value="rotating-batch">Rotating batch</mat-option>
+                      <mat-option value="per-relying-party">Per relying party</mat-option>
+                    </mat-select>
+                  </mat-form-field>
+                  <mat-form-field fxFlex>
+                    <mat-label>Batch size</mat-label>
+                    <input
+                      id="credential-reuse-policy-batch-size"
+                      matInput
+                      type="number"
+                      min="2"
+                      formControlName="credentialReusePolicyBatchSize"
+                    />
+                    <mat-hint
+                      >Required for once-only, rotating-batch, or per-relying-party</mat-hint
+                    >
+                  </mat-form-field>
+                </div>
+                <div fxLayout="row" fxLayoutGap="16px" fxLayout.lt-md="column">
+                  <mat-form-field fxFlex>
+                    <mat-label>Unused credentials reissue trigger</mat-label>
+                    <input
+                      id="credential-reuse-policy-trigger-unused"
+                      matInput
+                      type="number"
+                      min="0"
+                      formControlName="credentialReusePolicyReissueTriggerUnused"
+                    />
+                    <mat-hint>Must be lower than batch size for once-only</mat-hint>
+                  </mat-form-field>
+                  <mat-form-field fxFlex>
+                    <mat-label>Lifetime reissue trigger (seconds)</mat-label>
+                    <input
+                      id="credential-reuse-policy-trigger-lifetime"
+                      matInput
+                      type="number"
+                      min="0"
+                      formControlName="credentialReusePolicyReissueTriggerLifetimeLeft"
+                    />
+                    <mat-hint
+                      >Required for limited-time, rotating-batch, or per-relying-party</mat-hint
+                    >
+                  </mat-form-field>
+                </div>
+              }
+            </mat-card-content>
+          </mat-card>
+
           <!-- Embedded Disclosure Policy -->
           <mat-card>
             <mat-card-header>

--- a/apps/client/src/app/issuance/credential-config/credential-config-create/credential-config-create.component.ts
+++ b/apps/client/src/app/issuance/credential-config/credential-config-create/credential-config-create.component.ts
@@ -199,6 +199,11 @@ export class CredentialConfigCreateComponent implements OnInit {
         this.defaultProofTypesSupported,
         [Validators.required, Validators.minLength(1)]
       ),
+      credentialReusePolicyEnabled: new FormControl(false),
+      credentialReusePolicyDetails: new FormControl<string[]>(['once_only']),
+      credentialReusePolicyBatchSize: new FormControl(10, [Validators.min(2)]),
+      credentialReusePolicyReissueTriggerUnused: new FormControl(2, [Validators.min(0)]),
+      credentialReusePolicyReissueTriggerLifetimeLeft: new FormControl(86400, [Validators.min(0)]),
     } as { [k in keyof Omit<CredentialConfigCreate, 'config'>]: any });
 
     // Set initial validator for vctString based on default mode
@@ -530,6 +535,17 @@ export class CredentialConfigCreateComponent implements OnInit {
           ? configuredProofTypes
           : this.defaultProofTypesSupported;
       })(),
+      credentialReusePolicyEnabled: !!(normalizedConfig.config as any)?.credentialReusePolicy,
+      credentialReusePolicyDetails: (normalizedConfig.config as any)?.credentialReusePolicy
+        ?.options?.[0]?.details || ['once_only'],
+      credentialReusePolicyBatchSize:
+        (normalizedConfig.config as any)?.credentialReusePolicy?.options?.[0]?.batch_size || 10,
+      credentialReusePolicyReissueTriggerUnused:
+        (normalizedConfig.config as any)?.credentialReusePolicy?.options?.[0]
+          ?.reissue_trigger_unused || 2,
+      credentialReusePolicyReissueTriggerLifetimeLeft:
+        (normalizedConfig.config as any)?.credentialReusePolicy?.options?.[0]
+          ?.reissue_trigger_lifetime_left || 86400,
     } as any);
 
     const flatFields = this.flattenFieldDefinitionsForForm(normalizedConfig.fields || []);
@@ -878,6 +894,29 @@ export class CredentialConfigCreateComponent implements OnInit {
         formValue.proofTypesSupported?.length > 0
           ? formValue.proofTypesSupported
           : this.defaultProofTypesSupported,
+      ...(formValue.credentialReusePolicyEnabled && {
+        credentialReusePolicy: {
+          id: 'arf_annex_ii',
+          options: [
+            {
+              details: formValue.credentialReusePolicyDetails,
+              ...(formValue.credentialReusePolicyDetails?.some((detail: string) =>
+                ['once_only', 'rotating-batch', 'per-relying-party'].includes(detail)
+              ) && { batch_size: Number(formValue.credentialReusePolicyBatchSize) }),
+              ...(formValue.credentialReusePolicyDetails?.includes('once_only') && {
+                reissue_trigger_unused: Number(formValue.credentialReusePolicyReissueTriggerUnused),
+              }),
+              ...(formValue.credentialReusePolicyDetails?.some((detail: string) =>
+                ['limited_time', 'rotating-batch', 'per-relying-party'].includes(detail)
+              ) && {
+                reissue_trigger_lifetime_left: Number(
+                  formValue.credentialReusePolicyReissueTriggerLifetimeLeft
+                ),
+              }),
+            },
+          ],
+        },
+      }),
       // Key attestation requirements (if enabled)
       ...(formValue.keyAttestationEnabled && {
         keyAttestationsRequired: {
@@ -957,6 +996,11 @@ export class CredentialConfigCreateComponent implements OnInit {
     delete formValue.keyStorageTypes;
     delete formValue.userAuthenticationTypes;
     delete formValue.proofTypesSupported;
+    delete formValue.credentialReusePolicyEnabled;
+    delete formValue.credentialReusePolicyDetails;
+    delete formValue.credentialReusePolicyBatchSize;
+    delete formValue.credentialReusePolicyReissueTriggerUnused;
+    delete formValue.credentialReusePolicyReissueTriggerLifetimeLeft;
 
     return formValue;
   }

--- a/apps/client/src/app/utils/schemas.json
+++ b/apps/client/src/app/utils/schemas.json
@@ -6533,6 +6533,7 @@
         "clientId": {
           "type": "string",
           "minLength": 1,
+          "pattern": "^[A-Za-z0-9._:-]+$",
           "description": "Unique client identifier."
         },
         "secret": {
@@ -7039,6 +7040,57 @@
                 "type": "string",
                 "enum": ["jwt", "attestation"]
               }
+            },
+            "credentialReusePolicy": {
+              "description": "Optional PID/EAA reuse policy published in credential metadata.",
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "options": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "details": {
+                        "minItems": 1,
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "enum": [
+                            "once_only",
+                            "limited_time",
+                            "limited-time",
+                            "rotating-batch",
+                            "per-relying-party"
+                          ]
+                        }
+                      },
+                      "batch_size": {
+                        "type": "integer",
+                        "minimum": 2,
+                        "maximum": 9007199254740991
+                      },
+                      "reissue_trigger_unused": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      },
+                      "reissue_trigger_lifetime_left": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      }
+                    },
+                    "required": ["details"],
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "required": ["id"],
+              "additionalProperties": false
             }
           },
           "required": ["format", "display"],
@@ -8095,6 +8147,24 @@
                     "format": "uri",
                     "description": "Issuer URL for the external authorization server."
                   },
+                  "sessionBinding": {
+                    "description": "Explicit mapping from an external access-token claim to an existing issuance session.",
+                    "type": "object",
+                    "properties": {
+                      "method": {
+                        "type": "string",
+                        "const": "access_token_claim",
+                        "description": "Read the correlation value from a configured access-token claim."
+                      },
+                      "claim": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "Claim name that contains the issuance-session correlation value."
+                      }
+                    },
+                    "required": ["method", "claim"],
+                    "additionalProperties": false
+                  },
                   "label": {
                     "description": "Optional display label for UI selection.",
                     "type": "string"
@@ -8446,6 +8516,10 @@
             },
             "additionalProperties": {}
           }
+        },
+        "notificationEndpointEnabled": {
+          "description": "Whether the OID4VCI notification endpoint is exposed for this issuance configuration.",
+          "type": "boolean"
         },
         "credentialResponseEncryption": {
           "description": "Enable encrypted credential responses.",

--- a/docs/getting-started/issuance/credential-configuration.md
+++ b/docs/getting-started/issuance/credential-configuration.md
@@ -55,6 +55,7 @@ For a complete configuration example, see the [Complete Configuration Example](#
 - `sdJwtTrustFormat`: **OPTIONAL (SD-JWT only)** - Controls trust signaling in issued SD-JWT credentials:
     - `x5c` (default): include the X.509 chain in the JWT header
     - `federation`: use federation issuer identity (`iss`) for trust resolution
+- `credentialReusePolicy`: **OPTIONAL** - Publishes a PID/EAA reuse policy in the credential metadata. See [Credential Reuse Policy](#credential-reuse-policy) for details.
 - `embeddedDisclosurePolicy`: **OPTIONAL** - Defines the embedded disclosure policy for the credential. See [Embedded Disclosure Policy](#embedded-disclosure-policy) for details.
 - `iaeActions`: **OPTIONAL** - Sequence of Interactive Authorization actions required before credential issuance. See [Interactive Authorization Actions](#interactive-authorization-actions) for details.
 
@@ -557,6 +558,54 @@ When `lifeTime` is specified:
 | 1 week   | 604800   | Weekly permits              |
 | 1 month  | 2592000  | Monthly subscriptions       |
 | 1 year   | 31536000 | Annual licenses             |
+
+---
+
+## Credential Reuse Policy
+
+`credentialReusePolicy` controls how a wallet should limit repeated presentations of a PID/EAA. EUDIPLO publishes it as `credential_reuse_policy` inside the credential's `credential_metadata` in issuer metadata.
+
+The current implementation supports the ARF Annex II profile from ETSI TS 119 472-3. Configure it with:
+
+- `id`: Use `arf_annex_ii` for the predefined ARF profile.
+- `options`: An array containing the policy details. For `arf_annex_ii`, this is required.
+- `options[].details`: One or more reuse methods, in descending preference order.
+- `options[].batch_size`: Required for `once_only`, `rotating-batch`, and `per-relying-party`. It must be at least `2`.
+- `options[].reissue_trigger_unused`: Required for `once_only`. It is the lower limit for unused credentials and must be lower than `batch_size`.
+- `options[].reissue_trigger_lifetime_left`: Required for `limited_time`, `rotating-batch`, and `per-relying-party`. It specifies the number of seconds before credential expiration when the wallet should request a new credential.
+
+### Reuse Methods
+
+- `once_only`: The wallet uses a credential only once.
+- `limited_time`: The wallet reuses a credential for a limited time.
+- `rotating-batch`: The wallet uses credentials from a batch and requests a new batch as the lifetime trigger is reached.
+- `per-relying-party`: The wallet applies reuse independently for each relying party.
+
+When multiple methods are listed in `details`, they are ordered preferences, not simultaneous restrictions. The wallet uses the first method it supports and falls back to the next supported method. For example, `per-relying-party` followed by `once_only` means that capable wallets use the per-relying-party method, while wallets without that capability fall back to one-time use.
+
+```json
+{
+    "id": "pid-sd-jwt",
+    "config": {
+        "format": "dc+sd-jwt",
+        "display": [],
+        "credentialReusePolicy": {
+            "id": "arf_annex_ii",
+            "options": [
+                {
+                    "details": ["per-relying-party", "once_only"],
+                    "batch_size": 10,
+                    "reissue_trigger_unused": 2,
+                    "reissue_trigger_lifetime_left": 86400
+                }
+            ]
+        }
+    },
+    "fields": []
+}
+```
+
+In the example, `per-relying-party` has priority. `once_only` is a compatibility fallback. The policy is optional; if it is omitted, the issuer does not limit how many times the wallet presents the credential through this metadata mechanism.
 
 ---
 

--- a/schemas/CreateClientDto.schema.json
+++ b/schemas/CreateClientDto.schema.json
@@ -5,6 +5,7 @@
     "clientId": {
       "type": "string",
       "minLength": 1,
+      "pattern": "^[A-Za-z0-9._:-]+$",
       "description": "Unique client identifier."
     },
     "secret": {

--- a/schemas/CredentialConfigCreate.schema.json
+++ b/schemas/CredentialConfigCreate.schema.json
@@ -134,6 +134,61 @@
               "attestation"
             ]
           }
+        },
+        "credentialReusePolicy": {
+          "description": "Optional PID/EAA reuse policy published in credential metadata.",
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "options": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "details": {
+                    "minItems": 1,
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "once_only",
+                        "limited_time",
+                        "limited-time",
+                        "rotating-batch",
+                        "per-relying-party"
+                      ]
+                    }
+                  },
+                  "batch_size": {
+                    "type": "integer",
+                    "minimum": 2,
+                    "maximum": 9007199254740991
+                  },
+                  "reissue_trigger_unused": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "reissue_trigger_lifetime_left": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  }
+                },
+                "required": [
+                  "details"
+                ],
+                "additionalProperties": false
+              }
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "additionalProperties": false
         }
       },
       "required": [

--- a/schemas/IssuanceConfig.schema.json
+++ b/schemas/IssuanceConfig.schema.json
@@ -74,6 +74,27 @@
                 "format": "uri",
                 "description": "Issuer URL for the external authorization server."
               },
+              "sessionBinding": {
+                "description": "Explicit mapping from an external access-token claim to an existing issuance session.",
+                "type": "object",
+                "properties": {
+                  "method": {
+                    "type": "string",
+                    "const": "access_token_claim",
+                    "description": "Read the correlation value from a configured access-token claim."
+                  },
+                  "claim": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Claim name that contains the issuance-session correlation value."
+                  }
+                },
+                "required": [
+                  "method",
+                  "claim"
+                ],
+                "additionalProperties": false
+              },
               "label": {
                 "description": "Optional display label for UI selection.",
                 "type": "string"
@@ -461,6 +482,10 @@
         "additionalProperties": {}
       }
     },
+    "notificationEndpointEnabled": {
+      "description": "Whether the OID4VCI notification endpoint is exposed for this issuance configuration.",
+      "type": "boolean"
+    },
     "credentialResponseEncryption": {
       "description": "Enable encrypted credential responses.",
       "type": "boolean"
@@ -468,11 +493,6 @@
     "credentialRequestEncryption": {
       "description": "Require encrypted credential requests.",
       "type": "boolean"
-    },
-    "notificationEndpointEnabled": {
-      "description": "Whether the issuer notification endpoint is enabled and advertised in metadata.",
-      "type": "boolean",
-      "default": true
     },
     "txCodeMaxAttempts": {
       "description": "Maximum verification attempts for transaction codes. Null resets to defaults.",


### PR DESCRIPTION
## 📝 Description

Adds configurable PID/EAA credential reuse policy support based on the ARF Annex II profile in ETSI TS 119 472-3. The policy is published as `credential_reuse_policy` in per-credential issuer metadata, with ordered wallet fallback preferences and validation for batch and reissue-trigger fields.

## 🔄 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test improvements
- [ ] 🏗️ Build/CI changes

## 💥 Breaking Changes (if applicable)

None. The policy is optional and omitted metadata retains the existing behavior.

## 🧪 Testing

- [x] Unit/schema validation checks
- [ ] Integration tests
- [ ] E2E tests
- [x] Manual/build validation

**Validation performed:**

- `pnpm --filter @eudiplo/backend build`
- `pnpm --filter @eudiplo/client exec ng build --configuration development`
- Runtime Zod checks for valid and invalid policy combinations
- Repository backend/client lint hooks and Knip passed during commit/push

## ✔️ Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing build/lint checks pass locally

## 📋 Additional Notes

The client exposes the policy controls per credential. Multiple methods are serialized in priority order so wallets can select the first supported method and fall back to subsequent methods.